### PR TITLE
Fix user table migration

### DIFF
--- a/db/migrate/20150131013853_add_uid_to_user.rb
+++ b/db/migrate/20150131013853_add_uid_to_user.rb
@@ -1,10 +1,26 @@
 class AddUidToUser < ActiveRecord::Migration
-  def change
-    change_table(:users) do |t|
-      t.string :uid, null: false, unique: true, default: ""
-      t.column :email, :string, unique: false
-    end
+  def up
+    add_column :users, :uid, :string
+    change_column :users, :email, :string, unique: false, null: true
+    remove_column :users, :encrypted_password
+    remove_column :users, :reset_password_token
+    remove_column :users, :reset_password_sent_at
+    remove_column :users, :guest
+    remove_column :users, :remember_created_at
+    remove_column :users, :sign_in_count
+    remove_column :users, :current_sign_in_at
+    remove_column :users, :last_sign_in_at
+    remove_column :users, :current_sign_in_ip
+    remove_column :users, :last_sign_in_ip
+
 
     add_index :users, :uid, unique: true
+    remove_index :users, :email
+  end
+
+  def down
+    change_column :users, :email, :string, unique: true
+    remove_column :users, :uid
+    add_index :users, :email, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,23 +36,12 @@ ActiveRecord::Schema.define(version: 20150131013853) do
   add_index "searches", ["user_id"], name: "index_searches_on_user_id"
 
   create_table "users", force: true do |t|
-    t.string   "encrypted_password",     default: "",    null: false
-    t.string   "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,     null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
+    t.string   "email",      default: ""
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "guest",                  default: false
-    t.string   "uid",                    default: "",    null: false
-    t.string   "email"
+    t.string   "uid"
   end
 
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   add_index "users", ["uid"], name: "index_users_on_uid", unique: true
 
 end


### PR DESCRIPTION
It was trying to create a column named email when one already existed. While at it, lets remove all the other extra columns in the user table (since devise was removed, those fields would never get set).

Fixes issue #2. 
