### PR TITLE
Enrich the copied solr records with coordinate metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,10 @@ $ TEST_SOLR_URL=http://example.com:8080/solr/core_name rake integration
 ```
 $ rails s
 ```
+
+# Uploading sample data
+
+To upload the sample records into your local jetty solr, run the following.
+
+    ./script/upload-to-solr.rb vecnet-solr-sample.json http://localhost:8983/solr/blacklight-core
+

--- a/geoname-cache.json
+++ b/geoname-cache.json
@@ -9692,7 +9692,7 @@
     "fcl": "A",
     "continentCode": "AS"
   },
-  "France": 3570675,
+  "France": 3017382,
   "3570675": {
     "adminCode3": "9721",
     "alternateNames": [
@@ -31414,5 +31414,830 @@
     "toponymName": "Southern Province",
     "fcl": "A",
     "continentCode": "AF"
+  },
+  "3017382": {
+    "timezone": {
+      "gmtOffset": 1,
+      "timeZoneId": "Europe/Paris",
+      "dstOffset": 2
+    },
+    "bbox": {
+      "east": 9.561556,
+      "south": 41.338779,
+      "north": 51.092804,
+      "west": -5.142222
+    },
+    "asciiName": "Republic of France",
+    "countryId": "3017382",
+    "fcl": "A",
+    "srtm3": 543,
+    "countryCode": "FR",
+    "lat": "46",
+    "fcode": "PCLI",
+    "continentCode": "EU",
+    "adminCode1": "00",
+    "lng": "2",
+    "geonameId": 3017382,
+    "toponymName": "Republic of France",
+    "population": 64768389,
+    "wikipediaURL": "en.wikipedia.org/wiki/France",
+    "adminName5": "",
+    "adminName4": "",
+    "adminName3": "",
+    "alternateNames": [
+      {
+        "isPreferredName": true,
+        "name": "ꃔꇩ",
+        "lang": "ii"
+      },
+      {
+        "name": "프랑스",
+        "lang": "ko"
+      },
+      {
+        "name": "ܦܪܢܣܐ",
+        "lang": "arc"
+      },
+      {
+        "name": "フランス",
+        "lang": "ja"
+      },
+      {
+        "name": "ຝລັ່ງ",
+        "lang": "lo"
+      },
+      {
+        "name": "ፈረንሣይ",
+        "lang": "am"
+      },
+      {
+        "name": "ፈረንሳይ",
+        "lang": "am"
+      },
+      {
+        "isPreferredName": true,
+        "name": "ፈረንሳይ",
+        "lang": "ti"
+      },
+      {
+        "name": "បារាំង",
+        "lang": "km"
+      },
+      {
+        "isPreferredName": true,
+        "name": "ଫ୍ରାନ୍ସ",
+        "lang": "or"
+      },
+      {
+        "name": "ฝรั่งเศส",
+        "lang": "th"
+      },
+      {
+        "name": "ފަރަންސޭސިވިލާތް",
+        "lang": "dv"
+      },
+      {
+        "name": "ประเทศฝรั่งเศส",
+        "lang": "th"
+      },
+      {
+        "name": "An Fhrainc",
+        "lang": "ga"
+      },
+      {
+        "name": "An Fhraing",
+        "lang": "gd"
+      },
+      {
+        "name": "Bro-C'hall",
+        "lang": "br"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Bufalansa",
+        "lang": "lg"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Falanisē",
+        "lang": "to"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Falánsɛ",
+        "lang": "ln"
+      },
+      {
+        "name": "Falansia",
+        "lang": "ln"
+      },
+      {
+        "name": "Farāni",
+        "lang": "ty"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Faransa",
+        "lang": "ha"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Faransi",
+        "lang": "bm"
+      },
+      {
+        "name": "Faransiis",
+        "lang": "so"
+      },
+      {
+        "name": "Faransiiska",
+        "lang": "so"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Farânzi",
+        "lang": "sg"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Farayse",
+        "lang": "ff"
+      },
+      {
+        "name": "fasygu'e",
+        "lang": "jbo"
+      },
+      {
+        "name": "Ffrainc",
+        "lang": "cy"
+      },
+      {
+        "name": "Frakkland",
+        "lang": "is"
+      },
+      {
+        "name": "Frakland",
+        "lang": "fo"
+      },
+      {
+        "name": "Franca",
+        "lang": "sq"
+      },
+      {
+        "name": "França",
+        "lang": "ca"
+      },
+      {
+        "name": "França",
+        "lang": "oc"
+      },
+      {
+        "name": "França",
+        "lang": "pt"
+      },
+      {
+        "name": "France",
+        "lang": "aa"
+      },
+      {
+        "name": "France",
+        "lang": "en"
+      },
+      {
+        "isPreferredName": true,
+        "name": "France",
+        "lang": "fr"
+      },
+      {
+        "name": "France",
+        "lang": "frp"
+      },
+      {
+        "name": "France",
+        "lang": "fur"
+      },
+      {
+        "name": "France",
+        "lang": "na"
+      },
+      {
+        "name": "France",
+        "lang": "nrm"
+      },
+      {
+        "name": "France",
+        "lang": "om"
+      },
+      {
+        "name": "France",
+        "lang": "pam"
+      },
+      {
+        "isPreferredName": true,
+        "name": "France",
+        "lang": "sn"
+      },
+      {
+        "name": "France",
+        "lang": "st"
+      },
+      {
+        "isPreferredName": true,
+        "name": "France"
+      },
+      {
+        "name": "Francë",
+        "lang": "sq"
+      },
+      {
+        "name": "Francëjô",
+        "lang": "csb"
+      },
+      {
+        "name": "Franchiya",
+        "lang": "rmy"
+      },
+      {
+        "name": "Francia",
+        "lang": "ast"
+      },
+      {
+        "name": "Francia",
+        "lang": "co"
+      },
+      {
+        "isShortName": true,
+        "isPreferredName": true,
+        "name": "Francia",
+        "lang": "es"
+      },
+      {
+        "name": "Francia",
+        "lang": "gl"
+      },
+      {
+        "name": "Francia",
+        "lang": "ia"
+      },
+      {
+        "name": "Francia",
+        "lang": "ilo"
+      },
+      {
+        "name": "Francia",
+        "lang": "io"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Francia",
+        "lang": "it"
+      },
+      {
+        "name": "Francia",
+        "lang": "la"
+      },
+      {
+        "name": "Francia",
+        "lang": "scn"
+      },
+      {
+        "name": "Franciaország",
+        "lang": "hu"
+      },
+      {
+        "name": "Francie",
+        "lang": "cs"
+      },
+      {
+        "name": "Francija",
+        "lang": "lv"
+      },
+      {
+        "name": "Francija",
+        "lang": "sl"
+      },
+      {
+        "name": "Francio",
+        "lang": "eo"
+      },
+      {
+        "name": "Francja",
+        "lang": "lmo"
+      },
+      {
+        "name": "Francja",
+        "lang": "pl"
+      },
+      {
+        "name": "Francland",
+        "lang": "ang"
+      },
+      {
+        "name": "Francogallia",
+        "lang": "la"
+      },
+      {
+        "name": "Francoska",
+        "lang": "hsb"
+      },
+      {
+        "name": "Francujo",
+        "lang": "eo"
+      },
+      {
+        "name": "Francuska",
+        "lang": "bs"
+      },
+      {
+        "name": "Francuska",
+        "lang": "hbs"
+      },
+      {
+        "name": "Francuska",
+        "lang": "hr"
+      },
+      {
+        "name": "Francúzsko",
+        "lang": "sk"
+      },
+      {
+        "name": "Frankräich",
+        "lang": "lb"
+      },
+      {
+        "name": "Frankreich",
+        "lang": "bar"
+      },
+      {
+        "name": "Frankreich",
+        "lang": "de"
+      },
+      {
+        "name": "Frankriek",
+        "lang": "li"
+      },
+      {
+        "name": "Frankriek",
+        "lang": "nds"
+      },
+      {
+        "name": "Frankrig",
+        "lang": "da"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Frankrigi",
+        "lang": "kl"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Frankriika",
+        "lang": "se"
+      },
+      {
+        "name": "Frankrijk",
+        "lang": "nl"
+      },
+      {
+        "name": "Frankrike",
+        "lang": "nb"
+      },
+      {
+        "name": "Frankrike",
+        "lang": "nn"
+      },
+      {
+        "name": "Frankrike",
+        "lang": "no"
+      },
+      {
+        "name": "Frankrike",
+        "lang": "sv"
+      },
+      {
+        "name": "Frankrish",
+        "lang": "ksh"
+      },
+      {
+        "name": "Frankryk",
+        "lang": "af"
+      },
+      {
+        "name": "Frankryk",
+        "lang": "fy"
+      },
+      {
+        "name": "Frans",
+        "lang": "ht"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Frañs",
+        "lang": "br"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Fransa",
+        "lang": "az"
+      },
+      {
+        "name": "Fransa",
+        "lang": "ku"
+      },
+      {
+        "name": "Fransa",
+        "lang": "pms"
+      },
+      {
+        "name": "Fransa",
+        "lang": "tet"
+      },
+      {
+        "name": "Fransa",
+        "lang": "tr"
+      },
+      {
+        "name": "Fransän",
+        "lang": "vo"
+      },
+      {
+        "name": "Fransia",
+        "lang": "lad"
+      },
+      {
+        "name": "Fransia",
+        "lang": "nov"
+      },
+      {
+        "name": "Fransiya",
+        "lang": "qu"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Frans nutome",
+        "lang": "ee"
+      },
+      {
+        "name": "Fransya",
+        "lang": "qu"
+      },
+      {
+        "name": "Fransya",
+        "lang": "war"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Franța",
+        "lang": "ro"
+      },
+      {
+        "name": "Frantsa",
+        "lang": "mg"
+      },
+      {
+        "name": "Frantscha",
+        "lang": "rm"
+      },
+      {
+        "name": "Frantza",
+        "lang": "sc"
+      },
+      {
+        "name": "Frantzia",
+        "lang": "eu"
+      },
+      {
+        "name": "Franza",
+        "lang": "mt"
+      },
+      {
+        "name": "Franzia",
+        "lang": "an"
+      },
+      {
+        "name": "Franzsa",
+        "lang": "vec"
+      },
+      {
+        "name": "Fraunce",
+        "lang": "sco"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Frɛnkyeman",
+        "lang": "ak"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Furansi",
+        "lang": "nd"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/France",
+        "lang": "link"
+      },
+      {
+        "name": "http://id.loc.gov/authorities/names/n79006404",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%A4%D1%80%D0%B0%D0%BD%D1%86%D0%B8%D1%8F",
+        "lang": "link"
+      },
+      {
+        "name": "Huák-guók",
+        "lang": "cdo"
+      },
+      {
+        "isPreferredName": true,
+        "name": "i-France",
+        "lang": "zu"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Nfalanse",
+        "lang": "lu"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Orílẹ́ède Faranse",
+        "lang": "yo"
+      },
+      {
+        "name": "Perancis",
+        "lang": "id"
+      },
+      {
+        "name": "Perancis",
+        "lang": "ms"
+      },
+      {
+        "name": "Pháp",
+        "lang": "vi"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Pow Frenk",
+        "lang": "kw"
+      },
+      {
+        "name": "Pow Frynk",
+        "lang": "kw"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Prancis",
+        "lang": "id"
+      },
+      {
+        "name": "Prancūzija",
+        "lang": "lt"
+      },
+      {
+        "name": "Pranis",
+        "lang": "tpi"
+      },
+      {
+        "name": "Pransiya",
+        "lang": "ceb"
+      },
+      {
+        "name": "Pransya",
+        "lang": "tl"
+      },
+      {
+        "name": "Prantsusmaa",
+        "lang": "et"
+      },
+      {
+        "name": "Ranska",
+        "lang": "fi"
+      },
+      {
+        "name": "Republic of France"
+      },
+      {
+        "name": "République Française",
+        "lang": "fr"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Ubaranja",
+        "lang": "ki"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Ubufaransa",
+        "lang": "rn"
+      },
+      {
+        "name": "Ufaransa",
+        "lang": "sw"
+      },
+      {
+        "name": "Vrankriek",
+        "lang": "vls"
+      },
+      {
+        "name": "Yn Rank",
+        "lang": "gv"
+      },
+      {
+        "name": "فرانس",
+        "lang": "ur"
+      },
+      {
+        "name": "فرانسه",
+        "lang": "fa"
+      },
+      {
+        "name": "فرانسه",
+        "lang": "ps"
+      },
+      {
+        "name": "فرانسىيە",
+        "lang": "ug"
+      },
+      {
+        "name": "فرنسا",
+        "lang": "ar"
+      },
+      {
+        "isPreferredName": true,
+        "name": "فەڕەنسا",
+        "lang": "ku"
+      },
+      {
+        "name": "צרפת",
+        "lang": "he"
+      },
+      {
+        "name": "Γαλλία",
+        "lang": "el"
+      },
+      {
+        "name": "Фаронса",
+        "lang": "tg"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Франц",
+        "lang": "mn"
+      },
+      {
+        "name": "Франц",
+        "lang": "os"
+      },
+      {
+        "name": "Франци",
+        "lang": "cv"
+      },
+      {
+        "name": "Франција",
+        "lang": "mk"
+      },
+      {
+        "name": "Франция",
+        "lang": "bg"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Франция",
+        "lang": "kk"
+      },
+      {
+        "name": "Франция",
+        "lang": "ru"
+      },
+      {
+        "name": "Франция",
+        "lang": "udm"
+      },
+      {
+        "name": "Франция",
+        "lang": "uz"
+      },
+      {
+        "name": "Франція",
+        "lang": "uk"
+      },
+      {
+        "name": "Франц улс",
+        "lang": "mn"
+      },
+      {
+        "name": "Француска",
+        "lang": "sr"
+      },
+      {
+        "name": "Францыя",
+        "lang": "be"
+      },
+      {
+        "isPreferredName": true,
+        "name": "ཕ་རཱན་སི།",
+        "lang": "bo"
+      },
+      {
+        "name": "ཕརཱནསི",
+        "lang": "dz"
+      },
+      {
+        "name": "Ֆրանսիա",
+        "lang": "hy"
+      },
+      {
+        "name": "საფრანგეთი",
+        "lang": "ka"
+      },
+      {
+        "name": "फ्रान्स",
+        "lang": "mr"
+      },
+      {
+        "name": "फ्रान्स",
+        "lang": "ne"
+      },
+      {
+        "name": "फ्रांस",
+        "lang": "hi"
+      },
+      {
+        "name": "फ्रांस",
+        "lang": "ks"
+      },
+      {
+        "name": "फ्रांस",
+        "lang": "sa"
+      },
+      {
+        "isPreferredName": true,
+        "name": "फ़्रांस",
+        "lang": "hi"
+      },
+      {
+        "name": "फ़्राँस",
+        "lang": "hi"
+      },
+      {
+        "isPreferredName": true,
+        "name": "ફ્રાંસ",
+        "lang": "gu"
+      },
+      {
+        "name": "ફ્રાઁસ",
+        "lang": "gu"
+      },
+      {
+        "name": "ఫ్రాన్స్‌",
+        "lang": "te"
+      },
+      {
+        "name": "ಫ್ರಾನ್ಸ್",
+        "lang": "kn"
+      },
+      {
+        "name": "பிரான்ஸ்",
+        "lang": "ta"
+      },
+      {
+        "name": "ഫ്രാന്‍സ്",
+        "lang": "ml"
+      },
+      {
+        "name": "ফ্রান্স",
+        "lang": "bn"
+      },
+      {
+        "isPreferredName": true,
+        "name": "ফ্ৰান্স",
+        "lang": "as"
+      },
+      {
+        "isPreferredName": true,
+        "name": "ပြင်သစ်",
+        "lang": "my"
+      },
+      {
+        "isPreferredName": true,
+        "name": "ප්‍රංශය",
+        "lang": "si"
+      },
+      {
+        "isPreferredName": true,
+        "name": "フランス共和国",
+        "lang": "ja"
+      },
+      {
+        "name": "法国",
+        "lang": "zh"
+      }
+    ],
+    "adminName2": "",
+    "name": "France",
+    "fclName": "country, state, region,...",
+    "countryName": "France",
+    "fcodeName": "independent political entity",
+    "adminName1": ""
   }
 }

--- a/geoname-cache.json
+++ b/geoname-cache.json
@@ -1,0 +1,31418 @@
+{
+  "182763": {
+    "timezone": {
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Nairobi",
+      "dstOffset": 3
+    },
+    "bbox": {
+      "east": 35.326385498046875,
+      "south": -1.3988890647888184,
+      "north": 0.308611124753952,
+      "west": 33.918609619140625
+    },
+    "asciiName": "Nyanza Province",
+    "countryId": "192950",
+    "fcl": "A",
+    "srtm3": 1181,
+    "cc2": "KE",
+    "countryCode": "KE",
+    "lat": "-0.5",
+    "fcode": "ADM1H",
+    "continentCode": "AF",
+    "adminCode1": "07",
+    "lng": "34.5",
+    "geonameId": 182763,
+    "toponymName": "Nyanza Province",
+    "population": 4392196,
+    "wikipediaURL": "en.wikipedia.org/wiki/Nyanza_Province",
+    "adminName5": "",
+    "adminName4": "",
+    "adminName3": "",
+    "alternateNames": [
+      {
+        "name": "http://en.wikipedia.org/wiki/Nyanza_Province",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%9D%D1%8C%D1%8F%D0%BD%D0%B7%D0%B0",
+        "lang": "link"
+      },
+      {
+        "isShortName": true,
+        "isPreferredName": true,
+        "name": "Nyanza"
+      },
+      {
+        "name": "Nyanza Province"
+      },
+      {
+        "name": "Nyanza Region"
+      }
+    ],
+    "adminName2": "",
+    "name": "Nyanza Province",
+    "fclName": "country, state, region,...",
+    "countryName": "Kenya",
+    "fcodeName": "historical first-order administrative division",
+    "adminName1": "KE.07"
+  },
+  "Nyanza Province": 182763,
+  "180320": {
+    "timezone": {
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Nairobi",
+      "dstOffset": 3
+    },
+    "bbox": {
+      "east": 34.55994178148318,
+      "south": -0.430860121679248,
+      "north": 0.311022202320769,
+      "west": 33.94849158648315
+    },
+    "asciiName": "Siaya District",
+    "countryId": "192950",
+    "fcl": "A",
+    "srtm3": 1273,
+    "countryCode": "KE",
+    "adminId1": "180320",
+    "lat": "0.105",
+    "fcode": "ADM1",
+    "continentCode": "AF",
+    "adminCode1": "46",
+    "lng": "34.302",
+    "geonameId": 180320,
+    "toponymName": "Siaya",
+    "population": 842304,
+    "wikipediaURL": "en.wikipedia.org/wiki/Siaya_District",
+    "adminName5": "",
+    "adminName4": "",
+    "adminName3": "",
+    "alternateNames": [
+      {
+        "name": "http://en.wikipedia.org/wiki/Siaya_District",
+        "lang": "link"
+      },
+      {
+        "name": "Siaya"
+      },
+      {
+        "name": "Siaya District"
+      }
+    ],
+    "adminName2": "",
+    "name": "Siaya",
+    "fclName": "country, state, region,...",
+    "countryName": "Kenya",
+    "fcodeName": "first-order administrative division",
+    "adminName1": "Siaya"
+  },
+  "Siaya District": 180320,
+  "6255146": {
+    "lng": "21.09375",
+    "geonameId": 6255146,
+    "timezone": {
+      "gmtOffset": 1,
+      "timeZoneId": "Africa/Bangui",
+      "dstOffset": 1
+    },
+    "bbox": {
+      "east": 51.412635803222656,
+      "south": -46.9697265625,
+      "north": 37.53944396972656,
+      "west": -18.1574885778138
+    },
+    "toponymName": "Africa",
+    "asciiName": "Africa",
+    "fcl": "L",
+    "population": 1031833000,
+    "wikipediaURL": "en.wikipedia.org/wiki/Africa",
+    "adminName5": "",
+    "srtm3": 592,
+    "adminName4": "",
+    "adminName3": "",
+    "alternateNames": [
+      {
+        "name": "アフリカ",
+        "lang": "ja"
+      },
+      {
+        "isPreferredName": true,
+        "name": "아프리카",
+        "lang": "ko"
+      },
+      {
+        "name": "แอฟริกา",
+        "lang": "th"
+      },
+      {
+        "name": "Affrica",
+        "lang": "cy"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Africa",
+        "lang": "en"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Africa",
+        "lang": "it"
+      },
+      {
+        "name": "Africa",
+        "lang": "la"
+      },
+      {
+        "isShortName": true,
+        "isPreferredName": true,
+        "name": "África",
+        "lang": "es"
+      },
+      {
+        "name": "África",
+        "lang": "pt"
+      },
+      {
+        "name": "Àfrica",
+        "lang": "ca"
+      },
+      {
+        "name": "Afrihkká",
+        "lang": "se"
+      },
+      {
+        "name": "Afrika",
+        "lang": "bs"
+      },
+      {
+        "name": "Afrika",
+        "lang": "cs"
+      },
+      {
+        "name": "Afrika",
+        "lang": "da"
+      },
+      {
+        "name": "Afrika",
+        "lang": "de"
+      },
+      {
+        "name": "Afrika",
+        "lang": "eu"
+      },
+      {
+        "name": "Afrika",
+        "lang": "hu"
+      },
+      {
+        "name": "Afrika",
+        "lang": "id"
+      },
+      {
+        "name": "Afrika",
+        "lang": "lt"
+      },
+      {
+        "name": "Afrika",
+        "lang": "nb"
+      },
+      {
+        "name": "Afrika",
+        "lang": "nl"
+      },
+      {
+        "name": "Afrika",
+        "lang": "no"
+      },
+      {
+        "name": "Afrika",
+        "lang": "sv"
+      },
+      {
+        "name": "Afrika",
+        "lang": "tr"
+      },
+      {
+        "name": "Āfrika",
+        "lang": "lv"
+      },
+      {
+        "name": "Afríka",
+        "lang": "is"
+      },
+      {
+        "name": "Afrikka",
+        "lang": "fi"
+      },
+      {
+        "name": "Afriko",
+        "lang": "eo"
+      },
+      {
+        "name": "Afrique",
+        "lang": "fr"
+      },
+      {
+        "name": "Afryka",
+        "lang": "pl"
+      },
+      {
+        "name": "an Afraic",
+        "lang": "ga"
+      },
+      {
+        "name": "Châu Phi",
+        "lang": "vi"
+      },
+      {
+        "isColloquial": true,
+        "name": "el Continente Negro",
+        "lang": "es"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Africa",
+        "lang": "link"
+      },
+      {
+        "name": "http://id.loc.gov/authorities/subjects/sh85001531",
+        "lang": "link"
+      },
+      {
+        "name": "افریقا",
+        "lang": "fa"
+      },
+      {
+        "name": "أفريقيا",
+        "lang": "ar"
+      },
+      {
+        "name": "אפריקה",
+        "lang": "he"
+      },
+      {
+        "name": "Αφρική",
+        "lang": "el"
+      },
+      {
+        "name": "Африка",
+        "lang": "bg"
+      },
+      {
+        "name": "Африка",
+        "lang": "ru"
+      },
+      {
+        "name": "Африка",
+        "lang": "uk"
+      },
+      {
+        "name": "अफ़्रीका",
+        "lang": "hi"
+      },
+      {
+        "name": "非洲",
+        "lang": "zh"
+      }
+    ],
+    "adminName2": "",
+    "name": "Africa",
+    "fclName": "parks,area, ...",
+    "countryName": "",
+    "fcodeName": "continent",
+    "adminName1": "",
+    "lat": "7.1881",
+    "fcode": "CONT",
+    "continentCode": "AF"
+  },
+  "Africa": 6255146,
+  "global": 6692860,
+  "6692860": {
+    "adminCode2": "572",
+    "alternateNames": [
+
+    ],
+    "countryName": "India",
+    "adminCode1": "19",
+    "lng": "77.50131",
+    "adminName2": "Bangalore Urban",
+    "fcodeName": "populated place",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 5.5,
+      "gmtOffset": 5.5,
+      "timeZoneId": "Asia/Kolkata"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 12.90869988008003,
+      "east": 77.51054118676966,
+      "north": 12.92668717758223,
+      "west": 77.49208618597204
+    },
+    "name": "Global Village",
+    "fcode": "PPL",
+    "geonameId": 6692860,
+    "asciiName": "Global Village",
+    "lat": "12.91769",
+    "population": 0,
+    "adminName1": "Karnataka",
+    "adminId1": "1267701",
+    "countryId": "1269750",
+    "fclName": "city, village,...",
+    "countryCode": "IN",
+    "srtm3": 807,
+    "adminId2": "1277331",
+    "toponymName": "Global Village",
+    "fcl": "P",
+    "continentCode": "AS"
+  },
+  "South Bend": 4926563,
+  "4926563": {
+    "timezone": {
+      "gmtOffset": -5,
+      "timeZoneId": "America/Indiana/Indianapolis",
+      "dstOffset": -4
+    },
+    "bbox": {
+      "east": -86.1947859425508,
+      "south": 41.64216722382274,
+      "north": 41.72459537617726,
+      "west": -86.30522725744922
+    },
+    "asciiName": "South Bend",
+    "countryId": "6252001",
+    "fcl": "P",
+    "srtm3": 213,
+    "adminId2": "4925848",
+    "countryCode": "US",
+    "adminId1": "4921868",
+    "lat": "41.68338",
+    "fcode": "PPLA2",
+    "continentCode": "NA",
+    "elevation": 211,
+    "adminCode2": "141",
+    "adminCode1": "IN",
+    "lng": "-86.25001",
+    "geonameId": 4926563,
+    "toponymName": "South Bend",
+    "population": 101168,
+    "wikipediaURL": "en.wikipedia.org/wiki/South_Bend%2C_Indiana",
+    "adminName5": "",
+    "adminName4": "",
+    "adminName3": "",
+    "alternateNames": [
+      {
+        "name": "사우스벤드",
+        "lang": "ko"
+      },
+      {
+        "name": "サウスベンド",
+        "lang": "ja"
+      },
+      {
+        "name": "46601",
+        "lang": "post"
+      },
+      {
+        "name": "46604",
+        "lang": "post"
+      },
+      {
+        "name": "46612",
+        "lang": "post"
+      },
+      {
+        "name": "46613",
+        "lang": "post"
+      },
+      {
+        "name": "46614",
+        "lang": "post"
+      },
+      {
+        "name": "46615",
+        "lang": "post"
+      },
+      {
+        "name": "46616",
+        "lang": "post"
+      },
+      {
+        "name": "46617",
+        "lang": "post"
+      },
+      {
+        "name": "46619",
+        "lang": "post"
+      },
+      {
+        "name": "46620",
+        "lang": "post"
+      },
+      {
+        "name": "46624",
+        "lang": "post"
+      },
+      {
+        "name": "46626",
+        "lang": "post"
+      },
+      {
+        "name": "46628",
+        "lang": "post"
+      },
+      {
+        "name": "46629",
+        "lang": "post"
+      },
+      {
+        "name": "46634",
+        "lang": "post"
+      },
+      {
+        "name": "46635",
+        "lang": "post"
+      },
+      {
+        "name": "46637",
+        "lang": "post"
+      },
+      {
+        "name": "46660",
+        "lang": "post"
+      },
+      {
+        "name": "46680",
+        "lang": "post"
+      },
+      {
+        "name": "46699",
+        "lang": "post"
+      },
+      {
+        "name": "Flexuvium Australe",
+        "lang": "la"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/South_Bend%2C_Indiana",
+        "lang": "link"
+      },
+      {
+        "name": "SBN",
+        "lang": "iata"
+      },
+      {
+        "name": "South Bend",
+        "lang": "de"
+      },
+      {
+        "isPreferredName": true,
+        "name": "South Bend",
+        "lang": "en"
+      },
+      {
+        "name": "South Bend",
+        "lang": "eo"
+      },
+      {
+        "name": "South Bend",
+        "lang": "es"
+      },
+      {
+        "name": "South Bend",
+        "lang": "fr"
+      },
+      {
+        "name": "South Bend",
+        "lang": "id"
+      },
+      {
+        "name": "South Bend",
+        "lang": "io"
+      },
+      {
+        "name": "South Bend",
+        "lang": "nl"
+      },
+      {
+        "name": "South Bend",
+        "lang": "pl"
+      },
+      {
+        "name": "South Bend",
+        "lang": "sv"
+      },
+      {
+        "name": "ساوث بند",
+        "lang": "ar"
+      },
+      {
+        "name": "ساوث بند، ایندیانا",
+        "lang": "fa"
+      },
+      {
+        "name": "סאות בנד",
+        "lang": "he"
+      },
+      {
+        "name": "Горад Саўт-Бенд",
+        "lang": "be"
+      },
+      {
+        "name": "Саут Бенд",
+        "lang": "bg"
+      },
+      {
+        "name": "Саут Бенд",
+        "lang": "sr"
+      },
+      {
+        "name": "Саут-Бенд",
+        "lang": "ru"
+      },
+      {
+        "name": "Саут-Бенд",
+        "lang": "uk"
+      },
+      {
+        "name": "南本德",
+        "lang": "zh"
+      }
+    ],
+    "adminName2": "Saint Joseph County",
+    "name": "South Bend",
+    "fclName": "city, village,...",
+    "countryName": "United States",
+    "fcodeName": "seat of a second-order administrative division",
+    "adminName1": "Indiana"
+  },
+  "Solomon Islands": 2103350,
+  "2103350": {
+    "timezone": {
+      "gmtOffset": 11,
+      "timeZoneId": "Pacific/Guadalcanal",
+      "dstOffset": 11
+    },
+    "bbox": {
+      "east": 168.843506,
+      "south": -12.291889,
+      "north": -5.0785,
+      "west": 155.508606
+    },
+    "asciiName": "Solomon Islands",
+    "countryId": "2103350",
+    "fcl": "A",
+    "srtm3": 231,
+    "countryCode": "SB",
+    "lat": "-8",
+    "fcode": "PCLI",
+    "continentCode": "OC",
+    "adminCode1": "00",
+    "lng": "159",
+    "geonameId": 2103350,
+    "toponymName": "Solomon Islands",
+    "population": 559198,
+    "wikipediaURL": "en.wikipedia.org/wiki/Solomon_Islands",
+    "adminName5": "",
+    "adminName4": "",
+    "adminName3": "",
+    "alternateNames": [
+      {
+        "name": "솔로몬",
+        "lang": "ko"
+      },
+      {
+        "name": "솔로몬 제도",
+        "lang": "ko"
+      },
+      {
+        "name": "ሰሎሞን ደሴት",
+        "lang": "am"
+      },
+      {
+        "isPreferredName": true,
+        "name": "ሰሎሞን ደሴት",
+        "lang": "ti"
+      },
+      {
+        "name": "ሰለሞን ደሴቶች",
+        "lang": "am"
+      },
+      {
+        "name": "ސޮލޮމޮން ޖަޒީރާ",
+        "lang": "dv"
+      },
+      {
+        "name": "ସୋଲୋମନ ଆୟରଲ୍ୟାଣ୍ଡ",
+        "lang": "or"
+      },
+      {
+        "isPreferredName": true,
+        "name": "ସୋଲୋମନ୍ ଦ୍ବୀପପୁଞ୍ଜ",
+        "lang": "or"
+      },
+      {
+        "name": "หมู่เกาะโซโลมอน",
+        "lang": "th"
+      },
+      {
+        "name": "Adeyê Solomoni",
+        "lang": "diq"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Amazinga ya Salumoni",
+        "lang": "rn"
+      },
+      {
+        "name": "Àwọn Erékùsù Sólómọ́nì",
+        "lang": "yo"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Bisanga Solomɔ",
+        "lang": "ln"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Bizanga by'eSolomooni",
+        "lang": "lg"
+      },
+      {
+        "name": "British Solomon Islands"
+      },
+      {
+        "name": "British Solomon Islands Protectorate"
+      },
+      {
+        "name": "Duni Solomon",
+        "lang": "wo"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Duuɗe Solomon",
+        "lang": "ff"
+      },
+      {
+        "name": "Giravên Salomon",
+        "lang": "ku"
+      },
+      {
+        "name": "Gżejjer Solomon",
+        "lang": "mt"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Solomon_Islands",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%A1%D0%BE%D0%BB%D0%BE%D0%BC%D0%BE%D0%BD%D0%BE%D0%B2%D1%8B_%D0%9E%D1%81%D1%82%D1%80%D0%BE%D0%B2%D0%B0",
+        "lang": "link"
+      },
+      {
+        "name": "Ibirwa bya Solomoni",
+        "lang": "rw"
+      },
+      {
+        "name": "Iles Salomon",
+        "lang": "fr"
+      },
+      {
+        "name": "Iles Salomon",
+        "lang": "frp"
+      },
+      {
+        "isShortName": true,
+        "isPreferredName": true,
+        "name": "Îles Salomon",
+        "lang": "fr"
+      },
+      {
+        "name": "Ilhas Salomão",
+        "lang": "pt"
+      },
+      {
+        "name": "Illas Salamon",
+        "lang": "oc"
+      },
+      {
+        "name": "Illas Salomon",
+        "lang": "oc"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Illas Salomón",
+        "lang": "gl"
+      },
+      {
+        "name": "Illas Salomón - Solomon Islands",
+        "lang": "gl"
+      },
+      {
+        "name": "Inizi Solomon",
+        "lang": "br"
+      },
+      {
+        "name": "Insulae Salomonis",
+        "lang": "la"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Insulas Solomon",
+        "lang": "ia"
+      },
+      {
+        "name": "Insulele Solomon",
+        "lang": "ro"
+      },
+      {
+        "name": "Ishujt Solomon",
+        "lang": "sq"
+      },
+      {
+        "name": "Is-isla ti Solomon",
+        "lang": "ilo"
+      },
+      {
+        "name": "Islas Salomón",
+        "lang": "an"
+      },
+      {
+        "isShortName": true,
+        "isPreferredName": true,
+        "name": "Islas Salomón",
+        "lang": "es"
+      },
+      {
+        "name": "Islas Salomón",
+        "lang": "ext"
+      },
+      {
+        "name": "Islas Solomon",
+        "lang": "bcl"
+      },
+      {
+        "name": "Islles Salomón",
+        "lang": "ast"
+      },
+      {
+        "name": "Isoe Salomon",
+        "lang": "lij"
+      },
+      {
+        "name": "Ìsole Salomon",
+        "lang": "pms"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Isole Salomone",
+        "lang": "it"
+      },
+      {
+        "name": "Isole Solomon",
+        "lang": "it"
+      },
+      {
+        "isPreferredName": true,
+        "name": "i-Solomon Islands",
+        "lang": "zu"
+      },
+      {
+        "name": "Ìsuli Salamuni",
+        "lang": "scn"
+      },
+      {
+        "name": "Isul Salomon",
+        "lang": "lmo"
+      },
+      {
+        "name": "Jasiiradaha Solomon",
+        "lang": "so"
+      },
+      {
+        "name": "Kapuloan Solomon",
+        "lang": "jv"
+      },
+      {
+        "name": "Kapuloan Solomon",
+        "lang": "su"
+      },
+      {
+        "name": "Kapuluang Solomon",
+        "lang": "tl"
+      },
+      {
+        "name": "Kapupud-ang Solomon",
+        "lang": "ceb"
+      },
+      {
+        "name": "Kapuropod-an Solomon",
+        "lang": "war"
+      },
+      {
+        "name": "Kepulauan Solomon",
+        "lang": "id"
+      },
+      {
+        "name": "Kepulauan Solomon",
+        "lang": "ms"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Lutanda lua Solomu",
+        "lang": "lu"
+      },
+      {
+        "name": "Na h-Eileanan Sholaimh",
+        "lang": "gd"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Nosy Salomona",
+        "lang": "mg"
+      },
+      {
+        "name": "Nosy Solomona",
+        "lang": "mg"
+      },
+      {
+        "name": "Ny h-Ellanyn Holomon",
+        "lang": "gv"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Oileáin Sholaimh",
+        "lang": "ga"
+      },
+      {
+        "name": "Oileáin Sholamón",
+        "lang": "ga"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Orílẹ́ède Etikun Solomoni",
+        "lang": "yo"
+      },
+      {
+        "isPreferredName": true,
+        "name": "ʻOtumotu Solomone",
+        "lang": "to"
+      },
+      {
+        "name": "Pulo-pulo Solomon",
+        "lang": "ace"
+      },
+      {
+        "name": "Quần đảo Solomon",
+        "lang": "vi"
+      },
+      {
+        "name": "Quần đảo Xô-lô-mông",
+        "lang": "vi"
+      },
+      {
+        "name": "Saalomoni Saared",
+        "lang": "et"
+      },
+      {
+        "name": "Salamon-szigetek",
+        "lang": "hu"
+      },
+      {
+        "name": "Šalamounovy ostrovy",
+        "lang": "cs"
+      },
+      {
+        "name": "Šalamúnove ostrovy",
+        "lang": "sk"
+      },
+      {
+        "name": "Salamunovi Otoci",
+        "lang": "hr"
+      },
+      {
+        "name": "Saliamono salos",
+        "lang": "lt"
+      },
+      {
+        "name": "Saliamono Salos",
+        "lang": "lt"
+      },
+      {
+        "name": "Saliamuona Salas",
+        "lang": "sgs"
+      },
+      {
+        "name": "Salomó",
+        "lang": "ca"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Salomo Gun",
+        "lang": "bm"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Salomon",
+        "lang": "br"
+      },
+      {
+        "name": "Salomon",
+        "lang": "fr"
+      },
+      {
+        "name": "Salomon",
+        "lang": "ht"
+      },
+      {
+        "name": "Salomón",
+        "lang": "es"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Salomonas",
+        "lang": "rm"
+      },
+      {
+        "name": "Salomone",
+        "lang": "ksh"
+      },
+      {
+        "name": "Salomone, isole",
+        "lang": "it"
+      },
+      {
+        "name": "Salomonen",
+        "lang": "als"
+      },
+      {
+        "name": "Salomonen",
+        "lang": "de"
+      },
+      {
+        "name": "Salomonen",
+        "lang": "lb"
+      },
+      {
+        "name": "Salomonen",
+        "lang": "nds"
+      },
+      {
+        "name": "Salomoninseln",
+        "lang": "de"
+      },
+      {
+        "name": "Salomon Insuli",
+        "lang": "io"
+      },
+      {
+        "name": "Salomonöarna",
+        "lang": "sv"
+      },
+      {
+        "name": "Salomonøerne",
+        "lang": "da"
+      },
+      {
+        "name": "Salomonoj",
+        "lang": "eo"
+      },
+      {
+        "name": "Salomonovi otoki",
+        "lang": "sl"
+      },
+      {
+        "name": "Salomonovo otočje",
+        "lang": "sl"
+      },
+      {
+        "name": "Salomonøyane",
+        "lang": "nn"
+      },
+      {
+        "name": "Salomonøyene",
+        "lang": "nb"
+      },
+      {
+        "name": "Salomonøyene",
+        "lang": "nn"
+      },
+      {
+        "name": "Salomonøyene",
+        "lang": "no"
+      },
+      {
+        "name": "Sálomonoyggjarnar",
+        "lang": "fo"
+      },
+      {
+        "name": "Salomonsaaret",
+        "lang": "fi"
+      },
+      {
+        "name": "Salomonseilanden",
+        "lang": "nl"
+      },
+      {
+        "name": "Salomonseilannen",
+        "lang": "fy"
+      },
+      {
+        "name": "Salomonseilen",
+        "lang": "li"
+      },
+      {
+        "name": "Salómonseyjar",
+        "lang": "is"
+      },
+      {
+        "name": "Salomonski Otoci",
+        "lang": "hr"
+      },
+      {
+        "name": "Salomonsullot",
+        "lang": "se"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Salomon-sullot",
+        "lang": "se"
+      },
+      {
+        "name": "Salomón Tlālhuāctli",
+        "lang": "nah"
+      },
+      {
+        "name": "Salomon uharteak",
+        "lang": "eu"
+      },
+      {
+        "name": "Salomon Uharteak",
+        "lang": "eu"
+      },
+      {
+        "name": "Salomony",
+        "lang": "dsb"
+      },
+      {
+        "name": "Salomony",
+        "lang": "hsb"
+      },
+      {
+        "name": "Salumun watakuna",
+        "lang": "qu"
+      },
+      {
+        "name": "Solamon Ailen",
+        "lang": "pih"
+      },
+      {
+        "name": "Só͘-lô-bûn Kûn-tó",
+        "lang": "nan"
+      },
+      {
+        "name": "Solomon adaları",
+        "lang": "az"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Solomon Adaları",
+        "lang": "az"
+      },
+      {
+        "name": "Solomon Adaları",
+        "lang": "crh"
+      },
+      {
+        "name": "Solomon Adaları",
+        "lang": "tr"
+      },
+      {
+        "name": "Solomon Ailans",
+        "lang": "tpi"
+      },
+      {
+        "name": "Solomoneilande",
+        "lang": "af"
+      },
+      {
+        "name": "Solomon Eilande",
+        "lang": "af"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Solomon-Inseln",
+        "lang": "de"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Solomon Islands",
+        "lang": "ak"
+      },
+      {
+        "name": "Solomon Islands",
+        "lang": "en"
+      },
+      {
+        "name": "Solomon Islands",
+        "lang": "mt"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Solomon Islands",
+        "lang": "nd"
+      },
+      {
+        "name": "Solomon Islands",
+        "lang": "pam"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Solomon Islands",
+        "lang": "so"
+      },
+      {
+        "name": "Solomon Islands"
+      },
+      {
+        "name": "Solomon Orollari",
+        "lang": "uz"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Solomonska Ostrva",
+        "lang": "bs"
+      },
+      {
+        "name": "Solomonski Otoci",
+        "lang": "hbs"
+      },
+      {
+        "name": "Sólomon Tó Bináhaazyínígíí",
+        "lang": "nv"
+      },
+      {
+        "name": "Solomonuäns",
+        "lang": "vo"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Solomon ƒudomekpowo nutome",
+        "lang": "ee"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Tsibiran Salaman",
+        "lang": "ha"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Visiwa vya Solomon",
+        "lang": "ki"
+      },
+      {
+        "name": "Visiwa vya Solomon",
+        "lang": "sw"
+      },
+      {
+        "name": "Wyspy Salomona",
+        "lang": "pl"
+      },
+      {
+        "name": "Ynysoedd Solomon",
+        "lang": "cy"
+      },
+      {
+        "name": "Ynysow Salamon",
+        "lang": "kw"
+      },
+      {
+        "name": "Zālamana salas",
+        "lang": "lv"
+      },
+      {
+        "name": "Zālamana Salas",
+        "lang": "lv"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Zûâ Salomöon",
+        "lang": "sg"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Zvitsuwa zvaSolomon",
+        "lang": "sn"
+      },
+      {
+        "name": "جزایر سلیمان",
+        "lang": "fa"
+      },
+      {
+        "name": "جزائر سلیمان",
+        "lang": "ur"
+      },
+      {
+        "name": "جزر سليمان",
+        "lang": "ar"
+      },
+      {
+        "name": "جزر سولومون",
+        "lang": "arz"
+      },
+      {
+        "isPreferredName": true,
+        "name": "جزیره های سالامون",
+        "lang": "fa"
+      },
+      {
+        "name": "د سلېمان ټاپوان",
+        "lang": "ps"
+      },
+      {
+        "name": "دوورگەکانی سلێمان",
+        "lang": "ckb"
+      },
+      {
+        "isPreferredName": true,
+        "name": "دوورگەکانی سلێمان",
+        "lang": "ku"
+      },
+      {
+        "name": "سولومن آئلینڈ",
+        "lang": "pnb"
+      },
+      {
+        "isPreferredName": true,
+        "name": "سولومن آئلینڈز",
+        "lang": "ur"
+      },
+      {
+        "name": "سولومون تاقىم ئاراللىرى",
+        "lang": "ug"
+      },
+      {
+        "name": "איי שלמה",
+        "lang": "he"
+      },
+      {
+        "name": "שלמה, איי",
+        "lang": "he"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Νησιά Σολομώντα",
+        "lang": "el"
+      },
+      {
+        "name": "Νήσοι Σολομώντα",
+        "lang": "el"
+      },
+      {
+        "name": "Νήσοι Σολομώντος",
+        "lang": "el"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Саламонавы Астравы",
+        "lang": "be"
+      },
+      {
+        "name": "Соломонан гӀайренаш",
+        "lang": "ce"
+      },
+      {
+        "name": "Соломон Аралдары",
+        "lang": "kk"
+      },
+      {
+        "name": "Соломон аралууд",
+        "lang": "bxr"
+      },
+      {
+        "name": "Соломон арыылара",
+        "lang": "sah"
+      },
+      {
+        "name": "Соломони",
+        "lang": "mk"
+      },
+      {
+        "name": "Соломонин Арлс",
+        "lang": "xal"
+      },
+      {
+        "name": "Соломонова Острва",
+        "lang": "sr"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Соломонови О-ви",
+        "lang": "bg"
+      },
+      {
+        "name": "Соломонови острови",
+        "lang": "bg"
+      },
+      {
+        "name": "Соломонови Острови",
+        "lang": "bg"
+      },
+      {
+        "name": "Соломоновите Острови",
+        "lang": "mk"
+      },
+      {
+        "name": "Соломонові Острови",
+        "lang": "uk"
+      },
+      {
+        "name": "Соломоновы Острова",
+        "lang": "ru"
+      },
+      {
+        "name": "Соломонска Острва",
+        "lang": "sr"
+      },
+      {
+        "isPreferredName": true,
+        "name": "Соломонские острова",
+        "lang": "ru"
+      },
+      {
+        "name": "Соломон Утравĕсем",
+        "lang": "cv"
+      },
+      {
+        "name": "Соломон Утрауҙары",
+        "lang": "ba"
+      },
+      {
+        "name": "Соломоны сакъадæхтæ",
+        "lang": "os"
+      },
+      {
+        "name": "Ҷазираҳои Соломон",
+        "lang": "tg"
+      },
+      {
+        "name": "སོ་ལོ་མོན་གླིང་ཕྲན་ཚོ་ཁག",
+        "lang": "bo"
+      },
+      {
+        "isPreferredName": true,
+        "name": "སོ་ལོ་མོན། གླིང་ཕྲན་ཚོ་ཁག།",
+        "lang": "bo"
+      },
+      {
+        "name": "Սոլոմոնյան կղզիներ",
+        "lang": "hy"
+      },
+      {
+        "name": "Սողոմոնյան Կղզիներ",
+        "lang": "hy"
+      },
+      {
+        "name": "სოლომონის კუნძულები",
+        "lang": "ka"
+      },
+      {
+        "name": "सॉलोमन द्वीपसमूह",
+        "lang": "mr"
+      },
+      {
+        "name": "सोलोमन द्धीप",
+        "lang": "ne"
+      },
+      {
+        "isPreferredName": true,
+        "name": "सोलोमन द्वीप",
+        "lang": "hi"
+      },
+      {
+        "name": "सोलोमन-द्वीप",
+        "lang": "sa"
+      },
+      {
+        "name": "सोलोमन द्वीपसमूह",
+        "lang": "hi"
+      },
+      {
+        "isPreferredName": true,
+        "name": "सोलोमन बेटे",
+        "lang": "mr"
+      },
+      {
+        "isPreferredName": true,
+        "name": "सोलोमोन टापु",
+        "lang": "ne"
+      },
+      {
+        "isPreferredName": true,
+        "name": "સોલોમન આઇલેન્ડ",
+        "lang": "gu"
+      },
+      {
+        "name": "సోలమన్ దీవులు",
+        "lang": "te"
+      },
+      {
+        "isPreferredName": true,
+        "name": "సోలోమన్ దీవులు",
+        "lang": "te"
+      },
+      {
+        "name": "ਸੋਲੋਮਨ ਟਾਪੂ",
+        "lang": "pa"
+      },
+      {
+        "name": "ಸಾಲೊಮನ್ ದ್ವೀಪಗಳು",
+        "lang": "kn"
+      },
+      {
+        "isPreferredName": true,
+        "name": "ಸೊಲೊಮನ್ ದ್ವೀಪಗಳು",
+        "lang": "kn"
+      },
+      {
+        "name": "சாலமன் தீவுகள்",
+        "lang": "ta"
+      },
+      {
+        "name": "சொலமன் தீவுகள்",
+        "lang": "ta"
+      },
+      {
+        "name": "സോളമൻ ദ്വീപുകൾ",
+        "lang": "ml"
+      },
+      {
+        "isPreferredName": true,
+        "name": "സോളമന്‍‍ ദ്വീപുകള്‍",
+        "lang": "ml"
+      },
+      {
+        "isPreferredName": true,
+        "name": "সলোমন দ্বীপপুঞ্জ",
+        "lang": "bn"
+      },
+      {
+        "name": "সলোমন দ্বীপমালা",
+        "lang": "bpy"
+      },
+      {
+        "isPreferredName": true,
+        "name": "ဆော်လမွန်ကျွန်းစု",
+        "lang": "my"
+      },
+      {
+        "name": "ဆော်လမွန်အိုင်းလန်းနိုင်ငံ",
+        "lang": "my"
+      },
+      {
+        "name": "සොලමන් දුපත්",
+        "lang": "si"
+      },
+      {
+        "name": "所罗门群岛",
+        "lang": "zh"
+      },
+      {
+        "name": "所羅門群島",
+        "lang": "yue"
+      },
+      {
+        "name": "ソロモン諸島",
+        "lang": "ja"
+      }
+    ],
+    "adminName2": "",
+    "name": "Solomon Islands",
+    "fclName": "country, state, region,...",
+    "countryName": "Solomon Islands",
+    "fcodeName": "independent political entity",
+    "adminName1": ""
+  },
+  "Rafin Marke": 9412420,
+  "9412420": {
+    "adminCode3": "JI0810",
+    "alternateNames": [
+
+    ],
+    "adminCode2": "18024",
+    "countryName": "Nigeria",
+    "adminCode1": "39",
+    "lng": "9.0221",
+    "adminName2": "Garki",
+    "fcodeName": "third-order administrative division",
+    "adminName3": "Rafin Marke",
+    "timezone": {
+      "dstOffset": 1,
+      "gmtOffset": 1,
+      "timeZoneId": "Africa/Lagos"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 12.40195170000004,
+      "east": 9.11000725100007,
+      "north": 12.510260569000025,
+      "west": 8.945550885000046
+    },
+    "name": "Rafin Marke",
+    "fcode": "ADM3",
+    "geonameId": 9412420,
+    "asciiName": "Rafin Marke",
+    "lat": "12.45339",
+    "population": 0,
+    "adminName1": "Jigawa",
+    "adminId1": "2565345",
+    "countryId": "2328926",
+    "fclName": "country, state, region,...",
+    "countryCode": "NG",
+    "srtm3": 381,
+    "adminId3": "9412420",
+    "adminId2": "8634242",
+    "toponymName": "Rafin Marke",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "South Bend Regional Airport": 6299046,
+  "6299046": {
+    "alternateNames": [
+      {
+        "name": "http://en.wikipedia.org/wiki/South_Bend_Regional_Airport",
+        "lang": "link"
+      },
+      {
+        "name": "KSBN",
+        "lang": "icao"
+      },
+      {
+        "name": "SBN",
+        "lang": "iata"
+      },
+      {
+        "name": "South Bend Regional Airport",
+        "isPreferredName": true
+      },
+      {
+        "name": "South Bend, South Bend Regional Airport"
+      }
+    ],
+    "countryName": "United States",
+    "adminCode1": "IN",
+    "lng": "-86.31725",
+    "adminName2": "",
+    "fcodeName": "airport",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": -4,
+      "gmtOffset": -5,
+      "timeZoneId": "America/Indiana/Indianapolis"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "name": "South Bend Regional Airport",
+    "fcode": "AIRP",
+    "geonameId": 6299046,
+    "asciiName": "South Bend Regional Airport",
+    "lat": "41.70866",
+    "population": 0,
+    "adminName1": "Indiana",
+    "adminId1": "4921868",
+    "countryId": "6252001",
+    "fclName": "spot, building, farm",
+    "elevation": 243,
+    "countryCode": "US",
+    "srtm3": 237,
+    "wikipediaURL": "en.wikipedia.org/wiki/South_Bend_Regional_Airport",
+    "toponymName": "South Bend Regional Airport",
+    "fcl": "S",
+    "continentCode": "NA"
+  },
+  "Bbaale": 8644158,
+  "8644158": {
+    "adminCode3": "8644158",
+    "alternateNames": [
+
+    ],
+    "adminCode2": "83",
+    "countryName": "Uganda",
+    "adminCode1": "C",
+    "lng": "32.85252",
+    "adminName2": "Kayunga",
+    "fcodeName": "third-order administrative division",
+    "adminName3": "Bbaale",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Kampala"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "name": "Bbaale",
+    "fcode": "ADM3",
+    "geonameId": 8644158,
+    "asciiName": "Bbaale",
+    "lat": "1.09952",
+    "population": 0,
+    "adminName1": "Central Region",
+    "adminId1": "234594",
+    "countryId": "226074",
+    "fclName": "country, state, region,...",
+    "countryCode": "UG",
+    "srtm3": 1061,
+    "adminId3": "8644158",
+    "adminId2": "448218",
+    "toponymName": "Bbaale",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Asembo Location": 200827,
+  "200827": {
+    "alternateNames": [
+      {
+        "name": "Asembo Location"
+      },
+      {
+        "name": "Usembo"
+      }
+    ],
+    "countryName": "Kenya",
+    "adminCode1": "46",
+    "lng": "34.36667",
+    "adminName2": "",
+    "fcodeName": "administrative division",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Nairobi"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "name": "Asembo Location",
+    "fcode": "ADMD",
+    "geonameId": 200827,
+    "asciiName": "Asembo Location",
+    "lat": "-0.13333",
+    "population": 0,
+    "adminName1": "Siaya",
+    "countryId": "192950",
+    "adminId1": "180320",
+    "fclName": "country, state, region,...",
+    "countryCode": "KE",
+    "srtm3": 1218,
+    "toponymName": "Asembo Location",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Kilombero District": 157408,
+  "157408": {
+    "adminCode2": "157408",
+    "alternateNames": [
+
+    ],
+    "countryName": "Tanzania",
+    "adminCode1": "10",
+    "lng": "36.41667",
+    "adminName2": "Kilombero District",
+    "fcodeName": "second-order administrative division",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Dar_es_Salaam"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "name": "Kilombero District",
+    "fcode": "ADM2",
+    "geonameId": 157408,
+    "asciiName": "Kilombero District",
+    "lat": "-8.25",
+    "population": 0,
+    "adminName1": "Morogoro",
+    "adminId1": "153214",
+    "countryId": "149590",
+    "fclName": "country, state, region,...",
+    "countryCode": "TZ",
+    "srtm3": 257,
+    "adminId2": "157408",
+    "toponymName": "Kilombero District",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Muheza District": 152629,
+  "152629": {
+    "adminCode2": "152629",
+    "alternateNames": [
+      {
+        "name": "http://en.wikipedia.org/wiki/Muheza_District",
+        "lang": "link"
+      },
+      {
+        "name": "Muheza"
+      }
+    ],
+    "countryName": "Tanzania",
+    "adminCode1": "18",
+    "lng": "38.923",
+    "adminName2": "Muheza District",
+    "fcodeName": "second-order administrative division",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Dar_es_Salaam"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "name": "Muheza District",
+    "fcode": "ADM2",
+    "geonameId": 152629,
+    "asciiName": "Muheza District",
+    "lat": "-4.905",
+    "population": 0,
+    "adminName1": "Tanga",
+    "adminId1": "149595",
+    "countryId": "149590",
+    "fclName": "country, state, region,...",
+    "countryCode": "TZ",
+    "srtm3": 144,
+    "adminId2": "152629",
+    "wikipediaURL": "en.wikipedia.org/wiki/Muheza_District",
+    "toponymName": "Muheza District",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Garki": 8634242,
+  "8634242": {
+    "adminCode2": "18024",
+    "alternateNames": [
+      {
+        "name": "Garki"
+      },
+      {
+        "name": "Garki Local Government Area"
+      }
+    ],
+    "countryName": "Nigeria",
+    "adminCode1": "39",
+    "lng": "9.06052",
+    "adminName2": "Garki",
+    "fcodeName": "second-order administrative division",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 1,
+      "gmtOffset": 1,
+      "timeZoneId": "Africa/Lagos"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 12.275354881000055,
+      "east": 9.534899998000071,
+      "north": 12.587234598000066,
+      "west": 8.721031074000052
+    },
+    "name": "Garki",
+    "fcode": "ADM2",
+    "geonameId": 8634242,
+    "asciiName": "Garki",
+    "lat": "12.42962",
+    "population": 0,
+    "adminName1": "Jigawa",
+    "adminId1": "2565345",
+    "countryId": "2328926",
+    "fclName": "country, state, region,...",
+    "countryCode": "NG",
+    "srtm3": 379,
+    "adminId2": "8634242",
+    "toponymName": "Garki",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Namawala River": 151982,
+  "151982": {
+    "alternateNames": [
+      {
+        "name": "Namawala Idanda"
+      },
+      {
+        "name": "Namawala River"
+      }
+    ],
+    "countryName": "Tanzania",
+    "adminCode1": "10",
+    "lng": "36.53333",
+    "adminName2": "",
+    "fcodeName": "stream",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Dar_es_Salaam"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "name": "Namawala River",
+    "fcode": "STM",
+    "geonameId": 151982,
+    "asciiName": "Namawala River",
+    "lat": "-8.23333",
+    "population": 0,
+    "adminName1": "Morogoro",
+    "countryId": "149590",
+    "adminId1": "153214",
+    "fclName": "stream, lake, ...",
+    "countryCode": "TZ",
+    "srtm3": 254,
+    "toponymName": "Namawala River",
+    "fcl": "H",
+    "continentCode": "AF"
+  },
+  "Namawala": 151982,
+  "Tanzania": 149590,
+  "149590": {
+    "alternateNames": [
+      {
+        "name": "탄자니아",
+        "lang": "ko"
+      },
+      {
+        "name": "ታንዛኒያ",
+        "lang": "am"
+      },
+      {
+        "name": "ታንዛኒያ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "タンザニア",
+        "lang": "ja"
+      },
+      {
+        "name": "ທານຊາເນຍ",
+        "lang": "lo"
+      },
+      {
+        "name": "ତାଞ୍ଜାନିଆ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "แทนซาเนีย",
+        "isPreferredName": true,
+        "lang": "th"
+      },
+      {
+        "name": "តង់ហ្សានី",
+        "lang": "km"
+      },
+      {
+        "name": "ประเทศแทนซาเนีย",
+        "lang": "th"
+      },
+      {
+        "name": "An Tansáin",
+        "lang": "ga"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Tanzania",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%A2%D0%B0%D0%BD%D0%B7%D0%B0%D0%BD%D0%B8%D1%8F",
+        "lang": "link"
+      },
+      {
+        "name": "i-Tanzania",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Orílẹ́ède Tanṣania",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "República Xunida de Tanzania",
+        "lang": "ast"
+      },
+      {
+        "name": "Tan-da-ni-a",
+        "lang": "vi"
+      },
+      {
+        "name": "Tan-da-ni-a (Tanzania)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Tansaania",
+        "lang": "et"
+      },
+      {
+        "name": "Tansaaniya",
+        "lang": "so"
+      },
+      {
+        "name": "Tansanän",
+        "lang": "vo"
+      },
+      {
+        "name": "Tansania",
+        "lang": "de"
+      },
+      {
+        "name": "Tansania",
+        "lang": "fi"
+      },
+      {
+        "name": "Tansania",
+        "lang": "fo"
+      },
+      {
+        "name": "Tansania",
+        "lang": "kw"
+      },
+      {
+        "name": "Tansania",
+        "lang": "nds"
+      },
+      {
+        "name": "Tansania",
+        "lang": "rm"
+      },
+      {
+        "name": "Tansania"
+      },
+      {
+        "name": "Tansanía",
+        "lang": "is"
+      },
+      {
+        "name": "Tansanïa",
+        "lang": "cy"
+      },
+      {
+        "name": "Tansanii",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Tansanya",
+        "lang": "qu"
+      },
+      {
+        "name": "Tanzani",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Tanzani",
+        "lang": "ht"
+      },
+      {
+        "name": "Tanzani",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Tanzani",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Tanzani",
+        "lang": "sq"
+      },
+      {
+        "name": "Tanzania",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "an"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "br"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "cy"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "da"
+      },
+      {
+        "isShortName": true,
+        "name": "Tanzania",
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Tanzania",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Tanzania",
+        "isPreferredName": true,
+        "lang": "et"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "eu"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "gd"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "gl"
+      },
+      {
+        "name": "Tanzania",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "id"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "ilo"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "io"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "it"
+      },
+      {
+        "name": "Tanzania",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Tanzania",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "la"
+      },
+      {
+        "name": "Tanzania",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "ms"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "nb"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "nl"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "nn"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "no"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "oc"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "pam"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "pl"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "ro"
+      },
+      {
+        "name": "Tanzania",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "sq"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "sv"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "sw"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "tl"
+      },
+      {
+        "name": "Tanzania",
+        "lang": "vi"
+      },
+      {
+        "name": "Tanzania"
+      },
+      {
+        "name": "Tanzánia",
+        "lang": "hu"
+      },
+      {
+        "name": "Tanzánia",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Tanzánia",
+        "lang": "sk"
+      },
+      {
+        "name": "Tanzània",
+        "lang": "ca"
+      },
+      {
+        "name": "Tanzânia",
+        "lang": "pt"
+      },
+      {
+        "name": "Tanzania nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Tanzanie",
+        "lang": "cs"
+      },
+      {
+        "name": "Tanzanie",
+        "lang": "fr"
+      },
+      {
+        "name": "Tanzanie",
+        "lang": "frp"
+      },
+      {
+        "name": "Tanzanie"
+      },
+      {
+        "name": "Tanzánie",
+        "isPreferredName": true,
+        "lang": "cs"
+      },
+      {
+        "name": "Tanzanië",
+        "lang": "af"
+      },
+      {
+        "name": "Tanzanïi",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Tanzanija",
+        "lang": "bs"
+      },
+      {
+        "name": "Tanzanija",
+        "lang": "hbs"
+      },
+      {
+        "name": "Tanzanija",
+        "lang": "hr"
+      },
+      {
+        "name": "Tanzanija",
+        "lang": "lt"
+      },
+      {
+        "name": "Tanzanija",
+        "lang": "sl"
+      },
+      {
+        "name": "Tanżanija",
+        "lang": "mt"
+      },
+      {
+        "name": "Tanzānija",
+        "lang": "lv"
+      },
+      {
+        "name": "Tanzanio",
+        "lang": "eo"
+      },
+      {
+        "name": "Tanzaniya",
+        "lang": "az"
+      },
+      {
+        "name": "Tanzaniya",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Tanzaniya",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Tanzaniya",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Tanzaniya",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Tanzanya",
+        "lang": "tr"
+      },
+      {
+        "name": "Tenisania",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "United Republic of Tanganyika and Zanzibar"
+      },
+      {
+        "name": "United Republic of Tanzania"
+      },
+      {
+        "name": "تانزانیا",
+        "lang": "fa"
+      },
+      {
+        "name": "تانزانیا",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "تانزانيا",
+        "lang": "ar"
+      },
+      {
+        "name": "تانزانيه",
+        "lang": "ps"
+      },
+      {
+        "name": "تانزانىيە",
+        "lang": "ug"
+      },
+      {
+        "name": "تنزانیہ",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "تنزانیا",
+        "lang": "ps"
+      },
+      {
+        "name": "تنزانيا",
+        "lang": "ar"
+      },
+      {
+        "name": "טאנזניה",
+        "isPreferredName": true,
+        "lang": "he"
+      },
+      {
+        "name": "טנזניה",
+        "lang": "he"
+      },
+      {
+        "name": "Τανζανία",
+        "lang": "el"
+      },
+      {
+        "name": "Обʼєднана Республіка Танзанія",
+        "isPreferredName": true,
+        "lang": "uk"
+      },
+      {
+        "name": "Танзанија",
+        "lang": "mk"
+      },
+      {
+        "name": "Танзанија",
+        "lang": "sr"
+      },
+      {
+        "name": "Танзания",
+        "lang": "bg"
+      },
+      {
+        "name": "Танзания",
+        "lang": "ru"
+      },
+      {
+        "name": "Танзания",
+        "lang": "tg"
+      },
+      {
+        "name": "Танзанія",
+        "lang": "uk"
+      },
+      {
+        "name": "Танзанія, Аб'яднаная Рэспубліка",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Танзанія, Обʼєднана Республіка",
+        "lang": "uk"
+      },
+      {
+        "name": "Տանզանիա",
+        "lang": "hy"
+      },
+      {
+        "name": "ტანზანია",
+        "lang": "ka"
+      },
+      {
+        "name": "टांझानिया",
+        "lang": "mr"
+      },
+      {
+        "name": "टंजानिया",
+        "lang": "ks"
+      },
+      {
+        "name": "टंजानिया",
+        "lang": "sa"
+      },
+      {
+        "name": "तान्जानिया",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "तंजा़निया",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "तंज़ानिया",
+        "lang": "hi"
+      },
+      {
+        "name": "तंस़ानिया",
+        "lang": "hi"
+      },
+      {
+        "name": "તાંઝાનિયા",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "టాంజానియా",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಟಾಂಜಾನಿಯಾ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "டான்சானியா",
+        "isPreferredName": true,
+        "lang": "ta"
+      },
+      {
+        "name": "ടാന്‍സാനിയ",
+        "lang": "ml"
+      },
+      {
+        "name": "তাঞ্জানিয়া",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "တန်ဇန်နီးယား",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "坦桑尼亚",
+        "lang": "zh"
+      },
+      {
+        "name": "タンザニア連合共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      }
+    ],
+    "countryName": "Tanzania",
+    "adminCode1": "00",
+    "lng": "35",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Dar_es_Salaam"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -11.745696,
+      "east": 40.443222,
+      "north": -0.990736,
+      "west": 29.327168
+    },
+    "name": "Tanzania",
+    "fcode": "PCLI",
+    "geonameId": 149590,
+    "asciiName": "United Republic of Tanzania",
+    "lat": "-6",
+    "population": 41892895,
+    "adminName1": "",
+    "countryId": "149590",
+    "fclName": "country, state, region,...",
+    "countryCode": "TZ",
+    "srtm3": 829,
+    "wikipediaURL": "en.wikipedia.org/wiki/Tanzania",
+    "toponymName": "United Republic of Tanzania",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Vietman": null,
+  "Asia": 6255147,
+  "6255147": {
+    "alternateNames": [
+      {
+        "name": "アジア",
+        "lang": "ja"
+      },
+      {
+        "name": "아시아",
+        "isPreferredName": true,
+        "lang": "ko"
+      },
+      {
+        "name": "เอเชีย",
+        "lang": "th"
+      },
+      {
+        "name": "Aasia",
+        "lang": "fi"
+      },
+      {
+        "name": "an Áise",
+        "lang": "ga"
+      },
+      {
+        "name": "Asia",
+        "lang": "cy"
+      },
+      {
+        "name": "Asia",
+        "isPreferredName": true,
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Asia",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Asia",
+        "lang": "eu"
+      },
+      {
+        "name": "Asia",
+        "lang": "id"
+      },
+      {
+        "name": "Asia",
+        "lang": "it"
+      },
+      {
+        "name": "Asia",
+        "lang": "la"
+      },
+      {
+        "name": "Asia",
+        "lang": "nb"
+      },
+      {
+        "name": "Asia",
+        "lang": "no"
+      },
+      {
+        "name": "Ásia",
+        "lang": "pt"
+      },
+      {
+        "name": "Ásia",
+        "lang": "se"
+      },
+      {
+        "name": "Àsia",
+        "lang": "ca"
+      },
+      {
+        "name": "Asía",
+        "lang": "is"
+      },
+      {
+        "name": "Asie",
+        "lang": "cs"
+      },
+      {
+        "name": "Asie",
+        "lang": "fr"
+      },
+      {
+        "name": "Asien",
+        "lang": "da"
+      },
+      {
+        "name": "Asien",
+        "lang": "de"
+      },
+      {
+        "name": "Asien",
+        "lang": "sv"
+      },
+      {
+        "name": "Asya",
+        "lang": "tr"
+      },
+      {
+        "isShortName": true,
+        "name": "Azië",
+        "isPreferredName": true,
+        "lang": "nl"
+      },
+      {
+        "name": "Azija",
+        "lang": "bs"
+      },
+      {
+        "name": "Azija",
+        "lang": "lt"
+      },
+      {
+        "name": "Āzija",
+        "lang": "lv"
+      },
+      {
+        "name": "Azio",
+        "lang": "eo"
+      },
+      {
+        "name": "Azja",
+        "lang": "pl"
+      },
+      {
+        "name": "Ázsia",
+        "lang": "hu"
+      },
+      {
+        "name": "Châu Á",
+        "lang": "vi"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Asia",
+        "lang": "link"
+      },
+      {
+        "name": "آسيا",
+        "lang": "ar"
+      },
+      {
+        "name": "ایشیا",
+        "lang": "ur"
+      },
+      {
+        "name": "אסיה",
+        "lang": "he"
+      },
+      {
+        "name": "Ασία",
+        "lang": "el"
+      },
+      {
+        "name": "Азия",
+        "lang": "bg"
+      },
+      {
+        "isShortName": true,
+        "name": "Азия",
+        "isPreferredName": true,
+        "lang": "ru"
+      },
+      {
+        "name": "Азія",
+        "lang": "uk"
+      },
+      {
+        "name": "एशिया महाद्वीप",
+        "lang": "hi"
+      },
+      {
+        "name": "亚洲",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "",
+    "fclName": "parks,area, ...",
+    "srtm3": 5101,
+    "lng": "89.29688",
+    "wikipediaURL": "en.wikipedia.org/wiki/Asia",
+    "adminName2": "",
+    "adminName3": "",
+    "fcodeName": "continent",
+    "adminName4": "",
+    "timezone": {
+      "dstOffset": 8,
+      "gmtOffset": 8,
+      "timeZoneId": "Australia/Perth"
+    },
+    "toponymName": "Asia",
+    "adminName5": "",
+    "fcl": "L",
+    "bbox": {
+      "south": -10.930000305175781,
+      "east": -168.98974609375,
+      "north": 81.8519287109375,
+      "west": 25.6685104370001
+    },
+    "continentCode": "AS",
+    "name": "Asia",
+    "fcode": "CONT",
+    "geonameId": 6255147,
+    "asciiName": "Asia",
+    "lat": "29.84064",
+    "population": 3812366000,
+    "adminName1": ""
+  },
+  "Americas": 3500854,
+  "3500854": {
+    "alternateNames": [
+      {
+        "name": "Aéroport international Las Américas",
+        "lang": "fr"
+      },
+      {
+        "name": "Aeroporto Internacional de Las Américas",
+        "lang": "pt"
+      },
+      {
+        "name": "Aeroporto Internazionale Las Américas",
+        "lang": "it"
+      },
+      {
+        "name": "Aeropuerto Internacional de Las Américas"
+      },
+      {
+        "name": "Aeropuerto Internacional Las Américas",
+        "lang": "es"
+      },
+      {
+        "name": "Aeropuerto Internacional Punta Caucedo"
+      },
+      {
+        "name": "Bandar Udara Internasional Las Américas",
+        "lang": "id"
+      },
+      {
+        "name": "De Las Americas International"
+      },
+      {
+        "name": "Flughafen Las Américas",
+        "lang": "de"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Las_Am%C3%A9ricas_International_Airport",
+        "lang": "link"
+      },
+      {
+        "name": "Las Américas International Airport",
+        "isPreferredName": true
+      },
+      {
+        "name": "Las Américas nemzetközi repülőtér",
+        "lang": "hu"
+      },
+      {
+        "name": "MDSD",
+        "lang": "icao"
+      },
+      {
+        "name": "Port lotniczy Las Americas",
+        "lang": "pl"
+      },
+      {
+        "name": "Santo Domingo/De Las Americas"
+      },
+      {
+        "name": "SDQ",
+        "lang": "iata"
+      },
+      {
+        "name": "فرودگاه بین‌المللی لا امریکاس",
+        "lang": "fa"
+      },
+      {
+        "name": "Фурудгоҳи бин‌алмилалӣ ло омрикос",
+        "lang": "tg"
+      },
+      {
+        "name": "लास अमेरिकास आंतरराष्ट्रीय विमानतळ",
+        "lang": "mr"
+      },
+      {
+        "name": "ラス・アメリカス国際空港",
+        "lang": "ja"
+      }
+    ],
+    "countryName": "Dominican Republic",
+    "adminCode1": "34",
+    "cc2": "DO",
+    "lng": "-69.66892",
+    "adminName2": "",
+    "fcodeName": "airport",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": -4,
+      "gmtOffset": -4,
+      "timeZoneId": "America/Santo_Domingo"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "name": "Las Américas International Airport",
+    "fcode": "AIRP",
+    "geonameId": 3500854,
+    "asciiName": "Las Americas International Airport",
+    "lat": "18.42966",
+    "population": 0,
+    "adminName1": "Nacional",
+    "adminId1": "3496024",
+    "countryId": "3508796",
+    "fclName": "spot, building, farm",
+    "elevation": 17,
+    "countryCode": "DO",
+    "srtm3": 21,
+    "wikipediaURL": "en.wikipedia.org/wiki/Las_Am%C3%A9ricas_International_Airport",
+    "toponymName": "Las Américas International Airport",
+    "fcl": "S",
+    "continentCode": "NA"
+  },
+  "Kisumu Airport": 6297309,
+  "6297309": {
+    "alternateNames": [
+      {
+        "name": "HKKI",
+        "lang": "icao"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Kisumu_International_Airport",
+        "lang": "link"
+      },
+      {
+        "name": "KIS",
+        "lang": "iata"
+      },
+      {
+        "name": "Kisumu"
+      },
+      {
+        "name": "Kisumu Airport",
+        "isPreferredName": true
+      },
+      {
+        "name": "Kisumu International Airport",
+        "lang": "en"
+      }
+    ],
+    "countryName": "Kenya",
+    "lng": "34.72889",
+    "adminName2": "",
+    "fcodeName": "airport",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Nairobi"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "name": "Kisumu International Airport",
+    "fcode": "AIRP",
+    "geonameId": 6297309,
+    "asciiName": "Kisumu Airport",
+    "lat": "-0.08614",
+    "population": 0,
+    "adminName1": "",
+    "countryId": "192950",
+    "fclName": "spot, building, farm",
+    "elevation": 1157,
+    "countryCode": "KE",
+    "srtm3": 1153,
+    "wikipediaURL": "en.wikipedia.org/wiki/Kisumu_International_Airport",
+    "toponymName": "Kisumu Airport",
+    "fcl": "S",
+    "continentCode": "AF"
+  },
+  "Idete": 159516,
+  "159516": {
+    "alternateNames": [
+
+    ],
+    "countryName": "Tanzania",
+    "adminCode1": "10",
+    "lng": "36.48333",
+    "adminName2": "",
+    "fcodeName": "populated place",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Dar_es_Salaam"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -8.108993648751426,
+      "east": 36.49241707380159,
+      "north": -8.091006351248573,
+      "west": 36.47424892619841
+    },
+    "name": "Idete",
+    "fcode": "PPL",
+    "geonameId": 159516,
+    "asciiName": "Idete",
+    "lat": "-8.1",
+    "population": 0,
+    "adminName1": "Morogoro",
+    "adminId1": "153214",
+    "countryId": "149590",
+    "fclName": "city, village,...",
+    "countryCode": "TZ",
+    "srtm3": 296,
+    "toponymName": "Idete",
+    "fcl": "P",
+    "continentCode": "AF"
+  },
+  "Tāzī": 1481511,
+  "1481511": {
+    "alternateNames": [
+      {
+        "name": "Tāzi"
+      },
+      {
+        "name": "Tāzī"
+      },
+      {
+        "name": "تازی"
+      }
+    ],
+    "countryName": "Afghanistan",
+    "adminCode1": "28",
+    "lng": "67.28284",
+    "adminName2": "",
+    "fcodeName": "locality",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 4.5,
+      "gmtOffset": 4.5,
+      "timeZoneId": "Asia/Kabul"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "name": "Tāzī",
+    "fcode": "LCTY",
+    "geonameId": 1481511,
+    "asciiName": "Tazi",
+    "lat": "32.35844",
+    "population": 0,
+    "adminName1": "Zabul",
+    "countryId": "1149361",
+    "adminId1": "1121143",
+    "fclName": "parks,area, ...",
+    "countryCode": "AF",
+    "srtm3": 1782,
+    "toponymName": "Tāzī",
+    "fcl": "L",
+    "continentCode": "AS"
+  },
+  "Southern Province": 896972,
+  "226227": {
+    "countryId": "226074",
+    "alternateNames": [
+
+    ],
+    "adminCode1": "00",
+    "countryName": "Uganda",
+    "fclName": "country, state, region,...",
+    "countryCode": "UG",
+    "srtm3": 1426,
+    "lng": "30.35",
+    "adminName2": "",
+    "adminName3": "",
+    "fcodeName": "historical first-order administrative division",
+    "adminName4": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Kampala"
+    },
+    "toponymName": "Southern Province",
+    "adminName5": "",
+    "fcl": "A",
+    "continentCode": "AF",
+    "name": "Southern Province",
+    "fcode": "ADM1H",
+    "asciiName": "Southern Province",
+    "geonameId": 226227,
+    "lat": "-1.35",
+    "adminName1": "",
+    "population": 0
+  },
+  "Rachuonyo District": 7802748,
+  "7802748": {
+    "adminCode2": "7802748",
+    "alternateNames": [
+      {
+        "name": "http://en.wikipedia.org/wiki/Rachuonyo_District",
+        "lang": "link"
+      },
+      {
+        "name": "Rachuonyo"
+      }
+    ],
+    "countryName": "Kenya",
+    "adminCode1": "17",
+    "lng": "34.739",
+    "adminName2": "Rachuonyo District",
+    "fcodeName": "second-order administrative division",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Nairobi"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "name": "Rachuonyo District",
+    "fcode": "ADM2",
+    "geonameId": 7802748,
+    "asciiName": "Rachuonyo District",
+    "lat": "-0.44",
+    "population": 300000,
+    "adminName1": "Homa Bay",
+    "adminId1": "7667665",
+    "countryId": "192950",
+    "fclName": "country, state, region,...",
+    "countryCode": "KE",
+    "srtm3": 1399,
+    "adminId2": "7802748",
+    "wikipediaURL": "en.wikipedia.org/wiki/Rachuonyo_District",
+    "toponymName": "Rachuonyo District",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "India": 1269750,
+  "1269750": {
+    "alternateNames": [
+      {
+        "name": "ꑴꄗ",
+        "isPreferredName": true,
+        "lang": "ii"
+      },
+      {
+        "name": "인도",
+        "lang": "ko"
+      },
+      {
+        "name": "ህንድ",
+        "lang": "am"
+      },
+      {
+        "name": "ህንድ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "インド",
+        "lang": "ja"
+      },
+      {
+        "name": "ଭାରତ",
+        "lang": "or"
+      },
+      {
+        "name": "ᐃᓐᑎᐊ",
+        "lang": "iu"
+      },
+      {
+        "name": "ឥណ្ឌា",
+        "lang": "km"
+      },
+      {
+        "name": "ອິນເດຍ",
+        "lang": "lo"
+      },
+      {
+        "name": "རྒྱ་གར",
+        "lang": "dz"
+      },
+      {
+        "name": "อินเดีย",
+        "lang": "th"
+      },
+      {
+        "name": "རྒྱ་གར་",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ހިންދުސްތާން",
+        "lang": "dv"
+      },
+      {
+        "name": "ประเทศอินเดีย",
+        "lang": "th"
+      },
+      {
+        "name": "Ấn Độ",
+        "lang": "vi"
+      },
+      {
+        "name": "An India",
+        "lang": "ga"
+      },
+      {
+        "name": "Barat",
+        "lang": "qu"
+      },
+      {
+        "name": "Barato",
+        "lang": "eo"
+      },
+      {
+        "name": "Bharat"
+      },
+      {
+        "name": "Bharato",
+        "lang": "eo"
+      },
+      {
+        "name": "Buyindi",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "End",
+        "lang": "ht"
+      },
+      {
+        "name": "Ende",
+        "lang": "frp"
+      },
+      {
+        "name": "Ɛndujamana",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Ênnde",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Enndo",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Eynda",
+        "lang": "kw"
+      },
+      {
+        "name": "Hinda Unio",
+        "lang": "eo"
+      },
+      {
+        "name": "Hindia",
+        "lang": "ms"
+      },
+      {
+        "name": "Hindio",
+        "lang": "eo"
+      },
+      {
+        "name": "Hindistan",
+        "lang": "az"
+      },
+      {
+        "name": "Hindistan",
+        "lang": "ku"
+      },
+      {
+        "name": "Hindistan",
+        "lang": "tk"
+      },
+      {
+        "name": "Hindistan",
+        "lang": "tr"
+      },
+      {
+        "name": "Hindıstan",
+        "lang": "diq"
+      },
+      {
+        "name": "Hindiston",
+        "lang": "uz"
+      },
+      {
+        "name": "Hindiya",
+        "lang": "so"
+      },
+      {
+        "name": "Hindstan",
+        "lang": "tt"
+      },
+      {
+        "name": "Hindujo",
+        "lang": "eo"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/India",
+        "lang": "link"
+      },
+      {
+        "name": "http://id.loc.gov/authorities/names/n80125948",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%98%D0%BD%D0%B4%D0%B8%D1%8F",
+        "lang": "link"
+      },
+      {
+        "name": "i-India",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Inde",
+        "lang": "fr"
+      },
+      {
+        "name": "Inde",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Inde",
+        "lang": "wa"
+      },
+      {
+        "name": "Înde",
+        "lang": "nrm"
+      },
+      {
+        "name": "Índɛ",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Indi",
+        "lang": "sq"
+      },
+      {
+        "name": "India",
+        "lang": "aa"
+      },
+      {
+        "name": "India",
+        "lang": "ab"
+      },
+      {
+        "name": "India",
+        "lang": "ak"
+      },
+      {
+        "name": "India",
+        "lang": "an"
+      },
+      {
+        "name": "India",
+        "lang": "ang"
+      },
+      {
+        "name": "India",
+        "lang": "arc"
+      },
+      {
+        "name": "India",
+        "lang": "ast"
+      },
+      {
+        "name": "India",
+        "lang": "av"
+      },
+      {
+        "name": "India",
+        "lang": "ay"
+      },
+      {
+        "name": "India",
+        "lang": "ba"
+      },
+      {
+        "name": "India",
+        "lang": "bi"
+      },
+      {
+        "name": "India",
+        "lang": "bm"
+      },
+      {
+        "name": "India",
+        "lang": "bo"
+      },
+      {
+        "name": "India",
+        "lang": "br"
+      },
+      {
+        "name": "India",
+        "lang": "bug"
+      },
+      {
+        "name": "India",
+        "lang": "ce"
+      },
+      {
+        "name": "India",
+        "lang": "ch"
+      },
+      {
+        "name": "India",
+        "lang": "cho"
+      },
+      {
+        "name": "India",
+        "lang": "chr"
+      },
+      {
+        "name": "India",
+        "lang": "chy"
+      },
+      {
+        "name": "India",
+        "lang": "co"
+      },
+      {
+        "name": "India",
+        "lang": "cr"
+      },
+      {
+        "name": "India",
+        "lang": "cy"
+      },
+      {
+        "name": "India",
+        "lang": "dz"
+      },
+      {
+        "name": "India",
+        "lang": "ee"
+      },
+      {
+        "name": "India",
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "India",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "India",
+        "lang": "et"
+      },
+      {
+        "name": "India",
+        "lang": "eu"
+      },
+      {
+        "name": "India",
+        "lang": "fj"
+      },
+      {
+        "name": "India",
+        "lang": "fo"
+      },
+      {
+        "name": "India",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "India",
+        "lang": "gn"
+      },
+      {
+        "name": "India",
+        "lang": "ha"
+      },
+      {
+        "name": "India",
+        "lang": "ho"
+      },
+      {
+        "name": "India",
+        "lang": "hu"
+      },
+      {
+        "name": "India",
+        "lang": "hz"
+      },
+      {
+        "name": "India",
+        "lang": "ia"
+      },
+      {
+        "name": "India",
+        "lang": "id"
+      },
+      {
+        "name": "India",
+        "lang": "ie"
+      },
+      {
+        "name": "India",
+        "lang": "ig"
+      },
+      {
+        "name": "India",
+        "lang": "ilo"
+      },
+      {
+        "name": "India",
+        "lang": "io"
+      },
+      {
+        "name": "India",
+        "lang": "it"
+      },
+      {
+        "name": "India",
+        "lang": "jv"
+      },
+      {
+        "name": "India",
+        "lang": "kg"
+      },
+      {
+        "name": "India",
+        "lang": "ki"
+      },
+      {
+        "name": "India",
+        "lang": "kj"
+      },
+      {
+        "name": "India",
+        "lang": "kl"
+      },
+      {
+        "name": "India",
+        "lang": "kv"
+      },
+      {
+        "name": "India",
+        "lang": "ky"
+      },
+      {
+        "name": "India",
+        "lang": "la"
+      },
+      {
+        "name": "India",
+        "lang": "lg"
+      },
+      {
+        "name": "India",
+        "lang": "li"
+      },
+      {
+        "name": "India",
+        "lang": "lij"
+      },
+      {
+        "name": "India",
+        "lang": "lmo"
+      },
+      {
+        "name": "India",
+        "lang": "ln"
+      },
+      {
+        "name": "India",
+        "lang": "lo"
+      },
+      {
+        "name": "India",
+        "lang": "mg"
+      },
+      {
+        "name": "India",
+        "lang": "mh"
+      },
+      {
+        "name": "India",
+        "lang": "ms"
+      },
+      {
+        "name": "India",
+        "lang": "mus"
+      },
+      {
+        "name": "India",
+        "lang": "my"
+      },
+      {
+        "name": "India",
+        "lang": "na"
+      },
+      {
+        "name": "India",
+        "lang": "nb"
+      },
+      {
+        "name": "India",
+        "lang": "ng"
+      },
+      {
+        "name": "India",
+        "lang": "nl"
+      },
+      {
+        "name": "India",
+        "lang": "nn"
+      },
+      {
+        "name": "India",
+        "lang": "no"
+      },
+      {
+        "name": "India",
+        "lang": "nov"
+      },
+      {
+        "name": "India",
+        "lang": "nv"
+      },
+      {
+        "name": "India",
+        "lang": "ny"
+      },
+      {
+        "name": "India",
+        "lang": "om"
+      },
+      {
+        "name": "India",
+        "lang": "pam"
+      },
+      {
+        "name": "India",
+        "lang": "pap"
+      },
+      {
+        "name": "India",
+        "lang": "pdc"
+      },
+      {
+        "name": "India",
+        "lang": "pih"
+      },
+      {
+        "name": "India",
+        "lang": "pms"
+      },
+      {
+        "name": "India",
+        "lang": "rm"
+      },
+      {
+        "name": "India",
+        "lang": "rn"
+      },
+      {
+        "name": "India",
+        "lang": "ro"
+      },
+      {
+        "name": "India",
+        "lang": "sd"
+      },
+      {
+        "name": "India",
+        "lang": "se"
+      },
+      {
+        "name": "India",
+        "lang": "sg"
+      },
+      {
+        "name": "India",
+        "lang": "sk"
+      },
+      {
+        "name": "India",
+        "lang": "sm"
+      },
+      {
+        "name": "India",
+        "lang": "sn"
+      },
+      {
+        "name": "India",
+        "lang": "sq"
+      },
+      {
+        "name": "India",
+        "lang": "ss"
+      },
+      {
+        "name": "India",
+        "lang": "st"
+      },
+      {
+        "name": "India",
+        "lang": "su"
+      },
+      {
+        "name": "India",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "India",
+        "lang": "ti"
+      },
+      {
+        "name": "India",
+        "lang": "tl"
+      },
+      {
+        "name": "India",
+        "lang": "tpi"
+      },
+      {
+        "name": "India",
+        "lang": "ts"
+      },
+      {
+        "name": "India",
+        "lang": "tum"
+      },
+      {
+        "name": "India",
+        "lang": "tw"
+      },
+      {
+        "name": "India",
+        "lang": "ve"
+      },
+      {
+        "name": "India",
+        "lang": "vec"
+      },
+      {
+        "name": "India",
+        "lang": "vo"
+      },
+      {
+        "name": "India",
+        "lang": "war"
+      },
+      {
+        "name": "India",
+        "lang": "wo"
+      },
+      {
+        "name": "India",
+        "lang": "xal"
+      },
+      {
+        "name": "India",
+        "lang": "xh"
+      },
+      {
+        "name": "India",
+        "lang": "yo"
+      },
+      {
+        "name": "India",
+        "lang": "za"
+      },
+      {
+        "name": "India",
+        "lang": "zu"
+      },
+      {
+        "name": "India"
+      },
+      {
+        "name": "Índia",
+        "lang": "ca"
+      },
+      {
+        "name": "Índia",
+        "lang": "oc"
+      },
+      {
+        "name": "Índia",
+        "lang": "pt"
+      },
+      {
+        "name": "Índia",
+        "lang": "tet"
+      },
+      {
+        "name": "Ìndia",
+        "lang": "sc"
+      },
+      {
+        "name": "India nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "India - भारत",
+        "lang": "gl"
+      },
+      {
+        "name": "Indie",
+        "lang": "cs"
+      },
+      {
+        "name": "Indie",
+        "lang": "csb"
+      },
+      {
+        "name": "Indie",
+        "lang": "fur"
+      },
+      {
+        "name": "Indie",
+        "lang": "pl"
+      },
+      {
+        "name": "Indie",
+        "lang": "sco"
+      },
+      {
+        "name": "Indië",
+        "lang": "af"
+      },
+      {
+        "name": "Indien",
+        "lang": "da"
+      },
+      {
+        "name": "Indien",
+        "lang": "de"
+      },
+      {
+        "name": "Indien",
+        "lang": "lb"
+      },
+      {
+        "name": "Indien",
+        "lang": "nds"
+      },
+      {
+        "name": "Indien",
+        "lang": "sv"
+      },
+      {
+        "name": "Indija",
+        "lang": "bs"
+      },
+      {
+        "name": "Indija",
+        "lang": "hbs"
+      },
+      {
+        "name": "Indija",
+        "lang": "hr"
+      },
+      {
+        "name": "Indija",
+        "lang": "lt"
+      },
+      {
+        "name": "Indija",
+        "lang": "lv"
+      },
+      {
+        "name": "Indija",
+        "lang": "sl"
+      },
+      {
+        "name": "Indiska",
+        "lang": "hsb"
+      },
+      {
+        "name": "Indiya",
+        "lang": "ceb"
+      },
+      {
+        "name": "Indiya",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Indiya",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Indiya",
+        "lang": "qu"
+      },
+      {
+        "name": "Indiya",
+        "lang": "rmy"
+      },
+      {
+        "name": "Indiyān",
+        "lang": "nah"
+      },
+      {
+        "name": "Indja",
+        "lang": "mt"
+      },
+      {
+        "name": "Indland",
+        "lang": "is"
+      },
+      {
+        "name": "Indy",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Inia",
+        "lang": "mi"
+      },
+      {
+        "name": "ʻInia",
+        "lang": "haw"
+      },
+      {
+        "name": "ʻInitia",
+        "lang": "to"
+      },
+      {
+        "name": "’Inītia",
+        "lang": "ty"
+      },
+      {
+        "name": "Inndije",
+        "lang": "ksh"
+      },
+      {
+        "name": "Innia",
+        "lang": "nap"
+      },
+      {
+        "name": "Innia",
+        "lang": "scn"
+      },
+      {
+        "name": "Intia",
+        "lang": "fi"
+      },
+      {
+        "name": "Na h-Innseachan",
+        "lang": "gd"
+      },
+      {
+        "name": "Orílẹ́ède India",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Republic of India"
+      },
+      {
+        "name": "Ubuhindi",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Unión India",
+        "lang": "es"
+      },
+      {
+        "name": "xingu'e",
+        "lang": "jbo"
+      },
+      {
+        "name": "Yndia",
+        "lang": "fy"
+      },
+      {
+        "name": "Yn Injey",
+        "lang": "gv"
+      },
+      {
+        "name": "الهند",
+        "lang": "ar"
+      },
+      {
+        "name": "انڈیا",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "بھارت",
+        "lang": "ur"
+      },
+      {
+        "name": "ھیندستان",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "ہِندوستان",
+        "lang": "ks"
+      },
+      {
+        "name": "هند",
+        "lang": "fa"
+      },
+      {
+        "name": "هند",
+        "lang": "ps"
+      },
+      {
+        "name": "ھىندىستان",
+        "lang": "ug"
+      },
+      {
+        "name": "אינדיע",
+        "lang": "yi"
+      },
+      {
+        "name": "הודו",
+        "lang": "he"
+      },
+      {
+        "name": "Ινδία",
+        "lang": "el"
+      },
+      {
+        "name": "Инди",
+        "lang": "cv"
+      },
+      {
+        "name": "Инди",
+        "lang": "os"
+      },
+      {
+        "name": "Индија",
+        "lang": "mk"
+      },
+      {
+        "name": "Индија",
+        "lang": "sr"
+      },
+      {
+        "name": "Индия",
+        "lang": "bg"
+      },
+      {
+        "name": "Индия",
+        "isPreferredName": true,
+        "lang": "kk"
+      },
+      {
+        "name": "Индия",
+        "lang": "ro"
+      },
+      {
+        "name": "Индия",
+        "lang": "ru"
+      },
+      {
+        "name": "Индия",
+        "lang": "udm"
+      },
+      {
+        "name": "Індія",
+        "lang": "uk"
+      },
+      {
+        "name": "Індыя",
+        "lang": "be"
+      },
+      {
+        "name": "Үндістан",
+        "lang": "kk"
+      },
+      {
+        "name": "Ҳиндистон",
+        "lang": "uz"
+      },
+      {
+        "name": "Һиндостан",
+        "lang": "ba"
+      },
+      {
+        "name": "Ҳиндустон",
+        "lang": "tg"
+      },
+      {
+        "name": "Энэтхэг",
+        "lang": "mn"
+      },
+      {
+        "name": "Энэтхэг",
+        "lang": "ro"
+      },
+      {
+        "name": "Հնդկաստան",
+        "lang": "hy"
+      },
+      {
+        "name": "ინდოეთი",
+        "lang": "ka"
+      },
+      {
+        "name": "भारत",
+        "lang": "bh"
+      },
+      {
+        "name": "भारत",
+        "lang": "hi"
+      },
+      {
+        "name": "भारत",
+        "lang": "mr"
+      },
+      {
+        "name": "भारत",
+        "lang": "ne"
+      },
+      {
+        "name": "भारत",
+        "lang": "pi"
+      },
+      {
+        "name": "भारत",
+        "lang": "sa"
+      },
+      {
+        "name": "भारतम्",
+        "lang": "sa"
+      },
+      {
+        "name": "ભારત",
+        "lang": "gu"
+      },
+      {
+        "name": "భారత దేశము",
+        "lang": "te"
+      },
+      {
+        "name": "భారత దేశం",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ਭਾਰਤ",
+        "lang": "pa"
+      },
+      {
+        "name": "ಭಾರತ",
+        "lang": "kn"
+      },
+      {
+        "name": "இந்தியா",
+        "lang": "ta"
+      },
+      {
+        "name": "ഇന്ത്യ",
+        "lang": "ml"
+      },
+      {
+        "name": "ভারত",
+        "lang": "as"
+      },
+      {
+        "name": "ভারত",
+        "lang": "bn"
+      },
+      {
+        "name": "ভারত",
+        "lang": "bpy"
+      },
+      {
+        "name": "ভাৰত",
+        "lang": "as"
+      },
+      {
+        "name": "အိန္ဒိယ",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "ඉන්දියාව",
+        "lang": "si"
+      },
+      {
+        "name": "印度",
+        "lang": "wuu"
+      },
+      {
+        "name": "印度",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "India",
+    "adminCode1": "00",
+    "lng": "79",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 5.5,
+      "gmtOffset": 5.5,
+      "timeZoneId": "Asia/Kolkata"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 6.747139,
+      "east": 97.403305,
+      "north": 35.504223,
+      "west": 68.162834
+    },
+    "name": "India",
+    "fcode": "PCLI",
+    "geonameId": 1269750,
+    "asciiName": "Republic of India",
+    "lat": "22",
+    "population": 1173108018,
+    "adminName1": "",
+    "countryId": "1269750",
+    "fclName": "country, state, region,...",
+    "countryCode": "IN",
+    "srtm3": 686,
+    "wikipediaURL": "en.wikipedia.org/wiki/India",
+    "toponymName": "Republic of India",
+    "fcl": "A",
+    "continentCode": "AS"
+  },
+  "Denmark": 7839499,
+  "7839499": {
+    "adminCode2": "52730",
+    "alternateNames": [
+
+    ],
+    "countryName": "Australia",
+    "adminCode1": "08",
+    "lng": "117.37518",
+    "adminName2": "Denmark",
+    "fcodeName": "second-order administrative division",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 8,
+      "gmtOffset": 8,
+      "timeZoneId": "Australia/Perth"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -35.0678427475,
+      "east": 117.488366592,
+      "north": -34.753289412,
+      "west": 116.724809152
+    },
+    "name": "Denmark",
+    "fcode": "ADM2",
+    "geonameId": 7839499,
+    "asciiName": "Denmark",
+    "lat": "-34.93473",
+    "population": 5748,
+    "adminName1": "Western Australia",
+    "adminId1": "2058645",
+    "countryId": "2077456",
+    "fclName": "country, state, region,...",
+    "countryCode": "AU",
+    "srtm3": 33,
+    "adminId2": "7839499",
+    "toponymName": "Denmark",
+    "fcl": "A",
+    "continentCode": "OC"
+  },
+  "Japan": 1861060,
+  "1861060": {
+    "alternateNames": [
+      {
+        "name": "ܝܦܢ",
+        "lang": "arc"
+      },
+      {
+        "name": "ꏝꀪ",
+        "isPreferredName": true,
+        "lang": "ii"
+      },
+      {
+        "name": "일본",
+        "lang": "ko"
+      },
+      {
+        "name": "ጃፓን",
+        "lang": "am"
+      },
+      {
+        "name": "ጃፓን",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ᨍᨛᨄ",
+        "lang": "bug"
+      },
+      {
+        "name": "ޖަޕާނު",
+        "lang": "dv"
+      },
+      {
+        "name": "ᏣᏆᏂᏱ",
+        "lang": "chr"
+      },
+      {
+        "name": "ᓃᑉᐊᓐ",
+        "lang": "iu"
+      },
+      {
+        "name": "ଜାପାନ",
+        "lang": "or"
+      },
+      {
+        "name": "ཇ་པཱན",
+        "lang": "dz"
+      },
+      {
+        "name": "ជប៉ុន",
+        "lang": "km"
+      },
+      {
+        "name": "ଜାପାନ୍",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "ญี่ปุ่น",
+        "lang": "th"
+      },
+      {
+        "name": "ຍີ່ປຸ່ນ",
+        "lang": "lo"
+      },
+      {
+        "name": "ཇཱ་པཱན།",
+        "lang": "dz"
+      },
+      {
+        "name": "རི་པིན་",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "རི་པིན།",
+        "lang": "bo"
+      },
+      {
+        "name": "ປະເທດຍີ່ປຸ່ນ",
+        "lang": "lo"
+      },
+      {
+        "name": "ประเทศญี่ปุ่น",
+        "lang": "th"
+      },
+      {
+        "name": "An tSeapáin",
+        "lang": "ga"
+      },
+      {
+        "name": "An t-Seapan",
+        "lang": "gd"
+      },
+      {
+        "name": "Binaʼadaałtzózí Dinéʼiʼ Bikéyah",
+        "lang": "nv"
+      },
+      {
+        "name": "Chapan",
+        "lang": "ch"
+      },
+      {
+        "name": "Chapón",
+        "lang": "an"
+      },
+      {
+        "name": "Djapan",
+        "lang": "na"
+      },
+      {
+        "name": "Dzapan nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Ġappun",
+        "lang": "mt"
+      },
+      {
+        "name": "Giapon",
+        "lang": "pms"
+      },
+      {
+        "name": "Giapòn",
+        "lang": "vec"
+      },
+      {
+        "name": "Giappon",
+        "lang": "lij"
+      },
+      {
+        "name": "Giappone",
+        "lang": "it"
+      },
+      {
+        "name": "Giappone"
+      },
+      {
+        "name": "Giappuni",
+        "lang": "scn"
+      },
+      {
+        "name": "Giapun",
+        "lang": "lmo"
+      },
+      {
+        "name": "Giapun",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Gyapan",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Hapõ",
+        "lang": "gn"
+      },
+      {
+        "name": "Hapon",
+        "lang": "bcl"
+      },
+      {
+        "name": "Hapon",
+        "lang": "ceb"
+      },
+      {
+        "name": "Hapon",
+        "lang": "pam"
+      },
+      {
+        "name": "Hapon",
+        "lang": "pap"
+      },
+      {
+        "name": "Hapon",
+        "lang": "tl"
+      },
+      {
+        "name": "Hapon",
+        "lang": "war"
+      },
+      {
+        "name": "Hapón",
+        "lang": "ilo"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Japan",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%AF%D0%BF%D0%BE%D0%BD%D0%B8%D1%8F",
+        "lang": "link"
+      },
+      {
+        "name": "Iapan",
+        "lang": "ang"
+      },
+      {
+        "name": "Iāpana",
+        "lang": "haw"
+      },
+      {
+        "name": "Iapani",
+        "lang": "sm"
+      },
+      {
+        "name": "Iaponia",
+        "lang": "la"
+      },
+      {
+        "name": "i-Japan",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "IJapani",
+        "lang": "zu"
+      },
+      {
+        "name": "IJaphani",
+        "lang": "ss"
+      },
+      {
+        "name": "Jaapan",
+        "lang": "et"
+      },
+      {
+        "name": "Jaappaan",
+        "lang": "om"
+      },
+      {
+        "name": "Jabaan",
+        "lang": "so"
+      },
+      {
+        "name": "Jabbaan",
+        "lang": "so"
+      },
+      {
+        "name": "Jáhpan",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Japan",
+        "lang": "aa"
+      },
+      {
+        "name": "Japan",
+        "lang": "af"
+      },
+      {
+        "name": "Japan",
+        "lang": "br"
+      },
+      {
+        "name": "Japan",
+        "lang": "bs"
+      },
+      {
+        "name": "Japan",
+        "lang": "cho"
+      },
+      {
+        "name": "Japan",
+        "lang": "chy"
+      },
+      {
+        "name": "Japan",
+        "lang": "cy"
+      },
+      {
+        "name": "Japan",
+        "lang": "da"
+      },
+      {
+        "name": "Japan",
+        "lang": "de"
+      },
+      {
+        "name": "Japan",
+        "lang": "en"
+      },
+      {
+        "name": "Japan",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "name": "Japan",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Japan",
+        "lang": "hr"
+      },
+      {
+        "name": "Japan",
+        "lang": "is"
+      },
+      {
+        "name": "Japan",
+        "lang": "kj"
+      },
+      {
+        "name": "Japan",
+        "isPreferredName": true,
+        "lang": "kw"
+      },
+      {
+        "name": "Japan",
+        "lang": "lb"
+      },
+      {
+        "name": "Japan",
+        "lang": "lbe"
+      },
+      {
+        "name": "Japan",
+        "lang": "li"
+      },
+      {
+        "name": "Japan",
+        "lang": "mh"
+      },
+      {
+        "name": "Japan",
+        "lang": "mus"
+      },
+      {
+        "name": "Japan",
+        "lang": "nb"
+      },
+      {
+        "name": "Japan",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Japan",
+        "lang": "nds"
+      },
+      {
+        "name": "Japan",
+        "lang": "ng"
+      },
+      {
+        "name": "Japan",
+        "lang": "nl"
+      },
+      {
+        "name": "Japan",
+        "lang": "nn"
+      },
+      {
+        "name": "Japan",
+        "lang": "no"
+      },
+      {
+        "name": "Japan",
+        "lang": "om"
+      },
+      {
+        "name": "Japan",
+        "lang": "sco"
+      },
+      {
+        "name": "Japan",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Japan",
+        "lang": "sv"
+      },
+      {
+        "name": "Japan",
+        "lang": "ti"
+      },
+      {
+        "name": "Japan",
+        "lang": "ts"
+      },
+      {
+        "name": "Japan",
+        "lang": "ve"
+      },
+      {
+        "name": "Japán",
+        "lang": "hu"
+      },
+      {
+        "name": "Japana",
+        "lang": "mg"
+      },
+      {
+        "name": "Japána",
+        "lang": "se"
+      },
+      {
+        "name": "Japāna",
+        "lang": "lv"
+      },
+      {
+        "name": "Japane",
+        "lang": "nso"
+      },
+      {
+        "name": "Japang",
+        "lang": "bjn"
+      },
+      {
+        "name": "Japang",
+        "lang": "min"
+      },
+      {
+        "name": "Japani",
+        "lang": "fi"
+      },
+      {
+        "name": "Japani",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Japani",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Japani",
+        "lang": "sw"
+      },
+      {
+        "name": "Japanio",
+        "lang": "eo"
+      },
+      {
+        "name": "Japanska",
+        "lang": "hsb"
+      },
+      {
+        "name": "Japańska",
+        "lang": "dsb"
+      },
+      {
+        "name": "Japanujo",
+        "lang": "eo"
+      },
+      {
+        "name": "Japão",
+        "lang": "pt"
+      },
+      {
+        "name": "Japó",
+        "lang": "ca"
+      },
+      {
+        "name": "Japon",
+        "lang": "br"
+      },
+      {
+        "name": "Japon",
+        "lang": "fr"
+      },
+      {
+        "name": "Japon",
+        "lang": "ht"
+      },
+      {
+        "name": "Japon",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Japon",
+        "lang": "ku"
+      },
+      {
+        "name": "Japon",
+        "lang": "nrm"
+      },
+      {
+        "name": "Japon",
+        "lang": "oc"
+      },
+      {
+        "name": "Japon"
+      },
+      {
+        "name": "J·apon",
+        "lang": "frp"
+      },
+      {
+        "isShortName": true,
+        "name": "Japón",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Japón",
+        "lang": "ext"
+      },
+      {
+        "name": "Japoneja",
+        "lang": "ltg"
+      },
+      {
+        "name": "Japoni",
+        "lang": "sq"
+      },
+      {
+        "name": "Japonia",
+        "lang": "eu"
+      },
+      {
+        "name": "Japonia",
+        "lang": "io"
+      },
+      {
+        "name": "Japonia",
+        "lang": "pl"
+      },
+      {
+        "name": "Japonia",
+        "lang": "ro"
+      },
+      {
+        "name": "Japonia",
+        "lang": "sq"
+      },
+      {
+        "name": "Japonii",
+        "lang": "vep"
+      },
+      {
+        "name": "Japonija",
+        "lang": "lt"
+      },
+      {
+        "name": "Japonska",
+        "lang": "sl"
+      },
+      {
+        "name": "Japonsko",
+        "lang": "cs"
+      },
+      {
+        "name": "Japonsko",
+        "lang": "sk"
+      },
+      {
+        "name": "Japòńskô",
+        "lang": "csb"
+      },
+      {
+        "name": "Japonya",
+        "lang": "diq"
+      },
+      {
+        "name": "Japonya",
+        "lang": "ku"
+      },
+      {
+        "name": "Japonya",
+        "lang": "tr"
+      },
+      {
+        "name": "Japu",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Japun",
+        "lang": "kab"
+      },
+      {
+        "name": "Japůńijo",
+        "lang": "szl"
+      },
+      {
+        "name": "Japuonėjė",
+        "lang": "sgs"
+      },
+      {
+        "name": "Jepang",
+        "lang": "id"
+      },
+      {
+        "name": "Jepang",
+        "lang": "jv"
+      },
+      {
+        "name": "Jepang",
+        "lang": "su"
+      },
+      {
+        "name": "Jepun",
+        "lang": "ms"
+      },
+      {
+        "name": "Jeupun",
+        "lang": "ace"
+      },
+      {
+        "name": "Ji̍t-pún",
+        "lang": "nan"
+      },
+      {
+        "name": "Nditbonj",
+        "lang": "za"
+      },
+      {
+        "name": "Ngi̍t-pún",
+        "lang": "hak"
+      },
+      {
+        "name": "Nhật Bản",
+        "lang": "vi"
+      },
+      {
+        "name": "Nihon",
+        "lang": "kw"
+      },
+      {
+        "name": "Nihon"
+      },
+      {
+        "name": "Nihun",
+        "lang": "ay"
+      },
+      {
+        "name": "Nihun",
+        "lang": "qu"
+      },
+      {
+        "name": "Nĭk-buōng",
+        "lang": "cdo"
+      },
+      {
+        "name": "Nipono",
+        "lang": "mi"
+      },
+      {
+        "isColloquial": true,
+        "name": "Nippon"
+      },
+      {
+        "name": "Njabani",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Orílẹ́ède Japani",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "pongue",
+        "lang": "jbo"
+      },
+      {
+        "name": "Sapoŋ",
+        "lang": "wo"
+      },
+      {
+        "name": "Sapoo",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Siapan",
+        "lang": "cy"
+      },
+      {
+        "name": "Siapan",
+        "lang": "tpi"
+      },
+      {
+        "name": "Siapani",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Tāpōnē",
+        "lang": "ty"
+      },
+      {
+        "name": "Ubuyapani",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Ubuyapani",
+        "lang": "rw"
+      },
+      {
+        "name": "Ujapani",
+        "lang": "sw"
+      },
+      {
+        "name": "Xapon",
+        "lang": "nah"
+      },
+      {
+        "name": "Xapón",
+        "lang": "ast"
+      },
+      {
+        "name": "Xapón",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Xapón - 日本",
+        "lang": "gl"
+      },
+      {
+        "name": "Yapan",
+        "lang": "tw"
+      },
+      {
+        "name": "Yapän",
+        "lang": "vo"
+      },
+      {
+        "name": "Yaponiya",
+        "lang": "az"
+      },
+      {
+        "name": "Yaponiya",
+        "lang": "uz"
+      },
+      {
+        "name": "Yaponiya"
+      },
+      {
+        "name": "Ýaponiýa",
+        "lang": "tk"
+      },
+      {
+        "name": "Yn Çhapaan",
+        "lang": "gv"
+      },
+      {
+        "name": "Zapɔ",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Zapɔ́",
+        "lang": "ln"
+      },
+      {
+        "name": "Zapɔn",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Zapöon",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "اليابان",
+        "lang": "ar"
+      },
+      {
+        "name": "اليابان",
+        "lang": "arz"
+      },
+      {
+        "name": "جاپان",
+        "lang": "pnb"
+      },
+      {
+        "name": "جاپان",
+        "lang": "ps"
+      },
+      {
+        "name": "جاپان",
+        "lang": "sd"
+      },
+      {
+        "name": "جاپان",
+        "lang": "ur"
+      },
+      {
+        "name": "جاپون",
+        "lang": "mzn"
+      },
+      {
+        "name": "ژاپن",
+        "lang": "fa"
+      },
+      {
+        "name": "ژاپۆن",
+        "lang": "ckb"
+      },
+      {
+        "name": "ژاپۆن",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "نیہون",
+        "lang": "ur"
+      },
+      {
+        "name": "ياپونىيە",
+        "lang": "ug"
+      },
+      {
+        "name": "יאפאן",
+        "lang": "yi"
+      },
+      {
+        "name": "יאַפּאַן",
+        "lang": "yi"
+      },
+      {
+        "name": "יפן",
+        "lang": "he"
+      },
+      {
+        "name": "Ιαπωνία",
+        "lang": "el"
+      },
+      {
+        "name": "Дьоппуон",
+        "lang": "sah"
+      },
+      {
+        "name": "Жапония",
+        "isPreferredName": true,
+        "lang": "kk"
+      },
+      {
+        "name": "Жапония",
+        "lang": "ky"
+      },
+      {
+        "name": "Жапония",
+        "lang": "ro"
+      },
+      {
+        "name": "Жопун",
+        "lang": "tg"
+      },
+      {
+        "name": "Иапониа",
+        "lang": "ab"
+      },
+      {
+        "name": "Јапан",
+        "lang": "sr"
+      },
+      {
+        "name": "Јапонија",
+        "lang": "mk"
+      },
+      {
+        "name": "Ниxуудин Нутг",
+        "lang": "xal"
+      },
+      {
+        "name": "Ниппон",
+        "lang": "koi"
+      },
+      {
+        "name": "Ꙗпѡнїꙗ",
+        "lang": "cu"
+      },
+      {
+        "name": "Япон",
+        "lang": "kbd"
+      },
+      {
+        "name": "Япон",
+        "lang": "mn"
+      },
+      {
+        "name": "Япон",
+        "lang": "os"
+      },
+      {
+        "name": "Япони",
+        "lang": "ce"
+      },
+      {
+        "name": "Япони",
+        "lang": "cv"
+      },
+      {
+        "name": "Япони",
+        "lang": "mrj"
+      },
+      {
+        "name": "Японий",
+        "lang": "mhr"
+      },
+      {
+        "name": "Япония",
+        "lang": "ba"
+      },
+      {
+        "name": "Япония",
+        "lang": "bg"
+      },
+      {
+        "name": "Япония",
+        "lang": "krc"
+      },
+      {
+        "name": "Япония",
+        "lang": "kv"
+      },
+      {
+        "name": "Япония",
+        "lang": "lez"
+      },
+      {
+        "name": "Япония",
+        "lang": "ru"
+      },
+      {
+        "name": "Япония",
+        "lang": "tt"
+      },
+      {
+        "name": "Япония",
+        "lang": "udm"
+      },
+      {
+        "name": "Япония",
+        "lang": "uz"
+      },
+      {
+        "name": "Японія",
+        "lang": "be"
+      },
+      {
+        "name": "Японія",
+        "lang": "rue"
+      },
+      {
+        "name": "Японія",
+        "lang": "uk"
+      },
+      {
+        "name": "Япон Улас",
+        "lang": "bxr"
+      },
+      {
+        "name": "Япунмастор",
+        "lang": "mdf"
+      },
+      {
+        "name": "Ճապոնիա",
+        "lang": "hy"
+      },
+      {
+        "name": "იაპონია",
+        "lang": "ka"
+      },
+      {
+        "name": "იაპონია",
+        "lang": "xmf"
+      },
+      {
+        "name": "जपान",
+        "lang": "mr"
+      },
+      {
+        "name": "जपान्",
+        "lang": "sa"
+      },
+      {
+        "name": "जापान",
+        "lang": "hi"
+      },
+      {
+        "name": "जापान",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "जापान",
+        "lang": "new"
+      },
+      {
+        "name": "જાપાન",
+        "lang": "gu"
+      },
+      {
+        "name": "జపాన్",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ਜਪਾਨ",
+        "lang": "pa"
+      },
+      {
+        "name": "ಜಪಾನ್",
+        "lang": "kn"
+      },
+      {
+        "name": "ஜப்பான்",
+        "lang": "ta"
+      },
+      {
+        "name": "ജപ്പാൻ",
+        "lang": "ml"
+      },
+      {
+        "name": "জাপান",
+        "isPreferredName": true,
+        "lang": "as"
+      },
+      {
+        "name": "জাপান",
+        "lang": "bn"
+      },
+      {
+        "name": "জাপান",
+        "lang": "bpy"
+      },
+      {
+        "name": "ဂျပန်",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "ဂျပန်နိုင်ငံ",
+        "lang": "my"
+      },
+      {
+        "name": "ජපානය",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "日本",
+        "lang": "gan"
+      },
+      {
+        "name": "日本",
+        "lang": "ja"
+      },
+      {
+        "name": "日本",
+        "lang": "lzh"
+      },
+      {
+        "name": "日本",
+        "lang": "wuu"
+      },
+      {
+        "name": "日本",
+        "lang": "yue"
+      },
+      {
+        "name": "日本",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Japan",
+    "adminCode1": "00",
+    "lng": "139.75309",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 9,
+      "gmtOffset": 9,
+      "timeZoneId": "Asia/Tokyo"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 24.036472,
+      "east": 153.985229,
+      "north": 45.52314,
+      "west": 122.93853
+    },
+    "name": "Japan",
+    "fcode": "PCLI",
+    "geonameId": 1861060,
+    "asciiName": "Japan",
+    "lat": "35.68536",
+    "population": 127288000,
+    "adminName1": "",
+    "countryId": "1861060",
+    "fclName": "country, state, region,...",
+    "countryCode": "JP",
+    "srtm3": 19,
+    "wikipediaURL": "en.wikipedia.org/wiki/Japan",
+    "toponymName": "Japan",
+    "fcl": "A",
+    "continentCode": "AS"
+  },
+  "Switzerland": 2658434,
+  "2658434": {
+    "alternateNames": [
+      {
+        "name": "スイス",
+        "lang": "ja"
+      },
+      {
+        "name": "스위스",
+        "lang": "ko"
+      },
+      {
+        "name": "ស្វីស",
+        "lang": "km"
+      },
+      {
+        "name": "ስዊዘርላንድ",
+        "lang": "am"
+      },
+      {
+        "name": "ስዊዘርላንድ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ཧྲུད་ཧྲི།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ສະວິດເຊີແລນ",
+        "lang": "lo"
+      },
+      {
+        "name": "སུའིཊ་ཛར་ལེན",
+        "lang": "dz"
+      },
+      {
+        "name": "ସ୍ବିଜରଲ୍ୟାଣ୍ଡ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "สวิตเซอร์แลนด์",
+        "lang": "th"
+      },
+      {
+        "name": "An Eilvéis",
+        "lang": "ga"
+      },
+      {
+        "name": "Confederatio Helvetica"
+      },
+      {
+        "name": "Confédération Suisse",
+        "lang": "fr"
+      },
+      {
+        "name": "Confederazione Svizzera",
+        "lang": "it"
+      },
+      {
+        "name": "Elveția",
+        "isPreferredName": true,
+        "lang": "ro"
+      },
+      {
+        "name": "Helvetia"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Switzerland",
+        "lang": "link"
+      },
+      {
+        "name": "isveçriya",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "İsviçre",
+        "lang": "tr"
+      },
+      {
+        "name": "i-Switzerland",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Ĩveits",
+        "isPreferredName": true,
+        "lang": "et"
+      },
+      {
+        "name": "Orílẹ́ède switiṣilandi",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Schweiz",
+        "lang": "da"
+      },
+      {
+        "isShortName": true,
+        "name": "Schweiz",
+        "isPreferredName": true,
+        "lang": "de"
+      },
+      {
+        "name": "Schweiz",
+        "lang": "sv"
+      },
+      {
+        "name": "Schweiz"
+      },
+      {
+        "name": "Schweizerische Eidgenossenschaft",
+        "lang": "de"
+      },
+      {
+        "name": "Schweizerische Eidgenossenschaft"
+      },
+      {
+        "name": "Schweizi",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Schwiz"
+      },
+      {
+        "name": "Soisa",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Soïssa",
+        "isPreferredName": true,
+        "lang": "oc"
+      },
+      {
+        "name": "Suíça",
+        "lang": "pt"
+      },
+      {
+        "name": "Suis",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Sûîsi",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Suisilani",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Suissa",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Suïssa",
+        "lang": "ca"
+      },
+      {
+        "isShortName": true,
+        "name": "Suisse",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "name": "Suisse"
+      },
+      {
+        "name": "Suitza",
+        "lang": "eu"
+      },
+      {
+        "isShortName": true,
+        "name": "Suiza",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Suíza",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Suwiis",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Suwisi",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Suwizalan",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Svájc",
+        "lang": "hu"
+      },
+      {
+        "name": "Švajcarska",
+        "isPreferredName": true,
+        "lang": "bs"
+      },
+      {
+        "name": "Švajčiarsko",
+        "lang": "sk"
+      },
+      {
+        "name": "Šveica",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Šveicarija",
+        "lang": "lt"
+      },
+      {
+        "name": "Šveice",
+        "lang": "lv"
+      },
+      {
+        "name": "Sveis",
+        "lang": "fo"
+      },
+      {
+        "name": "Sveits",
+        "lang": "nb"
+      },
+      {
+        "name": "Sveits",
+        "lang": "nn"
+      },
+      {
+        "name": "Šveits",
+        "lang": "et"
+      },
+      {
+        "name": "Sveitsi",
+        "lang": "fi"
+      },
+      {
+        "name": "Švica",
+        "lang": "sl"
+      },
+      {
+        "name": "Švicarska",
+        "lang": "hr"
+      },
+      {
+        "name": "Sviss",
+        "lang": "is"
+      },
+      {
+        "name": "Svisujo",
+        "lang": "eo"
+      },
+      {
+        "name": "Svizra",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "isShortName": true,
+        "name": "Svizzera",
+        "lang": "it"
+      },
+      {
+        "name": "Svizzera",
+        "lang": "mt"
+      },
+      {
+        "name": "Svizzera"
+      },
+      {
+        "name": "Švýcarsko",
+        "lang": "cs"
+      },
+      {
+        "name": "Swetzaland",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Swiiserlaand",
+        "lang": "so"
+      },
+      {
+        "name": "Swise",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Swisɛ",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Swiss",
+        "lang": "id"
+      },
+      {
+        "name": "Swiss Confederation"
+      },
+      {
+        "name": "Switizirandi",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Switserland",
+        "lang": "af"
+      },
+      {
+        "name": "Switzerland",
+        "lang": "en"
+      },
+      {
+        "name": "Switzerland",
+        "lang": "ms"
+      },
+      {
+        "name": "Switzerland",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Switzerland",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Switzerland"
+      },
+      {
+        "name": "Switzerland nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Szwajcaria",
+        "lang": "pl"
+      },
+      {
+        "name": "Thụy Sĩ",
+        "lang": "vi"
+      },
+      {
+        "name": "Ubusuwisi",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Uswisi",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Uswisi",
+        "lang": "sw"
+      },
+      {
+        "name": "Y Swistir",
+        "lang": "cy"
+      },
+      {
+        "name": "Zvicër",
+        "lang": "sq"
+      },
+      {
+        "name": "Zwitserland",
+        "lang": "nl"
+      },
+      {
+        "name": "سویس",
+        "lang": "ps"
+      },
+      {
+        "name": "سویسرا",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "سوئٹزر لینڈ",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "سوئیس",
+        "lang": "fa"
+      },
+      {
+        "name": "سويسرا",
+        "lang": "ar"
+      },
+      {
+        "name": "שווייץ",
+        "lang": "he"
+      },
+      {
+        "name": "שוויץ",
+        "isPreferredName": true,
+        "lang": "he"
+      },
+      {
+        "name": "Ελβετία",
+        "isPreferredName": true,
+        "lang": "el"
+      },
+      {
+        "name": "Швајцарија",
+        "lang": "mk"
+      },
+      {
+        "name": "Швајцарска",
+        "lang": "sr"
+      },
+      {
+        "name": "Швейцария",
+        "lang": "bg"
+      },
+      {
+        "name": "Швейцария",
+        "isPreferredName": true,
+        "lang": "kk"
+      },
+      {
+        "name": "Швейцария",
+        "lang": "ru"
+      },
+      {
+        "name": "Швейцарія",
+        "lang": "uk"
+      },
+      {
+        "name": "Швейцарыя",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Շվեյցարիա",
+        "lang": "hy"
+      },
+      {
+        "name": "შვეიცარია",
+        "lang": "ka"
+      },
+      {
+        "name": "स्विजरल्याण्ड",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "स्विटज़रलैंड",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "स्वित्झर्लंड",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "स्विस",
+        "lang": "hi"
+      },
+      {
+        "name": "સ્વિટ્ઝર્લૅન્ડ",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "స్విట్జర్లేండ్",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಸ್ವಿಡ್ಜರ್‌ಲ್ಯಾಂಡ್",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "ஸ்விட்சர்லாந்து",
+        "lang": "ta"
+      },
+      {
+        "name": "സ്വിറ്റ്സര്‍ലാന്‍ഡ്",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "সুইজর্লণ্ড",
+        "lang": "bn"
+      },
+      {
+        "name": "সুইজারল্যান্ড",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "ဆွစ်ဇလန်",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "ස්විස්ටර්ලන්තය",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "瑞士",
+        "lang": "zh"
+      },
+      {
+        "name": "スイス連邦",
+        "isPreferredName": true,
+        "lang": "ja"
+      }
+    ],
+    "countryName": "Switzerland",
+    "adminCode1": "00",
+    "lng": "8.01427",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 2,
+      "gmtOffset": 1,
+      "timeZoneId": "Europe/Zurich"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 45.825695,
+      "east": 10.491472,
+      "north": 47.805332,
+      "west": 5.957472
+    },
+    "name": "Switzerland",
+    "fcode": "PCLI",
+    "geonameId": 2658434,
+    "asciiName": "Swiss Confederation",
+    "lat": "47.00016",
+    "population": 7581000,
+    "adminName1": "",
+    "countryId": "2658434",
+    "fclName": "country, state, region,...",
+    "countryCode": "CH",
+    "srtm3": 931,
+    "wikipediaURL": "en.wikipedia.org/wiki/Switzerland",
+    "toponymName": "Swiss Confederation",
+    "fcl": "A",
+    "continentCode": "EU"
+  },
+  "Germany": 2921044,
+  "2921044": {
+    "alternateNames": [
+      {
+        "name": "ꄓꇩ",
+        "isPreferredName": true,
+        "lang": "ii"
+      },
+      {
+        "name": "독일",
+        "lang": "ko"
+      },
+      {
+        "name": "ܓܪܡܢ",
+        "lang": "arc"
+      },
+      {
+        "name": "ドイツ",
+        "lang": "ja"
+      },
+      {
+        "name": "ጀርመን",
+        "lang": "am"
+      },
+      {
+        "name": "ጀርመን",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ଜର୍ମାନୀ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "เยอรมนี",
+        "lang": "th"
+      },
+      {
+        "name": "เยอรมัน",
+        "isPreferredName": true,
+        "lang": "th"
+      },
+      {
+        "name": "འཇར་མན་",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ເຢຍລະມັນ",
+        "lang": "lo"
+      },
+      {
+        "name": "ཇཱར་མ་ནི",
+        "lang": "dz"
+      },
+      {
+        "name": "អាល្លឺម៉ង់",
+        "lang": "km"
+      },
+      {
+        "name": "ประเทศเยอรมนี",
+        "lang": "th"
+      },
+      {
+        "name": "สหพันธ์สาธารณรัฐเยอรมนี",
+        "lang": "th"
+      },
+      {
+        "name": "A' Ghearmailt",
+        "lang": "gd"
+      },
+      {
+        "name": "Alamagn",
+        "lang": "br"
+      },
+      {
+        "name": "Alemagne",
+        "lang": "frp"
+      },
+      {
+        "name": "Alemaina",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Alemaña",
+        "lang": "an"
+      },
+      {
+        "name": "Alemaña",
+        "lang": "ast"
+      },
+      {
+        "name": "Alemaña",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Alemaña",
+        "lang": "gn"
+      },
+      {
+        "name": "Alemaña",
+        "lang": "tet"
+      },
+      {
+        "name": "Alemanha",
+        "lang": "oc"
+      },
+      {
+        "name": "Alemanha",
+        "lang": "pt"
+      },
+      {
+        "name": "Alemani",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Alémani",
+        "lang": "ln"
+      },
+      {
+        "isShortName": true,
+        "name": "Alemania",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Alemania",
+        "lang": "eu"
+      },
+      {
+        "name": "Alemania",
+        "lang": "ilo"
+      },
+      {
+        "name": "Alemania",
+        "lang": "lad"
+      },
+      {
+        "name": "Alemanu",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Alemanya",
+        "lang": "ca"
+      },
+      {
+        "name": "Alemanya",
+        "lang": "tl"
+      },
+      {
+        "name": "Alemanya",
+        "lang": "war"
+      },
+      {
+        "name": "Alimaɲi",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Alimaniya",
+        "lang": "qu"
+      },
+      {
+        "name": "Alimanya",
+        "lang": "qu"
+      },
+      {
+        "isShortName": true,
+        "name": "Allemagne",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "name": "Allemangne",
+        "lang": "nrm"
+      },
+      {
+        "name": "Almaañ",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Almaniya",
+        "lang": "az"
+      },
+      {
+        "name": "Almanya",
+        "lang": "ku"
+      },
+      {
+        "name": "Almanya",
+        "lang": "tr"
+      },
+      {
+        "name": "Almayn",
+        "lang": "kw"
+      },
+      {
+        "name": "An Ghearmáin",
+        "lang": "ga"
+      },
+      {
+        "name": "Budaaki",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Bundesrepublik Deutschland",
+        "lang": "de"
+      },
+      {
+        "name": "Däitschland",
+        "lang": "lb"
+      },
+      {
+        "name": "Deitschland",
+        "lang": "bar"
+      },
+      {
+        "name": "Deitschland",
+        "lang": "pdc"
+      },
+      {
+        "name": "Deitschlånd",
+        "lang": "bar"
+      },
+      {
+        "name": "Deutän",
+        "lang": "vo"
+      },
+      {
+        "name": "Deutschland",
+        "isPreferredName": true,
+        "lang": "de"
+      },
+      {
+        "name": "Discüssiun sura la fundazziun",
+        "lang": "lmo"
+      },
+      {
+        "name": "dotygu'e",
+        "lang": "jbo"
+      },
+      {
+        "name": "Đức",
+        "lang": "vi"
+      },
+      {
+        "name": "Duiska",
+        "lang": "se"
+      },
+      {
+        "name": "Duiskka",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Duitschland"
+      },
+      {
+        "name": "Duitsland",
+        "lang": "af"
+      },
+      {
+        "name": "Duitsland",
+        "lang": "nl"
+      },
+      {
+        "name": "Dútslân",
+        "lang": "fy"
+      },
+      {
+        "name": "Düütschland",
+        "lang": "nds"
+      },
+      {
+        "name": "Duutsjlandj",
+        "lang": "li"
+      },
+      {
+        "name": "Duutsland",
+        "lang": "vls"
+      },
+      {
+        "name": "Federal Republic of Germany",
+        "lang": "en"
+      },
+      {
+        "name": "Germania",
+        "lang": "ia"
+      },
+      {
+        "name": "Germania",
+        "lang": "io"
+      },
+      {
+        "name": "Germania",
+        "lang": "it"
+      },
+      {
+        "name": "Germania",
+        "lang": "la"
+      },
+      {
+        "name": "Germania",
+        "lang": "lmo"
+      },
+      {
+        "name": "Germania",
+        "lang": "pms"
+      },
+      {
+        "name": "Germania",
+        "lang": "rm"
+      },
+      {
+        "name": "Germania",
+        "lang": "ro"
+      },
+      {
+        "name": "Germania",
+        "lang": "vec"
+      },
+      {
+        "name": "Germània",
+        "lang": "sc"
+      },
+      {
+        "name": "Germania nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Germanio",
+        "lang": "eo"
+      },
+      {
+        "name": "Ġermanja",
+        "lang": "mt"
+      },
+      {
+        "name": "Germanujo",
+        "lang": "eo"
+      },
+      {
+        "name": "Germany",
+        "lang": "aa"
+      },
+      {
+        "isShortName": true,
+        "name": "Germany",
+        "isPreferredName": true,
+        "lang": "en"
+      },
+      {
+        "name": "Germany",
+        "lang": "ig"
+      },
+      {
+        "name": "Germany",
+        "lang": "na"
+      },
+      {
+        "name": "Germany",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Germany",
+        "lang": "om"
+      },
+      {
+        "name": "Germany",
+        "lang": "pam"
+      },
+      {
+        "name": "Germany",
+        "lang": "sco"
+      },
+      {
+        "name": "Germany",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Girimane",
+        "lang": "lg"
+      },
+      {
+        "name": "Girmania",
+        "lang": "scn"
+      },
+      {
+        "name": "Gjermani",
+        "lang": "sq"
+      },
+      {
+        "name": "Gjermania",
+        "lang": "sq"
+      },
+      {
+        "name": "Gjermanie",
+        "lang": "fur"
+      },
+      {
+        "name": "Gyaaman",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Heremani",
+        "lang": "ty"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Germany",
+        "lang": "link"
+      },
+      {
+        "name": "http://uk.wikipedia.org/wiki/%D0%9D%D1%96%D0%BC%D0%B5%D1%87%D1%87%D0%B8%D0%BD%D0%B0",
+        "lang": "link"
+      },
+      {
+        "name": "i-Germany",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "IJalimani",
+        "lang": "zu"
+      },
+      {
+        "name": "Jámánì",
+        "lang": "yo"
+      },
+      {
+        "name": "Jamus",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Jarmal",
+        "lang": "so"
+      },
+      {
+        "name": "Jarmalka",
+        "lang": "so"
+      },
+      {
+        "name": "Jerman",
+        "lang": "id"
+      },
+      {
+        "name": "Jerman",
+        "lang": "jv"
+      },
+      {
+        "name": "Jerman",
+        "lang": "ms"
+      },
+      {
+        "name": "Jėrman",
+        "lang": "su"
+      },
+      {
+        "name": "Jermaniya",
+        "lang": "rmy"
+      },
+      {
+        "name": "Miemieckô",
+        "lang": "csb"
+      },
+      {
+        "name": "Nemačka",
+        "isPreferredName": true,
+        "lang": "bs"
+      },
+      {
+        "name": "Nemačka",
+        "lang": "hbs"
+      },
+      {
+        "name": "Nemčija",
+        "lang": "sl"
+      },
+      {
+        "name": "Nemecko",
+        "lang": "sk"
+      },
+      {
+        "name": "Německo",
+        "lang": "cs"
+      },
+      {
+        "name": "Németország",
+        "lang": "hu"
+      },
+      {
+        "name": "Němska",
+        "lang": "hsb"
+      },
+      {
+        "name": "Niemcy",
+        "lang": "pl"
+      },
+      {
+        "name": "Njemačka",
+        "lang": "bs"
+      },
+      {
+        "name": "Njemačka",
+        "lang": "hr"
+      },
+      {
+        "name": "Njeremani",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Olmoniya",
+        "lang": "uz"
+      },
+      {
+        "name": "Orílẹ́ède Gemani",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Saksa",
+        "lang": "fi"
+      },
+      {
+        "name": "Saksamaa",
+        "lang": "et"
+      },
+      {
+        "name": "Siaman",
+        "lang": "tpi"
+      },
+      {
+        "name": "Siamane",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Teutōtitlan",
+        "lang": "nah"
+      },
+      {
+        "name": "Tiamana",
+        "lang": "mi"
+      },
+      {
+        "name": "Tôitšhi",
+        "lang": "st"
+      },
+      {
+        "name": "Tyskland",
+        "lang": "da"
+      },
+      {
+        "name": "Tyskland",
+        "lang": "nb"
+      },
+      {
+        "name": "Tyskland",
+        "lang": "nn"
+      },
+      {
+        "name": "Tyskland",
+        "lang": "no"
+      },
+      {
+        "name": "Tyskland",
+        "lang": "sv"
+      },
+      {
+        "name": "Týskland",
+        "lang": "fo"
+      },
+      {
+        "name": "Tysklandi",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Ubudage",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Udachi",
+        "lang": "sw"
+      },
+      {
+        "name": "Ujerumani",
+        "lang": "sw"
+      },
+      {
+        "name": "Vācija",
+        "lang": "lv"
+      },
+      {
+        "name": "Vokietija",
+        "lang": "lt"
+      },
+      {
+        "name": "West Germany",
+        "isHistoric": true,
+        "lang": "en"
+      },
+      {
+        "name": "Yn Ghermaan",
+        "lang": "gv"
+      },
+      {
+        "name": "Yr Almaen",
+        "lang": "cy"
+      },
+      {
+        "name": "Zâmani",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Þēodiscland",
+        "lang": "ang"
+      },
+      {
+        "name": "Þýskaland",
+        "lang": "is"
+      },
+      {
+        "name": "آلمان",
+        "lang": "fa"
+      },
+      {
+        "name": "المان",
+        "lang": "ps"
+      },
+      {
+        "name": "ألمانيا",
+        "lang": "ar"
+      },
+      {
+        "name": "المانيا",
+        "lang": "ar"
+      },
+      {
+        "name": "جرمنی",
+        "lang": "ur"
+      },
+      {
+        "name": "جرمني/آلمان",
+        "lang": "ps"
+      },
+      {
+        "name": "گېرمانىيە",
+        "lang": "ug"
+      },
+      {
+        "name": "ئەڵمانیا",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "גרמניה",
+        "lang": "he"
+      },
+      {
+        "name": "דייטשלאנד",
+        "lang": "yi"
+      },
+      {
+        "name": "Γερμανία",
+        "lang": "el"
+      },
+      {
+        "name": "Алмания",
+        "lang": "kk"
+      },
+      {
+        "name": "Герман",
+        "isPreferredName": true,
+        "lang": "mn"
+      },
+      {
+        "name": "Герман",
+        "lang": "os"
+      },
+      {
+        "name": "Германи",
+        "lang": "cv"
+      },
+      {
+        "name": "Германија",
+        "lang": "mk"
+      },
+      {
+        "name": "Германия",
+        "lang": "bg"
+      },
+      {
+        "name": "Германия",
+        "lang": "ru"
+      },
+      {
+        "name": "Германия",
+        "lang": "udm"
+      },
+      {
+        "name": "Германія",
+        "lang": "be"
+      },
+      {
+        "name": "Ӂермания",
+        "lang": "ro"
+      },
+      {
+        "name": "Немачка",
+        "lang": "sr"
+      },
+      {
+        "name": "Німеччина",
+        "lang": "uk"
+      },
+      {
+        "name": "Нямеччына",
+        "lang": "be"
+      },
+      {
+        "name": "Олмон",
+        "lang": "tg"
+      },
+      {
+        "name": "Олмония",
+        "lang": "uz"
+      },
+      {
+        "name": "Գերմանիա",
+        "lang": "hy"
+      },
+      {
+        "name": "გერმანია",
+        "lang": "ka"
+      },
+      {
+        "name": "जमिन",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "जर्मनी",
+        "lang": "hi"
+      },
+      {
+        "name": "जर्मनी",
+        "lang": "mr"
+      },
+      {
+        "name": "जर्मनी",
+        "lang": "ne"
+      },
+      {
+        "name": "જર્મની",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "ఙర్మని",
+        "lang": "te"
+      },
+      {
+        "name": "ಜರ್ಮನಿ",
+        "lang": "kn"
+      },
+      {
+        "name": "ஜெர்மன்",
+        "lang": "ta"
+      },
+      {
+        "name": "ஜெர்மனி",
+        "lang": "ta"
+      },
+      {
+        "name": "ജര്‍മനി",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "ജര്‍മ്മനി",
+        "lang": "ml"
+      },
+      {
+        "name": "জার্মানি",
+        "lang": "bn"
+      },
+      {
+        "name": "জাৰ্মানি",
+        "isPreferredName": true,
+        "lang": "as"
+      },
+      {
+        "name": "ဂျာမဏီ",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "ජර්මනිය",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "德国",
+        "lang": "zh"
+      },
+      {
+        "name": "ドイツ連邦共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      }
+    ],
+    "countryName": "Germany",
+    "adminCode1": "00",
+    "lng": "10.5",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 47.275776,
+      "east": 15.039889,
+      "north": 55.055637,
+      "west": 5.865639
+    },
+    "name": "Germany",
+    "fcode": "PCLI",
+    "geonameId": 2921044,
+    "asciiName": "Federal Republic of Germany",
+    "lat": "51.5",
+    "population": 81802257,
+    "adminName1": "",
+    "countryId": "2921044",
+    "fclName": "country, state, region,...",
+    "countryCode": "DE",
+    "srtm3": 303,
+    "wikipediaURL": "en.wikipedia.org/wiki/Germany",
+    "toponymName": "Federal Republic of Germany",
+    "fcl": "A",
+    "continentCode": "EU"
+  },
+  "China": 1814991,
+  "1814991": {
+    "alternateNames": [
+      {
+        "name": "ᏥᎾ",
+        "lang": "chr"
+      },
+      {
+        "name": "ꍏꇩ",
+        "isPreferredName": true,
+        "lang": "ii"
+      },
+      {
+        "name": "중국",
+        "lang": "ko"
+      },
+      {
+        "name": "จีน",
+        "lang": "th"
+      },
+      {
+        "name": "ຈີນ",
+        "lang": "lo"
+      },
+      {
+        "name": "ቻይና",
+        "lang": "am"
+      },
+      {
+        "name": "ቻይና",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ចិន",
+        "lang": "km"
+      },
+      {
+        "name": "ଚିନ୍",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "རྒྱ་ནག",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "རྒྱ་མི",
+        "lang": "dz"
+      },
+      {
+        "name": "중화인민공화국",
+        "lang": "ko"
+      },
+      {
+        "name": "ประเทศจีน",
+        "lang": "th"
+      },
+      {
+        "name": "Alþýðulýðveldið Kína",
+        "lang": "is"
+      },
+      {
+        "name": "An tSín",
+        "lang": "ga"
+      },
+      {
+        "name": "Caina",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Caina, Sin",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Cayina",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Chaina",
+        "isPreferredName": true,
+        "lang": "ig"
+      },
+      {
+        "name": "China",
+        "lang": "aa"
+      },
+      {
+        "isShortName": true,
+        "name": "China",
+        "lang": "de"
+      },
+      {
+        "isShortName": true,
+        "name": "China",
+        "isPreferredName": true,
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "China",
+        "lang": "es"
+      },
+      {
+        "name": "China",
+        "lang": "gl"
+      },
+      {
+        "name": "China",
+        "lang": "ia"
+      },
+      {
+        "name": "China",
+        "isPreferredName": true,
+        "lang": "kw"
+      },
+      {
+        "name": "China",
+        "isPreferredName": true,
+        "lang": "ms"
+      },
+      {
+        "name": "China",
+        "lang": "nah"
+      },
+      {
+        "name": "China",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "China",
+        "lang": "nl"
+      },
+      {
+        "name": "China",
+        "isPreferredName": true,
+        "lang": "oc"
+      },
+      {
+        "name": "China",
+        "lang": "om"
+      },
+      {
+        "isShortName": true,
+        "name": "China",
+        "lang": "pt"
+      },
+      {
+        "name": "China",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "China",
+        "lang": "ro"
+      },
+      {
+        "name": "China",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "China",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "isShortName": true,
+        "name": "Chine",
+        "lang": "fr"
+      },
+      {
+        "name": "Chińska Republika Ludowa",
+        "lang": "pl"
+      },
+      {
+        "name": "Chiny",
+        "lang": "pl"
+      },
+      {
+        "name": "Chung-hua Jen-min-kung-ho-kuo"
+      },
+      {
+        "name": "Chunwa Runallaqta Ripuwlika",
+        "lang": "qu"
+      },
+      {
+        "name": "Çin",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Çin",
+        "lang": "tr"
+      },
+      {
+        "name": "Çîn",
+        "lang": "ku"
+      },
+      {
+        "name": "Cina",
+        "lang": "id"
+      },
+      {
+        "isShortName": true,
+        "name": "Cina",
+        "lang": "it"
+      },
+      {
+        "name": "Ċina",
+        "lang": "mt"
+      },
+      {
+        "name": "Čína",
+        "lang": "cs"
+      },
+      {
+        "name": "Čína",
+        "lang": "sk"
+      },
+      {
+        "name": "Cīnan Folclicu Cynewīse",
+        "lang": "ang"
+      },
+      {
+        "name": "Ĉina Popola Respubliko",
+        "lang": "eo"
+      },
+      {
+        "name": "Çin Halk Cumhuriyeti",
+        "lang": "tr"
+      },
+      {
+        "name": "Ĉinio",
+        "lang": "eo"
+      },
+      {
+        "name": "Čínská lidová republika",
+        "lang": "cs"
+      },
+      {
+        "name": "Čínska ľudová republika",
+        "lang": "sk"
+      },
+      {
+        "name": "Ĉinujo",
+        "lang": "eo"
+      },
+      {
+        "name": "Cộng hòa Nhân dân Trung Hoa",
+        "lang": "vi"
+      },
+      {
+        "name": "Cunghvaz Yinzminz Gunghozgoz",
+        "lang": "za"
+      },
+      {
+        "name": "Folkerepublikken Kina",
+        "lang": "da"
+      },
+      {
+        "name": "Folkerepublikken Kina",
+        "lang": "nn"
+      },
+      {
+        "name": "Gweriniaeth Pobl Tsieina",
+        "lang": "cy"
+      },
+      {
+        "name": "Haina",
+        "lang": "mi"
+      },
+      {
+        "name": "Hiina",
+        "lang": "et"
+      },
+      {
+        "name": "Hiina Rahvavabariik",
+        "lang": "et"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/China",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%9A%D0%B8%D1%82%D0%B0%D0%B9",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%9A%D0%B8%D1%82%D0%B0%D0%B9_%28%D1%86%D0%B8%D0%B2%D0%B8%D0%BB%D0%B8%D0%B7%D0%B0%D1%86%D0%B8%D1%8F%29",
+        "lang": "link"
+      },
+      {
+        "name": "Hytaý Halk Respublikasy",
+        "lang": "tk"
+      },
+      {
+        "name": "i-China",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "jugygue",
+        "lang": "jbo"
+      },
+      {
+        "name": "Kiina",
+        "lang": "fi"
+      },
+      {
+        "name": "Kiinan kansantasavalta",
+        "lang": "fi"
+      },
+      {
+        "name": "Kiinná",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Kina",
+        "isPreferredName": true,
+        "lang": "bs"
+      },
+      {
+        "name": "Kina",
+        "lang": "da"
+      },
+      {
+        "name": "Kina",
+        "lang": "fo"
+      },
+      {
+        "name": "Kina",
+        "lang": "hr"
+      },
+      {
+        "name": "Kina",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "isShortName": true,
+        "name": "Kina",
+        "isPreferredName": true,
+        "lang": "nb"
+      },
+      {
+        "isShortName": true,
+        "name": "Kina",
+        "isPreferredName": true,
+        "lang": "nn"
+      },
+      {
+        "name": "Kina",
+        "lang": "no"
+      },
+      {
+        "name": "Kina",
+        "lang": "sv"
+      },
+      {
+        "name": "Kína",
+        "lang": "hu"
+      },
+      {
+        "name": "Kína",
+        "lang": "is"
+      },
+      {
+        "name": "Ķīna",
+        "lang": "lv"
+      },
+      {
+        "name": "Kinë",
+        "lang": "sq"
+      },
+      {
+        "name": "Kinija",
+        "lang": "lt"
+      },
+      {
+        "name": "Kitajska",
+        "lang": "sl"
+      },
+      {
+        "name": "Kyaena",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Maldang Republika ning Tsina",
+        "lang": "pam"
+      },
+      {
+        "name": "Narodna Republika Kina",
+        "lang": "bs"
+      },
+      {
+        "name": "Ol Manmeri Ripablik bilong Saina",
+        "lang": "tpi"
+      },
+      {
+        "name": "Orílẹ́ède ṣáínà",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "People's Republic of China",
+        "lang": "en"
+      },
+      {
+        "name": "People’s Republic of China",
+        "lang": "en"
+      },
+      {
+        "name": "Populala Republiko di Chinia",
+        "lang": "io"
+      },
+      {
+        "name": "Repubblica Popolare Cinese",
+        "lang": "it"
+      },
+      {
+        "name": "Republica Populară Chineză",
+        "lang": "ro"
+      },
+      {
+        "name": "Republica Populara de China",
+        "lang": "oc"
+      },
+      {
+        "name": "República Popular China",
+        "lang": "ast"
+      },
+      {
+        "name": "República Popular China",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "República Popular da China",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "República Popular da China",
+        "isPreferredName": true,
+        "lang": "pt"
+      },
+      {
+        "name": "Republica Popular de China",
+        "lang": "ia"
+      },
+      {
+        "name": "República Popular de la Xina",
+        "lang": "ca"
+      },
+      {
+        "name": "Republikang Popular ng Tsina",
+        "lang": "tl"
+      },
+      {
+        "name": "Republikang Popular sa Tsina",
+        "lang": "ceb"
+      },
+      {
+        "name": "Republik Pobl Sina",
+        "lang": "br"
+      },
+      {
+        "name": "Republik Rakyat China",
+        "lang": "ms"
+      },
+      {
+        "name": "Republik Rakyat Cina",
+        "lang": "id"
+      },
+      {
+        "name": "République populaire de Chine",
+        "lang": "fr"
+      },
+      {
+        "name": "Républyique du Peuplye dla Chinne",
+        "lang": "nrm"
+      },
+      {
+        "name": "Res Publica Popularis Sinarum",
+        "lang": "la"
+      },
+      {
+        "name": "Shiinaha",
+        "lang": "so"
+      },
+      {
+        "name": "Shîna",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Shine",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Siaina",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Siin",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Sina",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Sina",
+        "lang": "kg"
+      },
+      {
+        "name": "Sina",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Sinɛ",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Siniwajamana",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Sjina",
+        "lang": "af"
+      },
+      {
+        "name": "Trung Hoa",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Trung Quốc",
+        "lang": "vi"
+      },
+      {
+        "name": "Tsaina nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Tseina",
+        "lang": "cy"
+      },
+      {
+        "name": "Tsína",
+        "lang": "ilo"
+      },
+      {
+        "name": "Txina",
+        "lang": "eu"
+      },
+      {
+        "name": "Txinako Herri Errepublika",
+        "lang": "eu"
+      },
+      {
+        "name": "Ubushinwa",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Volksrepubliek China",
+        "lang": "nds"
+      },
+      {
+        "name": "Volksrepubliek China",
+        "lang": "nl"
+      },
+      {
+        "name": "Volksrepubliek van Sjina",
+        "lang": "af"
+      },
+      {
+        "name": "Volksrepublik China",
+        "lang": "de"
+      },
+      {
+        "name": "Volleksrepublik China",
+        "lang": "lb"
+      },
+      {
+        "isShortName": true,
+        "name": "Xina",
+        "lang": "ca"
+      },
+      {
+        "name": "Xina",
+        "lang": "nah"
+      },
+      {
+        "name": "Zhongguo"
+      },
+      {
+        "name": "Zhonghua Renmin Gongheguo"
+      },
+      {
+        "name": "الصين",
+        "lang": "ar"
+      },
+      {
+        "name": "جۇڭخۇا خەلق جۇمھۇرىيىتى",
+        "lang": "ug"
+      },
+      {
+        "name": "جمهورية الصين الشعبية",
+        "lang": "ar"
+      },
+      {
+        "name": "چین",
+        "lang": "fa"
+      },
+      {
+        "name": "چین",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "چین",
+        "lang": "ps"
+      },
+      {
+        "name": "چین",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "صين",
+        "lang": "ar"
+      },
+      {
+        "name": "הרפובליקה העממית של סין",
+        "lang": "he"
+      },
+      {
+        "name": "כינע",
+        "lang": "yi"
+      },
+      {
+        "name": "סין",
+        "lang": "he"
+      },
+      {
+        "name": "Κίνα",
+        "lang": "el"
+      },
+      {
+        "name": "Λαϊκή Δημοκρατία της Κίνας",
+        "lang": "el"
+      },
+      {
+        "name": "Бүгд Найрамдах Хятад Ард Улс",
+        "lang": "mn"
+      },
+      {
+        "name": "Кина",
+        "lang": "mk"
+      },
+      {
+        "name": "Кина",
+        "lang": "sr"
+      },
+      {
+        "name": "Китай",
+        "lang": "bg"
+      },
+      {
+        "name": "Китай",
+        "lang": "os"
+      },
+      {
+        "name": "Китай",
+        "lang": "ru"
+      },
+      {
+        "name": "Китай",
+        "lang": "uk"
+      },
+      {
+        "name": "Китайска народна република",
+        "lang": "bg"
+      },
+      {
+        "name": "Китайська Народна Республіка",
+        "lang": "uk"
+      },
+      {
+        "name": "Китай Халăх Республики",
+        "lang": "cv"
+      },
+      {
+        "name": "Кітай",
+        "lang": "be"
+      },
+      {
+        "name": "Қытай Халық Республикасы",
+        "lang": "kk"
+      },
+      {
+        "name": "Народна република Кина",
+        "lang": "sr"
+      },
+      {
+        "name": "Народна Република Кина",
+        "lang": "sr"
+      },
+      {
+        "name": "Хитой",
+        "lang": "uz"
+      },
+      {
+        "name": "Չինաստան",
+        "lang": "hy"
+      },
+      {
+        "name": "ჩინეთი",
+        "lang": "ka"
+      },
+      {
+        "name": "चीन",
+        "lang": "hi"
+      },
+      {
+        "name": "चीन",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "चीन",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "ચીન",
+        "lang": "gu"
+      },
+      {
+        "name": "చైనా",
+        "lang": "te"
+      },
+      {
+        "name": "ಚೀನ",
+        "lang": "kn"
+      },
+      {
+        "name": "ಚೀನಿ ಜನರ ಗಣರಾಜ್ಯ",
+        "lang": "kn"
+      },
+      {
+        "name": "சீன மக்கள் குடியரசு",
+        "lang": "ta"
+      },
+      {
+        "name": "சீனா",
+        "isPreferredName": true,
+        "lang": "ta"
+      },
+      {
+        "name": "ചൈന",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "চীন",
+        "isPreferredName": true,
+        "lang": "as"
+      },
+      {
+        "name": "চীন",
+        "lang": "bn"
+      },
+      {
+        "name": "တရုတ်",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "චීනය",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "中华人民共和国",
+        "lang": "wuu"
+      },
+      {
+        "name": "中华人民共和国",
+        "lang": "zh"
+      },
+      {
+        "name": "中华人民共和国"
+      },
+      {
+        "name": "中国",
+        "lang": "ja"
+      },
+      {
+        "isShortName": true,
+        "name": "中国",
+        "isPreferredName": true,
+        "lang": "zh"
+      },
+      {
+        "name": "中国"
+      },
+      {
+        "name": "中華人民共和国",
+        "lang": "ja"
+      },
+      {
+        "name": "中華人民共和國",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "China",
+    "adminCode1": "00",
+    "lng": "105",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 10.175472,
+      "east": 134.773911,
+      "north": 53.56086,
+      "west": 73.557693
+    },
+    "name": "China",
+    "fcode": "PCLI",
+    "geonameId": 1814991,
+    "asciiName": "People's Republic of China",
+    "lat": "35",
+    "population": 1330044000,
+    "adminName1": "",
+    "countryId": "1814991",
+    "fclName": "country, state, region,...",
+    "countryCode": "CN",
+    "srtm3": 1982,
+    "wikipediaURL": "en.wikipedia.org/wiki/China",
+    "toponymName": "People’s Republic of China",
+    "fcl": "A",
+    "continentCode": "AS"
+  },
+  "United States": 6252001,
+  "6252001": {
+    "alternateNames": [
+      {
+        "name": "ꂰꇩ",
+        "isPreferredName": true,
+        "lang": "ii"
+      },
+      {
+        "name": "미국",
+        "lang": "ko"
+      },
+      {
+        "name": "አሜሪካ",
+        "lang": "am"
+      },
+      {
+        "name": "አሜሪካ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ଯୁକ୍ତ ରାଷ୍ଟ୍ର ଆମେରିକା",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "ཨ་མེ་རི་ཀ་",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "สหรัฐอเมริกา",
+        "lang": "th"
+      },
+      {
+        "name": "សហរដ្ឋអាមេរិក",
+        "lang": "km"
+      },
+      {
+        "name": "ສະຫະລັດອາເມລິກາ",
+        "lang": "lo"
+      },
+      {
+        "name": "ཡུ་ནའིཊེཊ་སི་ཊེསི",
+        "lang": "dz"
+      },
+      {
+        "isShortName": true,
+        "isColloquial": true,
+        "name": "ABD",
+        "lang": "tr"
+      },
+      {
+        "name": "ÂLeaa-Ôko tî Amerika",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Ameerika Ühendriigid",
+        "lang": "et"
+      },
+      {
+        "name": "Amelika",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "America",
+        "lang": "en"
+      },
+      {
+        "name": "Amerihká Ovttastuvvan Stáhtat",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Amerika",
+        "isPreferredName": true,
+        "lang": "hr"
+      },
+      {
+        "name": "Amerika",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Amerika",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Amerika",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Amɛrika",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Amerika Birleşik Devletleri",
+        "lang": "tr"
+      },
+      {
+        "name": "Amerika Birləşmiş Ştatları",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Amerika Serikat",
+        "lang": "id"
+      },
+      {
+        "name": "Amerikas Forenede Stater",
+        "isPreferredName": true,
+        "lang": "da"
+      },
+      {
+        "name": "Amerikas Förenta Stater",
+        "lang": "sv"
+      },
+      {
+        "name": "Amerikas forente stater",
+        "lang": "no"
+      },
+      {
+        "name": "Amerikas Savienotās Valstis",
+        "isPreferredName": true,
+        "lang": "lv"
+      },
+      {
+        "name": "Amerika Syarikat",
+        "lang": "ms"
+      },
+      {
+        "name": "Ameriketako Estatu Batuak",
+        "lang": "eu"
+      },
+      {
+        "name": "Ameriki",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Ameriki",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Ameriki",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Amurka",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Bandaríkin",
+        "lang": "is"
+      },
+      {
+        "name": "Bandaríki Norður-Ameríku",
+        "isPreferredName": true,
+        "lang": "is"
+      },
+      {
+        "name": "Dowlaaji Dentuɗi Amerik",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Egyesült Államok",
+        "lang": "hu"
+      },
+      {
+        "isShortName": true,
+        "name": "Estados Unidos",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Estados Unidos",
+        "lang": "pt"
+      },
+      {
+        "name": "Estados Unidos de América",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Estats Units",
+        "lang": "ca"
+      },
+      {
+        "name": "Estats Units",
+        "isPreferredName": true,
+        "lang": "oc"
+      },
+      {
+        "name": "Estatu Batuak",
+        "isPreferredName": true,
+        "lang": "eu"
+      },
+      {
+        "name": "États-Unis",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "name": "Etazonia",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Hoa Kỳ",
+        "lang": "vi"
+      },
+      {
+        "name": "http://de.wikipedia.org/wiki/Vereinigte_Staaten",
+        "lang": "link"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/United_States",
+        "lang": "link"
+      },
+      {
+        "name": "http://id.loc.gov/authorities/names/n78095330",
+        "lang": "link"
+      },
+      {
+        "name": "http://it.wikipedia.org/wiki/Stati_Uniti_d%27America",
+        "lang": "link"
+      },
+      {
+        "name": "http://no.wikipedia.org/wiki/USA",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%A1%D0%BE%D0%B5%D0%B4%D0%B8%D0%BD%D1%91%D0%BD%D0%BD%D1%8B%D0%B5_%D0%A8%D1%82%D0%B0%D1%82%D1%8B_%D0%90%D0%BC%D0%B5%D1%80%D0%B8%D0%BA%D0%B8",
+        "lang": "link"
+      },
+      {
+        "name": "http://tr.wikipedia.org/wiki/Amerika_Birle%C5%9Fik_Devletleri",
+        "lang": "link"
+      },
+      {
+        "name": "http://www.usa.gov/",
+        "lang": "link"
+      },
+      {
+        "name": "http://www.whitehouse.gov/",
+        "lang": "link"
+      },
+      {
+        "name": "i-United States",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Jungtinės Amerikos Valstijos",
+        "isPreferredName": true,
+        "lang": "lt"
+      },
+      {
+        "name": "Jungtinės Valstijos US",
+        "lang": "lt"
+      },
+      {
+        "name": "Leta Zunze Ubumwe za Amerika",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Maraykanka",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Marekani",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Naalagaaffeqatigiit",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Orílẹ́ède Orilẹede Amerika",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Puleʻanga fakatahataha ʻAmelika",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Sambandsríki Amerika",
+        "lang": "fo"
+      },
+      {
+        "name": "Shtetet e Bashkuara të Amerikës",
+        "lang": "sq"
+      },
+      {
+        "name": "Sjedinjene Američke Države",
+        "isPreferredName": true,
+        "lang": "bs"
+      },
+      {
+        "name": "Sjedinjene Države",
+        "lang": "hr"
+      },
+      {
+        "name": "Spojené státy",
+        "lang": "cs"
+      },
+      {
+        "name": "Spojené štáty",
+        "lang": "sk"
+      },
+      {
+        "name": "Spojené státy americké",
+        "isPreferredName": true,
+        "lang": "cs"
+      },
+      {
+        "name": "Spojené štáty americké",
+        "isPreferredName": true,
+        "lang": "sk"
+      },
+      {
+        "name": "Stadis Unids da l'America",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Stadoù-Unanet",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Stáit Aontaithe Mheiriceá",
+        "lang": "ga"
+      },
+      {
+        "name": "Stany Zjednoczone",
+        "lang": "pl"
+      },
+      {
+        "name": "Statele Unite",
+        "lang": "ro"
+      },
+      {
+        "name": "Statele Unite ale Americii",
+        "lang": "ro"
+      },
+      {
+        "name": "Stati Uniti",
+        "lang": "it"
+      },
+      {
+        "name": "Stati Uniti",
+        "lang": "mt"
+      },
+      {
+        "name": "Statos Unite",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Statys Unys",
+        "isPreferredName": true,
+        "lang": "kw"
+      },
+      {
+        "name": "United States",
+        "lang": "aa"
+      },
+      {
+        "name": "United States",
+        "isPreferredName": true,
+        "lang": "en"
+      },
+      {
+        "name": "United States",
+        "lang": "lv"
+      },
+      {
+        "name": "United States",
+        "lang": "om"
+      },
+      {
+        "name": "United States of America",
+        "lang": "en"
+      },
+      {
+        "name": "U.S.",
+        "lang": "abbr"
+      },
+      {
+        "name": "USA",
+        "lang": "abbr"
+      },
+      {
+        "isShortName": true,
+        "isColloquial": true,
+        "name": "USA",
+        "lang": "da"
+      },
+      {
+        "name": "USA",
+        "isPreferredName": true,
+        "lang": "de"
+      },
+      {
+        "name": "USA",
+        "lang": "fr"
+      },
+      {
+        "isShortName": true,
+        "isColloquial": true,
+        "name": "USA",
+        "lang": "nb"
+      },
+      {
+        "isShortName": true,
+        "isColloquial": true,
+        "name": "USA",
+        "lang": "nn"
+      },
+      {
+        "isShortName": true,
+        "name": "USA",
+        "lang": "no"
+      },
+      {
+        "isShortName": true,
+        "isColloquial": true,
+        "name": "USA",
+        "lang": "sv"
+      },
+      {
+        "name": "U.S.A.",
+        "lang": "abbr"
+      },
+      {
+        "name": "USA nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Usono",
+        "lang": "eo"
+      },
+      {
+        "name": "Vereinigte Staaten",
+        "lang": "de"
+      },
+      {
+        "name": "Verenigde Staten",
+        "lang": "nl"
+      },
+      {
+        "name": "Verenigde State van Amerika",
+        "lang": "af"
+      },
+      {
+        "name": "Yhdysvallat",
+        "lang": "fi"
+      },
+      {
+        "name": "Yr Unol Daleithiau",
+        "lang": "cy"
+      },
+      {
+        "name": "ZDA",
+        "isPreferredName": true,
+        "lang": "sl"
+      },
+      {
+        "name": "Združene države Amerike",
+        "lang": "sl"
+      },
+      {
+        "name": "ایالات متحده",
+        "isPreferredName": true,
+        "lang": "fa"
+      },
+      {
+        "name": "ایالات متحدهٔ امریکا",
+        "lang": "fa"
+      },
+      {
+        "name": "الاولايات المتحدة الامريكية",
+        "lang": "ar"
+      },
+      {
+        "name": "الولايات المتحدة الأمريكية",
+        "isPreferredName": true,
+        "lang": "ar"
+      },
+      {
+        "name": "ریاستہائے متحدہ",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "وڵاتە یەکگرتووەکان",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "ארצות הברית",
+        "lang": "he"
+      },
+      {
+        "name": "Ηνωμένες Πολιτείες της Αμερικής",
+        "isPreferredName": true,
+        "lang": "el"
+      },
+      {
+        "name": "АҚШ",
+        "isPreferredName": true,
+        "lang": "kk"
+      },
+      {
+        "name": "Америкийн Нэгдсэн Улс",
+        "isPreferredName": true,
+        "lang": "mn"
+      },
+      {
+        "name": "Злучаныя Штаты",
+        "lang": "be"
+      },
+      {
+        "name": "Злучаныя Штаты Амерыкі",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Қўшма Штатлар",
+        "lang": "uz"
+      },
+      {
+        "name": "САЩ",
+        "lang": "bg"
+      },
+      {
+        "name": "Сједињене Америчке Државе",
+        "lang": "sr"
+      },
+      {
+        "name": "Сједињене Државе",
+        "isPreferredName": true,
+        "lang": "sr"
+      },
+      {
+        "name": "Соединенные Штаты",
+        "lang": "ru"
+      },
+      {
+        "name": "Соединети Американски Држави",
+        "isPreferredName": true,
+        "lang": "mk"
+      },
+      {
+        "name": "Сполучені Штати Америки",
+        "isPreferredName": true,
+        "lang": "uk"
+      },
+      {
+        "name": "Сша",
+        "isPreferredName": true,
+        "lang": "ru"
+      },
+      {
+        "name": "США",
+        "lang": "uk"
+      },
+      {
+        "name": "Съединени щати",
+        "isPreferredName": true,
+        "lang": "bg"
+      },
+      {
+        "name": "Ամէրիկայի Միացյալ Նահանգնէր",
+        "lang": "hy"
+      },
+      {
+        "name": "Միացյալ Նահանգներ",
+        "isPreferredName": true,
+        "lang": "hy"
+      },
+      {
+        "name": "ამერიკის შეერთებული შტატები",
+        "lang": "ka"
+      },
+      {
+        "name": "संयुक्त राज्य",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "संयुक्त राज्य अमरिका",
+        "lang": "hi"
+      },
+      {
+        "name": "संयुक्त राज्य अमेरिका",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "संयुक्त राज्ये /अमेरिका",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "સંયુકત રાજ્ય/ અમેરિકા",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "సంయుక్త రాజ్య అమెరికా",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಅಮೇರಿಕಾ ಸಂಯುಕ್ತ ಸಂಸ್ಥಾನ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "ஐக்கிய அமெரிக்க குடியரசு",
+        "isPreferredName": true,
+        "lang": "ta"
+      },
+      {
+        "name": "അമേരിക്കന്‍ ഐക്യനാടുകള്‍",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "মার্কিন যুক্তরাষ্ট্র",
+        "lang": "bn"
+      },
+      {
+        "name": "যুক্তৰাষ্ট্ৰ",
+        "isPreferredName": true,
+        "lang": "as"
+      },
+      {
+        "name": "ယူနိုက်တက်စတိတ်",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "එක්සත් ජනපදය",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "アメリカ合衆国",
+        "lang": "ja"
+      },
+      {
+        "name": "美国",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "United States",
+    "adminCode1": "00",
+    "lng": "-98.5",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 18.913685,
+      "east": -66.954811,
+      "north": 71.390656,
+      "west": 172.454697
+    },
+    "name": "United States",
+    "fcode": "PCLI",
+    "geonameId": 6252001,
+    "asciiName": "United States",
+    "lat": "39.76",
+    "population": 310232863,
+    "adminName1": "",
+    "countryId": "6252001",
+    "fclName": "country, state, region,...",
+    "countryCode": "US",
+    "srtm3": 543,
+    "wikipediaURL": "en.wikipedia.org/wiki/United_States",
+    "toponymName": "United States",
+    "fcl": "A",
+    "continentCode": "NA"
+  },
+  "Israel": 294640,
+  "294640": {
+    "alternateNames": [
+      {
+        "name": "이스라엘",
+        "lang": "ko"
+      },
+      {
+        "name": "እስራኤል",
+        "lang": "am"
+      },
+      {
+        "name": "እስራኤል",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "イスラエル",
+        "lang": "ja"
+      },
+      {
+        "name": "ଇସ୍ରାଏଲ୍",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "อิสราเอล",
+        "lang": "th"
+      },
+      {
+        "name": "ອິສລະເອວ",
+        "lang": "lo"
+      },
+      {
+        "name": "ཨིཛ་རཱེལ",
+        "lang": "dz"
+      },
+      {
+        "name": "ཨི་ཛ྄་རེལ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "អ៊ីស្រាអែល",
+        "lang": "km"
+      },
+      {
+        "name": "ประเทศอิสราเอล",
+        "lang": "th"
+      },
+      {
+        "name": "Dawlat Isrā’īl"
+      },
+      {
+        "name": "Eretz Yisrael"
+      },
+      {
+        "name": "Ereẕ Yisra’el",
+        "lang": "he"
+      },
+      {
+        "name": "Ereẕ Yisra’el"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Israel",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%98%D0%B7%D1%80%D0%B0%D0%B8%D0%BB%D1%8C",
+        "lang": "link"
+      },
+      {
+        "name": "i-Israel",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Iisrael",
+        "lang": "et"
+      },
+      {
+        "name": "Iosrael",
+        "lang": "ga"
+      },
+      {
+        "name": "ʻIsileli",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Isiraheli",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Isirayele",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Isirayelɛ",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Isirayeli",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Isireli",
+        "lang": "fj"
+      },
+      {
+        "name": "Israaʼiil",
+        "lang": "so"
+      },
+      {
+        "name": "Israa'iila",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Israel",
+        "lang": "af"
+      },
+      {
+        "name": "Israel",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Israel",
+        "lang": "an"
+      },
+      {
+        "name": "Israel",
+        "lang": "ast"
+      },
+      {
+        "name": "Israel",
+        "lang": "br"
+      },
+      {
+        "name": "Israel",
+        "lang": "ca"
+      },
+      {
+        "name": "Israel",
+        "lang": "cy"
+      },
+      {
+        "name": "Israel",
+        "lang": "da"
+      },
+      {
+        "name": "Israel",
+        "lang": "de"
+      },
+      {
+        "isShortName": true,
+        "name": "Israel",
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Israel",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Israel",
+        "lang": "eu"
+      },
+      {
+        "name": "Israel",
+        "lang": "fi"
+      },
+      {
+        "name": "Israel",
+        "lang": "fy"
+      },
+      {
+        "name": "Israel",
+        "lang": "gd"
+      },
+      {
+        "name": "Israel",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Israel",
+        "lang": "hsb"
+      },
+      {
+        "name": "Israel",
+        "lang": "ia"
+      },
+      {
+        "name": "Israel",
+        "lang": "id"
+      },
+      {
+        "name": "Israel",
+        "lang": "ilo"
+      },
+      {
+        "name": "Israel",
+        "lang": "io"
+      },
+      {
+        "name": "Israel",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Israel",
+        "lang": "la"
+      },
+      {
+        "name": "Israel",
+        "lang": "lb"
+      },
+      {
+        "name": "Israel",
+        "lang": "ms"
+      },
+      {
+        "name": "Israel",
+        "lang": "na"
+      },
+      {
+        "name": "Israel",
+        "lang": "nb"
+      },
+      {
+        "name": "Israel",
+        "lang": "nds"
+      },
+      {
+        "name": "Israel",
+        "lang": "nn"
+      },
+      {
+        "name": "Israel",
+        "lang": "no"
+      },
+      {
+        "name": "Israel",
+        "lang": "pam"
+      },
+      {
+        "name": "Israel",
+        "lang": "pt"
+      },
+      {
+        "name": "Israel",
+        "lang": "qu"
+      },
+      {
+        "name": "Israel",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Israel",
+        "lang": "ro"
+      },
+      {
+        "name": "Israel",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Israel",
+        "lang": "sv"
+      },
+      {
+        "name": "Israel",
+        "lang": "tl"
+      },
+      {
+        "name": "Israel",
+        "lang": "tpi"
+      },
+      {
+        "name": "Israel",
+        "lang": "vi"
+      },
+      {
+        "name": "Israel",
+        "lang": "yo"
+      },
+      {
+        "name": "Israel"
+      },
+      {
+        "name": "Ísrael",
+        "lang": "fo"
+      },
+      {
+        "name": "Ísrael",
+        "lang": "is"
+      },
+      {
+        "name": "Israèl",
+        "lang": "oc"
+      },
+      {
+        "name": "Israël",
+        "lang": "fr"
+      },
+      {
+        "name": "Israël",
+        "lang": "li"
+      },
+      {
+        "name": "Israël",
+        "lang": "nl"
+      },
+      {
+        "name": "Israel (Do Thái)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Israele",
+        "lang": "it"
+      },
+      {
+        "name": "Israeli",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Israeli",
+        "lang": "scn"
+      },
+      {
+        "name": "Israeli",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Israëli",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Israel nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Israelo",
+        "lang": "eo"
+      },
+      {
+        "name": "Israely",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Israel - ישראל",
+        "lang": "gl"
+      },
+      {
+        "name": "Israhēl",
+        "lang": "ang"
+      },
+      {
+        "name": "İsrail",
+        "lang": "tr"
+      },
+      {
+        "name": "Îsraîl",
+        "lang": "ku"
+      },
+      {
+        "name": "Isrā’īl"
+      },
+      {
+        "name": "Isroil",
+        "lang": "uz"
+      },
+      {
+        "name": "Isuraeli",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "I-xra-en",
+        "lang": "vi"
+      },
+      {
+        "name": "Izira'ila",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Izrael",
+        "lang": "bs"
+      },
+      {
+        "name": "Izrael",
+        "lang": "cs"
+      },
+      {
+        "name": "Izrael",
+        "lang": "hbs"
+      },
+      {
+        "name": "Izrael",
+        "lang": "hr"
+      },
+      {
+        "name": "Izrael",
+        "lang": "hu"
+      },
+      {
+        "name": "Izrael",
+        "lang": "pl"
+      },
+      {
+        "name": "Izrael",
+        "lang": "sk"
+      },
+      {
+        "name": "Izrael",
+        "lang": "sl"
+      },
+      {
+        "name": "Izrael",
+        "lang": "sq"
+      },
+      {
+        "name": "Iżrael",
+        "lang": "mt"
+      },
+      {
+        "name": "Izraēla",
+        "lang": "lv"
+      },
+      {
+        "name": "Izraeli",
+        "lang": "sq"
+      },
+      {
+        "name": "Izraelis",
+        "lang": "lt"
+      },
+      {
+        "name": "İzrail",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Izrayèl",
+        "lang": "ht"
+      },
+      {
+        "name": "Izuraeri",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Medinat Yisrael",
+        "lang": "lad"
+      },
+      {
+        "name": "Medinat Yisra’el",
+        "lang": "he"
+      },
+      {
+        "name": "Orílẹ́ède Iserẹli",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "State of Israel",
+        "lang": "en"
+      },
+      {
+        "name": "Yisirayeri",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Yisra’el"
+      },
+      {
+        "name": "Ysrael",
+        "lang": "kw"
+      },
+      {
+        "name": "اسراییل",
+        "isPreferredName": true,
+        "lang": "fa"
+      },
+      {
+        "name": "اسرائیل",
+        "lang": "fa"
+      },
+      {
+        "name": "اسرائیل",
+        "lang": "ur"
+      },
+      {
+        "name": "إسرائيل",
+        "lang": "ar"
+      },
+      {
+        "name": "اسرائيل",
+        "lang": "ar"
+      },
+      {
+        "name": "اسرايل",
+        "lang": "ps"
+      },
+      {
+        "name": "ئیسرائیل",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "ئىسرائىلىيە",
+        "lang": "ug"
+      },
+      {
+        "name": "ישראל",
+        "isPreferredName": true,
+        "lang": "he"
+      },
+      {
+        "name": "ישראל",
+        "lang": "yi"
+      },
+      {
+        "name": "מדינת ישראל",
+        "lang": "yi"
+      },
+      {
+        "name": "Ισραήλ",
+        "lang": "el"
+      },
+      {
+        "name": "Израел",
+        "lang": "bg"
+      },
+      {
+        "name": "Израел",
+        "lang": "mk"
+      },
+      {
+        "name": "Израел",
+        "lang": "sr"
+      },
+      {
+        "name": "Израиль",
+        "lang": "os"
+      },
+      {
+        "name": "Израиль",
+        "lang": "ru"
+      },
+      {
+        "name": "Ізраіль",
+        "lang": "be"
+      },
+      {
+        "name": "Ізраїль",
+        "lang": "uk"
+      },
+      {
+        "name": "Їздраил҄ь",
+        "lang": "cu"
+      },
+      {
+        "name": "Իզրաել",
+        "lang": "hy"
+      },
+      {
+        "name": "Իսրայել",
+        "lang": "hy"
+      },
+      {
+        "name": "ისრაელი",
+        "lang": "ka"
+      },
+      {
+        "name": "इजराइल",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "इज्रायल",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "इसराइल",
+        "lang": "hi"
+      },
+      {
+        "name": "इस्त्राइल",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "इस्रायल",
+        "lang": "mr"
+      },
+      {
+        "name": "ઇઝરાઇલ",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "ఇస్రాయేల్",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಇಸ್ರೇಲ್",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "இசுரேல்",
+        "lang": "ta"
+      },
+      {
+        "name": "இஸ்ரேல்",
+        "lang": "ta"
+      },
+      {
+        "name": "ഇസ്രായേല്‍",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "ইসরায়েল",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "ইস্রায়েল",
+        "lang": "bn"
+      },
+      {
+        "name": "အစ္စရေး",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "ඊශ්‍රායලය",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "以色列",
+        "lang": "zh"
+      },
+      {
+        "name": "イスラエル国",
+        "isPreferredName": true,
+        "lang": "ja"
+      }
+    ],
+    "countryName": "Israel",
+    "adminCode1": "00",
+    "lng": "34.75",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 2,
+      "timeZoneId": "Asia/Jerusalem"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 29.496639,
+      "east": 35.876804,
+      "north": 33.340137,
+      "west": 34.270278754419145
+    },
+    "name": "Israel",
+    "fcode": "PCLI",
+    "geonameId": 294640,
+    "asciiName": "State of Israel",
+    "lat": "31.5",
+    "population": 7353985,
+    "adminName1": "",
+    "countryId": "294640",
+    "fclName": "country, state, region,...",
+    "countryCode": "IL",
+    "srtm3": 168,
+    "wikipediaURL": "en.wikipedia.org/wiki/Israel",
+    "toponymName": "State of Israel",
+    "fcl": "A",
+    "continentCode": "AS"
+  },
+  "Thailand": 1605651,
+  "1605651": {
+    "alternateNames": [
+      {
+        "name": "ថៃ",
+        "lang": "km"
+      },
+      {
+        "name": "タイ",
+        "lang": "ja"
+      },
+      {
+        "name": "타이",
+        "lang": "ko"
+      },
+      {
+        "name": "태국",
+        "isPreferredName": true,
+        "lang": "ko"
+      },
+      {
+        "name": "ไทย",
+        "isPreferredName": true,
+        "lang": "th"
+      },
+      {
+        "name": "ታይላንድ",
+        "lang": "am"
+      },
+      {
+        "name": "ታይላንድ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ປະເທດໄທ",
+        "lang": "lo"
+      },
+      {
+        "name": "ଥାଇଲାଣ୍ଡ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "ཐའི་ལེན།",
+        "lang": "bo"
+      },
+      {
+        "name": "ประเทศไทย",
+        "lang": "th"
+      },
+      {
+        "name": "ཐཱའི་ལེནཌ",
+        "lang": "dz"
+      },
+      {
+        "name": "ราชอาณาจักรไทย",
+        "lang": "th"
+      },
+      {
+        "name": "An Téalainn",
+        "lang": "ga"
+      },
+      {
+        "name": "Gwlad Thai",
+        "lang": "cy"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Thailand",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%A2%D0%B0%D0%B8%D0%BB%D0%B0%D0%BD%D0%B4",
+        "lang": "link"
+      },
+      {
+        "name": "i-Thailand",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Kingdom of Thailand",
+        "lang": "en"
+      },
+      {
+        "name": "Muang-Thai"
+      },
+      {
+        "name": "Orílẹ́ède Tailandi",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Pow Tay",
+        "lang": "kw"
+      },
+      {
+        "name": "Prades Thai"
+      },
+      {
+        "name": "Prathet Thai"
+      },
+      {
+        "name": "Ratcha Anachak Thai"
+      },
+      {
+        "name": "Sayam"
+      },
+      {
+        "name": "Siam",
+        "lang": "es"
+      },
+      {
+        "name": "Siam"
+      },
+      {
+        "name": "Taeland",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Tai",
+        "lang": "et"
+      },
+      {
+        "name": "Tailan",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Tailân",
+        "lang": "fy"
+      },
+      {
+        "name": "Tailand",
+        "lang": "az"
+      },
+      {
+        "name": "Tailand",
+        "lang": "tk"
+      },
+      {
+        "name": "Taíland",
+        "lang": "is"
+      },
+      {
+        "name": "Tailanda",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Tailanda",
+        "lang": "ro"
+      },
+      {
+        "name": "Tailandas",
+        "lang": "lt"
+      },
+      {
+        "name": "Tailânde",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Tailandɛ",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Tailandi",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Tailandi",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Tailandia",
+        "lang": "an"
+      },
+      {
+        "name": "Tailandia",
+        "lang": "ast"
+      },
+      {
+        "isShortName": true,
+        "name": "Tailandia",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Tailandia",
+        "lang": "eu"
+      },
+      {
+        "name": "Tailandia",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Tailandia",
+        "lang": "ilo"
+      },
+      {
+        "name": "Tailandia",
+        "lang": "it"
+      },
+      {
+        "name": "Tailandia - ประเทศไทย",
+        "lang": "gl"
+      },
+      {
+        "name": "Tailàndia",
+        "lang": "ca"
+      },
+      {
+        "name": "Tailàndia",
+        "lang": "oc"
+      },
+      {
+        "name": "Tailândia",
+        "lang": "pt"
+      },
+      {
+        "name": "Tailand nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Tailando",
+        "lang": "io"
+      },
+      {
+        "name": "Tailandy",
+        "lang": "mg"
+      },
+      {
+        "name": "Tailandya",
+        "lang": "pam"
+      },
+      {
+        "name": "Taileni",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Taizeme",
+        "lang": "lv"
+      },
+      {
+        "name": "Tajland",
+        "lang": "bs"
+      },
+      {
+        "name": "Tajland",
+        "lang": "hbs"
+      },
+      {
+        "name": "Tajland",
+        "lang": "hr"
+      },
+      {
+        "name": "Tajlanda",
+        "lang": "sq"
+      },
+      {
+        "name": "Tajlandë",
+        "lang": "sq"
+      },
+      {
+        "name": "Tajlandia",
+        "lang": "pl"
+      },
+      {
+        "name": "Tajlandja",
+        "lang": "mt"
+      },
+      {
+        "name": "Tajlando",
+        "lang": "eo"
+      },
+      {
+        "name": "Tajska",
+        "lang": "sl"
+      },
+      {
+        "name": "Tayän",
+        "lang": "vo"
+      },
+      {
+        "name": "Tayilanda",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Tayilande",
+        "lang": "frp"
+      },
+      {
+        "name": "Tayilandi",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Tayilandi",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Tayirandi",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Taylaand",
+        "lang": "so"
+      },
+      {
+        "name": "Tayland",
+        "lang": "tr"
+      },
+      {
+        "name": "Taylandiya",
+        "lang": "tl"
+      },
+      {
+        "name": "Taylandya",
+        "lang": "war"
+      },
+      {
+        "name": "Taylannda",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Taylenda",
+        "lang": "ku"
+      },
+      {
+        "name": "Teiland",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "name": "Thaieana",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Thaiföld",
+        "lang": "hu"
+      },
+      {
+        "name": "Thái Lan",
+        "lang": "vi"
+      },
+      {
+        "name": "Thailand",
+        "lang": "af"
+      },
+      {
+        "name": "Thailand",
+        "lang": "br"
+      },
+      {
+        "name": "Thailand",
+        "lang": "da"
+      },
+      {
+        "name": "Thailand",
+        "lang": "de"
+      },
+      {
+        "isShortName": true,
+        "name": "Thailand",
+        "lang": "en"
+      },
+      {
+        "name": "Thailand",
+        "lang": "id"
+      },
+      {
+        "name": "Thailand",
+        "lang": "li"
+      },
+      {
+        "name": "Thailand",
+        "lang": "ms"
+      },
+      {
+        "name": "Thailand",
+        "lang": "nb"
+      },
+      {
+        "name": "Thailand",
+        "lang": "nds"
+      },
+      {
+        "name": "Thailand",
+        "lang": "nl"
+      },
+      {
+        "name": "Thailand",
+        "lang": "nn"
+      },
+      {
+        "name": "Thailand",
+        "lang": "no"
+      },
+      {
+        "name": "Thailand",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Thailand",
+        "lang": "sv"
+      },
+      {
+        "name": "Thailand"
+      },
+      {
+        "name": "Thailanda",
+        "lang": "ro"
+      },
+      {
+        "name": "Thaïlande",
+        "lang": "fr"
+      },
+      {
+        "name": "Thailandi",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Thailandia",
+        "isPreferredName": true,
+        "lang": "eu"
+      },
+      {
+        "name": "Thailandia",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "isShortName": true,
+        "name": "Thailandia",
+        "isPreferredName": true,
+        "lang": "it"
+      },
+      {
+        "name": "Thailandia",
+        "lang": "la"
+      },
+      {
+        "name": "Thailandia",
+        "lang": "scn"
+      },
+      {
+        "name": "Thailandska",
+        "lang": "hsb"
+      },
+      {
+        "name": "Thailandy",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Thaimaa",
+        "lang": "fi"
+      },
+      {
+        "name": "Thajsko",
+        "lang": "cs"
+      },
+      {
+        "name": "Thajsko",
+        "lang": "sk"
+      },
+      {
+        "name": "Thayilandi",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Thaysuyu",
+        "lang": "qu"
+      },
+      {
+        "name": "تایلەند",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "تایلند",
+        "lang": "fa"
+      },
+      {
+        "name": "تھائی لینڈ",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "تايلنډ",
+        "lang": "ps"
+      },
+      {
+        "name": "تايلند",
+        "lang": "ar"
+      },
+      {
+        "name": "תאיילנד",
+        "lang": "he"
+      },
+      {
+        "name": "תאילנד",
+        "lang": "he"
+      },
+      {
+        "name": "Ταϊλάνδη",
+        "lang": "el"
+      },
+      {
+        "name": "Таиланд",
+        "lang": "ru"
+      },
+      {
+        "name": "Таиланд",
+        "lang": "tg"
+      },
+      {
+        "name": "Таїланд",
+        "lang": "uk"
+      },
+      {
+        "name": "Тайланд",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Тайланд",
+        "lang": "bg"
+      },
+      {
+        "name": "Тайланд",
+        "isPreferredName": true,
+        "lang": "kk"
+      },
+      {
+        "name": "Тайланд",
+        "isPreferredName": true,
+        "lang": "ru"
+      },
+      {
+        "name": "Тайланд",
+        "isPreferredName": true,
+        "lang": "uk"
+      },
+      {
+        "name": "Тајланд",
+        "lang": "mk"
+      },
+      {
+        "name": "Тајланд",
+        "lang": "sr"
+      },
+      {
+        "name": "Թաիլանդ",
+        "lang": "hy"
+      },
+      {
+        "name": "ტაილანდი",
+        "lang": "ka"
+      },
+      {
+        "name": "थाइलैंड",
+        "lang": "hi"
+      },
+      {
+        "name": "थाइलैंड",
+        "lang": "ks"
+      },
+      {
+        "name": "थाइल्याण्ड",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "थाईलैण्ड",
+        "lang": "hi"
+      },
+      {
+        "name": "थायलंड",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "श्यामदेश",
+        "lang": "sa"
+      },
+      {
+        "name": "થાઇલેન્ડ",
+        "lang": "gu"
+      },
+      {
+        "name": "થાઇલેંડ",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "థాయిలాండ్",
+        "lang": "te"
+      },
+      {
+        "name": "థాయ్ లాండ్",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಥೈಲ್ಯಾಂಡ್",
+        "lang": "kn"
+      },
+      {
+        "name": "தாய்லாந்து",
+        "lang": "ta"
+      },
+      {
+        "name": "തായ്‌ലാന്‍ഡ്",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "থাই",
+        "lang": "bn"
+      },
+      {
+        "name": "থাইল্যান্ড",
+        "lang": "bn"
+      },
+      {
+        "name": "ထိုင်း",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "තායිලන්තය",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "泰国",
+        "lang": "zh"
+      },
+      {
+        "name": "タイ王国",
+        "lang": "ja"
+      }
+    ],
+    "countryName": "Thailand",
+    "adminCode1": "00",
+    "lng": "101",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 7,
+      "gmtOffset": 7,
+      "timeZoneId": "Asia/Bangkok"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 5.61,
+      "east": 105.639389,
+      "north": 20.463194,
+      "west": 97.345642
+    },
+    "name": "Thailand",
+    "fcode": "PCLI",
+    "geonameId": 1605651,
+    "asciiName": "Kingdom of Thailand",
+    "lat": "15.5",
+    "population": 67089500,
+    "adminName1": "",
+    "countryId": "1605651",
+    "fclName": "country, state, region,...",
+    "countryCode": "TH",
+    "srtm3": 120,
+    "wikipediaURL": "en.wikipedia.org/wiki/Thailand",
+    "toponymName": "Kingdom of Thailand",
+    "fcl": "A",
+    "continentCode": "AS"
+  },
+  "France": 3570675,
+  "3570675": {
+    "adminCode3": "9721",
+    "alternateNames": [
+      {
+        "name": "ฟอร์-เดอ-ฟร็องส์",
+        "lang": "th"
+      },
+      {
+        "name": "포르드프랑스",
+        "lang": "ko"
+      },
+      {
+        "name": "フォール＝ド＝フランス",
+        "lang": "ja"
+      },
+      {
+        "name": "97200",
+        "isPreferredName": true,
+        "lang": "post"
+      },
+      {
+        "name": "97201 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97202 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97203 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97204 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97205 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97206 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97207 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97208 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97209 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97219 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97234",
+        "lang": "post"
+      },
+      {
+        "name": "97241 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97242 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97243 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97244 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97245 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97246 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97247 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97248 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97249 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97251 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97252 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97253 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97254 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97255 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97256 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97257 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97258 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97259 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97261 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97262 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97263 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97264 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97265 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97266 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97267 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97268 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97269 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "97299 CEDEX",
+        "lang": "post"
+      },
+      {
+        "name": "FDF",
+        "lang": "iata"
+      },
+      {
+        "name": "Fordefransa",
+        "lang": "lv"
+      },
+      {
+        "name": "For de Fransas",
+        "lang": "lt"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "da"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "de"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "el"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "en"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "es"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "fi"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "fr"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "id"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "io"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "it"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "nl"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "oc"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "pl"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "pt"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "sk"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "sv"
+      },
+      {
+        "name": "Fort-de-France",
+        "lang": "vi"
+      },
+      {
+        "name": "Fôrt-de-France",
+        "lang": "frp"
+      },
+      {
+        "name": "Fort Royal"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Fort-de-France",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%A4%D0%BE%D1%80-%D0%B4%D0%B5-%D0%A4%D1%80%D0%B0%D0%BD%D1%81",
+        "lang": "link"
+      },
+      {
+        "name": "Le Fort-de-France"
+      },
+      {
+        "name": "فورٹ ڈی فرانس",
+        "lang": "pnb"
+      },
+      {
+        "name": "فورٹ ڈی فرانس",
+        "lang": "ur"
+      },
+      {
+        "name": "فور دو فرانس",
+        "lang": "ar"
+      },
+      {
+        "name": "فور دو فرانس",
+        "lang": "mzn"
+      },
+      {
+        "name": "فور-دو-فرانس",
+        "lang": "fa"
+      },
+      {
+        "name": "פור-דה-פראנס",
+        "lang": "he"
+      },
+      {
+        "name": "Φορ-ντε-Φρανς",
+        "lang": "el"
+      },
+      {
+        "name": "Горад Форт-дэ-Франс",
+        "lang": "be"
+      },
+      {
+        "name": "Фор де Франс",
+        "lang": "mk"
+      },
+      {
+        "name": "Фор де Франс",
+        "lang": "sr"
+      },
+      {
+        "name": "Фор-де-Франс",
+        "lang": "os"
+      },
+      {
+        "name": "Фор-де-Франс",
+        "lang": "ru"
+      },
+      {
+        "name": "Фор-де-Франс",
+        "lang": "uk"
+      },
+      {
+        "name": "Фор дьо Франс",
+        "lang": "bg"
+      },
+      {
+        "name": "Форт-де-Франс",
+        "lang": "ru"
+      },
+      {
+        "name": "ფორ-დე-ფრანსი",
+        "lang": "ka"
+      },
+      {
+        "name": "फोर्ट-दे-फ्रान्स",
+        "lang": "mr"
+      },
+      {
+        "name": "法兰西堡",
+        "lang": "zh"
+      }
+    ],
+    "adminCode2": "972",
+    "countryName": "Martinique",
+    "adminCode1": "MQ",
+    "lng": "-61.07334",
+    "adminCode4": "97209",
+    "adminName2": "Martinique",
+    "fcodeName": "capital of a political entity",
+    "adminName3": "Arrondissement de Fort-de-France",
+    "timezone": {
+      "dstOffset": -4,
+      "gmtOffset": -4,
+      "timeZoneId": "America/Martinique"
+    },
+    "adminName4": "Fort-de-France",
+    "adminName5": "",
+    "bbox": {
+      "south": 14.570233779811323,
+      "east": -61.0333587656621,
+      "north": 14.647600071708629,
+      "west": -61.11332397359571
+    },
+    "name": "Fort-de-France",
+    "fcode": "PPLC",
+    "geonameId": 3570675,
+    "asciiName": "Fort-de-France",
+    "lat": "14.60892",
+    "population": 89995,
+    "adminName1": "Martinique",
+    "adminId1": "6690603",
+    "countryId": "3570311",
+    "fclName": "city, village,...",
+    "countryCode": "MQ",
+    "srtm3": 6,
+    "adminId4": "6690660",
+    "adminId3": "3570674",
+    "adminId2": "6690604",
+    "wikipediaURL": "en.wikipedia.org/wiki/Fort-de-France",
+    "toponymName": "Fort-de-France",
+    "fcl": "P",
+    "continentCode": "NA"
+  },
+  "Kenya": 192950,
+  "192950": {
+    "alternateNames": [
+      {
+        "name": "케냐",
+        "lang": "ko"
+      },
+      {
+        "name": "ኬንያ",
+        "lang": "am"
+      },
+      {
+        "name": "ኬንያ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ケニア",
+        "lang": "ja"
+      },
+      {
+        "name": "เคนยา",
+        "lang": "th"
+      },
+      {
+        "name": "କେନିୟା",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "ເຄນຢ່າ",
+        "lang": "lo"
+      },
+      {
+        "name": "កេនយ៉ា",
+        "lang": "km"
+      },
+      {
+        "name": "ཀེ་ནི་ཡ",
+        "lang": "dz"
+      },
+      {
+        "name": "ཁེ་ནི་ཡ།",
+        "lang": "bo"
+      },
+      {
+        "name": "ཁེན་ཉི་ཡ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ประเทศเคนยา",
+        "lang": "th"
+      },
+      {
+        "name": "A Cheinia",
+        "lang": "gd"
+      },
+      {
+        "name": "An Chéinia",
+        "lang": "ga"
+      },
+      {
+        "name": "Cenia",
+        "lang": "cy"
+      },
+      {
+        "name": "Chenia",
+        "lang": "pms"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Kenya",
+        "lang": "link"
+      },
+      {
+        "name": "http://id.loc.gov/authorities/names/n80061011",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%9A%D0%B5%D0%BD%D0%B8%D1%8F",
+        "lang": "link"
+      },
+      {
+        "name": "i-Kenya",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Jamhuri ya Kenya"
+      },
+      {
+        "name": "Keenia",
+        "isPreferredName": true,
+        "lang": "et"
+      },
+      {
+        "name": "Keeniyaa",
+        "lang": "om"
+      },
+      {
+        "name": "Keňa",
+        "lang": "cs"
+      },
+      {
+        "name": "Keňa",
+        "lang": "sk"
+      },
+      {
+        "name": "Keña",
+        "lang": "ast"
+      },
+      {
+        "name": "Keñaa",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Kenia",
+        "lang": "af"
+      },
+      {
+        "name": "Kenia",
+        "lang": "an"
+      },
+      {
+        "name": "Kenia",
+        "lang": "de"
+      },
+      {
+        "isShortName": true,
+        "name": "Kenia",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Kenia",
+        "lang": "eu"
+      },
+      {
+        "name": "Kenia",
+        "lang": "fi"
+      },
+      {
+        "name": "Kenia",
+        "lang": "frp"
+      },
+      {
+        "name": "Kenia",
+        "lang": "io"
+      },
+      {
+        "name": "Kenia",
+        "lang": "la"
+      },
+      {
+        "name": "Kenia",
+        "lang": "li"
+      },
+      {
+        "name": "Kenia",
+        "lang": "nds"
+      },
+      {
+        "name": "Kenia",
+        "lang": "nl"
+      },
+      {
+        "name": "Kenia",
+        "lang": "pl"
+      },
+      {
+        "name": "Kenia",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Kenia",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Kenia",
+        "lang": "sq"
+      },
+      {
+        "name": "Kenia",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Kenia"
+      },
+      {
+        "name": "Kènia",
+        "isPreferredName": true,
+        "lang": "ca"
+      },
+      {
+        "name": "Kê-ni-a",
+        "lang": "vi"
+      },
+      {
+        "name": "Kenía",
+        "lang": "is"
+      },
+      {
+        "name": "Kê-ni-a (Kenya)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Kenija",
+        "lang": "bs"
+      },
+      {
+        "name": "Kenija",
+        "lang": "hbs"
+      },
+      {
+        "name": "Kenija",
+        "lang": "hr"
+      },
+      {
+        "name": "Kenija",
+        "lang": "hsb"
+      },
+      {
+        "name": "Kenija",
+        "lang": "lt"
+      },
+      {
+        "name": "Kenija",
+        "lang": "lv"
+      },
+      {
+        "name": "Kenija",
+        "lang": "sl"
+      },
+      {
+        "name": "Keniya",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Keniya",
+        "lang": "na"
+      },
+      {
+        "name": "Kenja",
+        "lang": "fo"
+      },
+      {
+        "name": "Kenja",
+        "lang": "mt"
+      },
+      {
+        "name": "Kenjo",
+        "lang": "eo"
+      },
+      {
+        "name": "Kenya",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Kenya",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Kenya",
+        "lang": "ca"
+      },
+      {
+        "name": "Kenya",
+        "lang": "cy"
+      },
+      {
+        "name": "Kenya",
+        "lang": "da"
+      },
+      {
+        "name": "Kenya",
+        "lang": "en"
+      },
+      {
+        "name": "Kenya",
+        "lang": "et"
+      },
+      {
+        "name": "Kenya",
+        "lang": "eu"
+      },
+      {
+        "name": "Kenya",
+        "lang": "fr"
+      },
+      {
+        "name": "Kenya",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Kenya",
+        "lang": "hu"
+      },
+      {
+        "name": "Kenya",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Kenya",
+        "lang": "id"
+      },
+      {
+        "name": "Kenya",
+        "lang": "it"
+      },
+      {
+        "name": "Kenya",
+        "lang": "ki"
+      },
+      {
+        "name": "Kenya",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Kenya",
+        "lang": "ku"
+      },
+      {
+        "name": "Kenya",
+        "lang": "kw"
+      },
+      {
+        "name": "Kenya",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Kenya",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Kenya",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Kenya",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Kenya",
+        "lang": "ms"
+      },
+      {
+        "name": "Kenya",
+        "lang": "nb"
+      },
+      {
+        "name": "Kenya",
+        "lang": "nn"
+      },
+      {
+        "name": "Kenya",
+        "lang": "no"
+      },
+      {
+        "name": "Kenya",
+        "lang": "oc"
+      },
+      {
+        "name": "Kenya",
+        "lang": "pam"
+      },
+      {
+        "name": "Kenya",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Kenya",
+        "lang": "ro"
+      },
+      {
+        "name": "Kenya",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Kenya",
+        "lang": "sv"
+      },
+      {
+        "name": "Kenya",
+        "lang": "sw"
+      },
+      {
+        "name": "Kenya",
+        "lang": "tl"
+      },
+      {
+        "name": "Kenya",
+        "lang": "tr"
+      },
+      {
+        "name": "Kenya",
+        "lang": "vi"
+      },
+      {
+        "name": "Kenya"
+      },
+      {
+        "name": "Kɛnya",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Kenýa",
+        "lang": "is"
+      },
+      {
+        "name": "Kenyäa",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Kenyän",
+        "lang": "vo"
+      },
+      {
+        "name": "Kenya nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Khenya",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Kiiniya",
+        "lang": "so"
+      },
+      {
+        "name": "Kiinya",
+        "lang": "so"
+      },
+      {
+        "name": "Orílẹ́ède Kenya",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Quenia",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Quénia",
+        "lang": "pt"
+      },
+      {
+        "name": "Quênia",
+        "isPreferredName": true,
+        "lang": "pt"
+      },
+      {
+        "name": "Quenia - Kenya",
+        "lang": "gl"
+      },
+      {
+        "name": "Republic of Kenya"
+      },
+      {
+        "name": "كېنىيە",
+        "lang": "ug"
+      },
+      {
+        "name": "كينيا",
+        "lang": "ar"
+      },
+      {
+        "name": "کینیا",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "کنیا",
+        "lang": "fa"
+      },
+      {
+        "name": "קניה",
+        "lang": "he"
+      },
+      {
+        "name": "Κένυα",
+        "lang": "el"
+      },
+      {
+        "name": "Кенија",
+        "lang": "mk"
+      },
+      {
+        "name": "Кенија",
+        "lang": "sr"
+      },
+      {
+        "name": "Кения",
+        "lang": "bg"
+      },
+      {
+        "name": "Кения",
+        "lang": "ru"
+      },
+      {
+        "name": "Кения",
+        "lang": "tg"
+      },
+      {
+        "name": "Кенія",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Кенія",
+        "lang": "uk"
+      },
+      {
+        "name": "Քենիա",
+        "lang": "hy"
+      },
+      {
+        "name": "კენია",
+        "lang": "ka"
+      },
+      {
+        "name": "केनिया",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "केन्या",
+        "lang": "hi"
+      },
+      {
+        "name": "केन्या",
+        "lang": "mr"
+      },
+      {
+        "name": "केन्या",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "केन्या",
+        "lang": "sa"
+      },
+      {
+        "name": "કેન્યા",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "కెన్యా",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಕೀನ್ಯಾ",
+        "lang": "kn"
+      },
+      {
+        "name": "கென்யா",
+        "lang": "ta"
+      },
+      {
+        "name": "കെനിയ",
+        "lang": "ml"
+      },
+      {
+        "name": "কেনিয়া",
+        "lang": "bn"
+      },
+      {
+        "name": "কেনিয়া",
+        "lang": "bn"
+      },
+      {
+        "name": "ကင်ညာ",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "කෙන්යාව",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "ケニア共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "肯尼亚",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Kenya",
+    "adminCode1": "00",
+    "lng": "38",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Nairobi"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -4.678047,
+      "east": 41.899078,
+      "north": 5.019938,
+      "west": 33.908859
+    },
+    "name": "Kenya",
+    "fcode": "PCLI",
+    "geonameId": 192950,
+    "asciiName": "Republic of Kenya",
+    "lat": "1",
+    "population": 40046566,
+    "adminName1": "",
+    "countryId": "192950",
+    "fclName": "country, state, region,...",
+    "countryCode": "KE",
+    "srtm3": 697,
+    "wikipediaURL": "en.wikipedia.org/wiki/Kenya",
+    "toponymName": "Republic of Kenya",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Honiara-Henderson International Airport": 6295679,
+  "6295679": {
+    "alternateNames": [
+      {
+        "name": "AGGH",
+        "lang": "icao"
+      },
+      {
+        "name": "Flughafen Honiara",
+        "isPreferredName": true,
+        "lang": "de"
+      },
+      {
+        "name": "Flughafen Honiara",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "name": "HIR",
+        "lang": "iata"
+      },
+      {
+        "name": "Honiara-Henderson International Airport",
+        "lang": "en"
+      },
+      {
+        "name": "Honiara International Airport",
+        "isPreferredName": true,
+        "lang": "en"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Honiara_International_Airport",
+        "lang": "link"
+      }
+    ],
+    "countryName": "Solomon Islands",
+    "adminCode1": "06",
+    "lng": "160.05479",
+    "adminName2": "",
+    "fcodeName": "airport",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 11,
+      "gmtOffset": 11,
+      "timeZoneId": "Pacific/Guadalcanal"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "name": "Honiara International Airport",
+    "fcode": "AIRP",
+    "geonameId": 6295679,
+    "asciiName": "Honiara-Henderson International Airport",
+    "lat": "-9.428",
+    "population": 0,
+    "adminName1": "Guadalcanal",
+    "adminId1": "2108831",
+    "countryId": "2103350",
+    "fclName": "spot, building, farm",
+    "elevation": 8,
+    "countryCode": "SB",
+    "srtm3": 5,
+    "wikipediaURL": "en.wikipedia.org/wiki/Honiara_International_Airport",
+    "toponymName": "Honiara-Henderson International Airport",
+    "fcl": "S",
+    "continentCode": "OC"
+  },
+  "Congo": 2260494,
+  "2260494": {
+    "alternateNames": [
+      {
+        "name": "콩고",
+        "lang": "ko"
+      },
+      {
+        "name": "콩고 공화국",
+        "lang": "ko"
+      },
+      {
+        "name": "ኮንጐ",
+        "lang": "am"
+      },
+      {
+        "name": "ኮንጐ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "コンゴ",
+        "lang": "ja"
+      },
+      {
+        "name": "ኮንጎ ሪፑብሊክ",
+        "lang": "am"
+      },
+      {
+        "name": "ຄອງໂກ",
+        "lang": "lo"
+      },
+      {
+        "name": "คองโก-บราซซาวิล",
+        "isPreferredName": true,
+        "lang": "th"
+      },
+      {
+        "name": "କଙ୍ଗୋ-ବ୍ରାଜିଭିଲ୍ଲେ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "ཀོང་ཀོ",
+        "lang": "bo"
+      },
+      {
+        "name": "កុងហ្គោ",
+        "lang": "km"
+      },
+      {
+        "name": "สาธารณรัฐคองโก",
+        "lang": "th"
+      },
+      {
+        "name": "An Congó",
+        "lang": "ga"
+      },
+      {
+        "name": "Concu",
+        "lang": "scn"
+      },
+      {
+        "name": "Công-gô",
+        "lang": "vi"
+      },
+      {
+        "name": "Công-gô (Congo)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Cộng hoà Congo",
+        "lang": "vi"
+      },
+      {
+        "name": "Congo",
+        "lang": "da"
+      },
+      {
+        "isShortName": true,
+        "name": "Congo",
+        "lang": "en"
+      },
+      {
+        "name": "Congo",
+        "lang": "gl"
+      },
+      {
+        "name": "Congo",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "isShortName": true,
+        "name": "Congo",
+        "lang": "it"
+      },
+      {
+        "name": "Congo",
+        "lang": "ms"
+      },
+      {
+        "isShortName": true,
+        "name": "Congo",
+        "lang": "pt"
+      },
+      {
+        "name": "Congo",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Congo",
+        "lang": "ro"
+      },
+      {
+        "name": "Còngo",
+        "lang": "pms"
+      },
+      {
+        "name": "Congo - Brazzaville",
+        "isPreferredName": true,
+        "lang": "ca"
+      },
+      {
+        "name": "Congo (Brazzaville)",
+        "lang": "en"
+      },
+      {
+        "name": "Congo-Brazzaville",
+        "isPreferredName": true,
+        "lang": "da"
+      },
+      {
+        "name": "Congo-Brazzaville",
+        "lang": "en"
+      },
+      {
+        "name": "Congo-Brazzaville",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "name": "Congo-Brazzaville",
+        "lang": "nl"
+      },
+      {
+        "name": "Còngo - Brazzaville",
+        "isPreferredName": true,
+        "lang": "oc"
+      },
+      {
+        "name": "Congo [República]",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Congo [Republiek]",
+        "isPreferredName": true,
+        "lang": "nl"
+      },
+      {
+        "name": "e-Congo [Republic]",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Republic_of_the_Congo",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%A0%D0%B5%D1%81%D0%BF%D1%83%D0%B1%D0%BB%D0%B8%D0%BA%D0%B0_%D0%9A%D0%BE%D0%BD%D0%B3%D0%BE",
+        "lang": "link"
+      },
+      {
+        "name": "Jamhuri ya Kongo",
+        "lang": "sw"
+      },
+      {
+        "name": "Khongo",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Kongas",
+        "lang": "lt"
+      },
+      {
+        "name": "Kongo",
+        "lang": "af"
+      },
+      {
+        "name": "Kongo",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Kongo",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Kongo",
+        "isPreferredName": true,
+        "lang": "bs"
+      },
+      {
+        "name": "Kongo",
+        "lang": "de"
+      },
+      {
+        "name": "Kongo",
+        "lang": "et"
+      },
+      {
+        "name": "Kongo",
+        "lang": "eu"
+      },
+      {
+        "name": "Kongo",
+        "isPreferredName": true,
+        "lang": "fi"
+      },
+      {
+        "name": "Kongo",
+        "lang": "fo"
+      },
+      {
+        "name": "Kongo",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Kongo",
+        "lang": "hr"
+      },
+      {
+        "name": "Kongo",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Kongo",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Kongo",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Kongo",
+        "lang": "lv"
+      },
+      {
+        "name": "Kongo",
+        "lang": "mt"
+      },
+      {
+        "name": "Kongo",
+        "lang": "pl"
+      },
+      {
+        "name": "Kongo",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Kongo",
+        "lang": "sk"
+      },
+      {
+        "name": "Kongo",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Kongo",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Kongo",
+        "lang": "sq"
+      },
+      {
+        "name": "Kongo",
+        "lang": "sv"
+      },
+      {
+        "name": "Kongo",
+        "lang": "sw"
+      },
+      {
+        "name": "Kongo",
+        "lang": "tr"
+      },
+      {
+        "name": "Kongó",
+        "isPreferredName": true,
+        "lang": "is"
+      },
+      {
+        "name": "Kôngô",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Kongö",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Kongoän",
+        "lang": "vo"
+      },
+      {
+        "name": "Kongo Brazavila",
+        "lang": "eo"
+      },
+      {
+        "name": "Kongo - Brazzaville",
+        "isPreferredName": true,
+        "lang": "tr"
+      },
+      {
+        "name": "Kongo-Brazzaville",
+        "isPreferredName": true,
+        "lang": "et"
+      },
+      {
+        "name": "Kongo-Brazzaville",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Kongo-Brazzaville",
+        "isPreferredName": true,
+        "lang": "lv"
+      },
+      {
+        "name": "Kongo-Brazzaville",
+        "isPreferredName": true,
+        "lang": "nn"
+      },
+      {
+        "isShortName": true,
+        "name": "Kongo-Brazzaville",
+        "lang": "no"
+      },
+      {
+        "name": "Kongo-Brazzaville",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Kongo-Brazzaville",
+        "lang": "sv"
+      },
+      {
+        "name": "Kongo Cumhuriyeti",
+        "lang": "tr"
+      },
+      {
+        "name": "Kongói Köztársaság",
+        "lang": "hu"
+      },
+      {
+        "name": "Kongoko Errepublika",
+        "lang": "eu"
+      },
+      {
+        "name": "Kongó [Köztársaság]",
+        "isPreferredName": true,
+        "lang": "hu"
+      },
+      {
+        "name": "Kongolo",
+        "lang": "eo"
+      },
+      {
+        "name": "Kongon tasavalta",
+        "lang": "fi"
+      },
+      {
+        "name": "Kongo repɔblik nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Kongo - Republik",
+        "isPreferredName": true,
+        "lang": "id"
+      },
+      {
+        "name": "Kongo [Republik]",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Kongo [Republika]",
+        "isPreferredName": true,
+        "lang": "cs"
+      },
+      {
+        "name": "Kongo [Republika]",
+        "isPreferredName": true,
+        "lang": "sl"
+      },
+      {
+        "name": "Kongo (Republik Kongo)",
+        "isPreferredName": true,
+        "lang": "de"
+      },
+      {
+        "name": "Kongo Respublika",
+        "lang": "lt"
+      },
+      {
+        "name": "Kongo Vabariik",
+        "lang": "et"
+      },
+      {
+        "name": "Kongu",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Konngo",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Konqo - Brazavil",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Lipapilika Kongo",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Middle Congo"
+      },
+      {
+        "name": "Moyen-Congo"
+      },
+      {
+        "name": "Orílẹ́ède Kóngò",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Repoblek Kongo",
+        "lang": "kw"
+      },
+      {
+        "name": "Repubblica del Congo",
+        "lang": "it"
+      },
+      {
+        "name": "Repubilika ya Kongo",
+        "lang": "kg"
+      },
+      {
+        "name": "Republica Congo",
+        "lang": "ro"
+      },
+      {
+        "name": "Republica de Còngo",
+        "lang": "oc"
+      },
+      {
+        "name": "Republica del Congo",
+        "lang": "ia"
+      },
+      {
+        "name": "República del Congo",
+        "lang": "ca"
+      },
+      {
+        "name": "República del Congo",
+        "lang": "es"
+      },
+      {
+        "name": "Republica del Congò",
+        "lang": "oc"
+      },
+      {
+        "name": "Republica d'o Congo",
+        "lang": "an"
+      },
+      {
+        "name": "Rèpublica du Congô",
+        "lang": "frp"
+      },
+      {
+        "name": "Republic of the Congo",
+        "isPreferredName": true,
+        "lang": "en"
+      },
+      {
+        "name": "Republic of the Congo",
+        "lang": "pam"
+      },
+      {
+        "name": "Republiek van die Kongo",
+        "lang": "af"
+      },
+      {
+        "name": "Republika e Kongos",
+        "lang": "sq"
+      },
+      {
+        "name": "Republika Konga",
+        "lang": "pl"
+      },
+      {
+        "name": "Republika Kongo",
+        "lang": "bs"
+      },
+      {
+        "name": "Republika Kongo",
+        "lang": "cs"
+      },
+      {
+        "name": "Republika Kongo",
+        "lang": "hr"
+      },
+      {
+        "name": "Republika Kongo",
+        "lang": "sl"
+      },
+      {
+        "name": "Republika ng Congo",
+        "lang": "tl"
+      },
+      {
+        "name": "Republik Congo",
+        "lang": "ms"
+      },
+      {
+        "name": "Republik Congo",
+        "lang": "na"
+      },
+      {
+        "name": "Republiken Kongo",
+        "lang": "sv"
+      },
+      {
+        "name": "Republiki ya Kɔ́ngɔ",
+        "lang": "ln"
+      },
+      {
+        "name": "Republikken Congo",
+        "lang": "da"
+      },
+      {
+        "name": "Republikken Kongo",
+        "isPreferredName": true,
+        "lang": "nb"
+      },
+      {
+        "name": "Republikken Kongo",
+        "lang": "no"
+      },
+      {
+        "name": "Republik Kongo",
+        "lang": "de"
+      },
+      {
+        "name": "Republik Kongo",
+        "lang": "id"
+      },
+      {
+        "name": "Republik Kongo",
+        "lang": "nds"
+      },
+      {
+        "name": "Republiko Kongo",
+        "lang": "io"
+      },
+      {
+        "name": "République du Congo",
+        "lang": "fr"
+      },
+      {
+        "name": "République Populaire du Congo"
+      },
+      {
+        "name": "Respublica Congensis",
+        "lang": "la"
+      },
+      {
+        "name": "Vestur-Kongó",
+        "lang": "is"
+      },
+      {
+        "name": "Y Congo [Gweriniaeth]",
+        "isPreferredName": true,
+        "lang": "cy"
+      },
+      {
+        "name": "الكونغو",
+        "lang": "ar"
+      },
+      {
+        "name": "الكونغو - برازافيل",
+        "isPreferredName": true,
+        "lang": "ar"
+      },
+      {
+        "name": "جمهوری کنگو",
+        "lang": "fa"
+      },
+      {
+        "name": "جمهورية الكونغو",
+        "lang": "ar"
+      },
+      {
+        "name": "د کانګو جمهوريت",
+        "lang": "ps"
+      },
+      {
+        "name": "كونگو",
+        "lang": "ug"
+      },
+      {
+        "name": "کانگو [جمہوریہ]",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "کۆماری کۆنگۆ",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "کنگو [جمهوری]",
+        "isPreferredName": true,
+        "lang": "fa"
+      },
+      {
+        "name": "הרפובליקה של קונגו",
+        "lang": "he"
+      },
+      {
+        "name": "קונגו - ברזאויל",
+        "isPreferredName": true,
+        "lang": "he"
+      },
+      {
+        "name": "Δημοκρατία του Κονγκό",
+        "lang": "el"
+      },
+      {
+        "name": "Κονγκό - Μπραζαβίλ",
+        "isPreferredName": true,
+        "lang": "el"
+      },
+      {
+        "name": "Конга",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Конго",
+        "lang": "bg"
+      },
+      {
+        "name": "Конго",
+        "lang": "ru"
+      },
+      {
+        "name": "Конго",
+        "lang": "uk"
+      },
+      {
+        "name": "Конґо",
+        "lang": "uk"
+      },
+      {
+        "name": "Конго - Бразавил",
+        "isPreferredName": true,
+        "lang": "mk"
+      },
+      {
+        "name": "Конго - Бразавил",
+        "isPreferredName": true,
+        "lang": "sr"
+      },
+      {
+        "name": "Конґо - Браззавіль",
+        "isPreferredName": true,
+        "lang": "uk"
+      },
+      {
+        "name": "Република Конго",
+        "lang": "bg"
+      },
+      {
+        "name": "Република Конго",
+        "lang": "sr"
+      },
+      {
+        "name": "Республика Конго",
+        "lang": "ru"
+      },
+      {
+        "name": "Կոնգո",
+        "lang": "hy"
+      },
+      {
+        "name": "კონგო",
+        "lang": "ka"
+      },
+      {
+        "name": "कांगो",
+        "lang": "hi"
+      },
+      {
+        "name": "काँगो - ब्राजाविले",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "कोङ्गो - ब्राज्जाभिल्ले",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "कोंगो",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "કોંગો - બ્રાઝાવિલે",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "కాంగో[గణరాజ్యం]",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಕಾಂಗೋ [ರಿಪಬ್ಲಿಕ್‌]",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "காங்கோ [குடியரசு]",
+        "isPreferredName": true,
+        "lang": "ta"
+      },
+      {
+        "name": "കോംഗോ - ബ്രാസാവില്‍",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "কঙ্গো",
+        "lang": "bn"
+      },
+      {
+        "name": "කොංගෝව",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "コンゴ共和国",
+        "lang": "ja"
+      },
+      {
+        "name": "刚果",
+        "lang": "zh"
+      },
+      {
+        "name": "刚果共和国",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Republic of the Congo",
+    "adminCode1": "00",
+    "lng": "15.5",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 1,
+      "gmtOffset": 1,
+      "timeZoneId": "Africa/Brazzaville"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -5.027223,
+      "east": 18.649839,
+      "north": 3.703082,
+      "west": 11.205009
+    },
+    "name": "Congo",
+    "fcode": "PCLI",
+    "geonameId": 2260494,
+    "asciiName": "Republic of the Congo",
+    "lat": "-1",
+    "population": 3039126,
+    "adminName1": "",
+    "countryId": "2260494",
+    "fclName": "country, state, region,...",
+    "countryCode": "CG",
+    "srtm3": 396,
+    "wikipediaURL": "en.wikipedia.org/wiki/Republic_of_the_Congo",
+    "toponymName": "Republic of the Congo",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Angola": 3351879,
+  "3351879": {
+    "alternateNames": [
+      {
+        "name": "앙골라",
+        "lang": "ko"
+      },
+      {
+        "name": "አንጎላ",
+        "lang": "am"
+      },
+      {
+        "name": "አንጐላ",
+        "lang": "am"
+      },
+      {
+        "name": "አንጐላ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "アンゴラ",
+        "lang": "ja"
+      },
+      {
+        "name": "ଆଙ୍ଗୋଲା",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "แองโกลา",
+        "lang": "th"
+      },
+      {
+        "name": "ອັນໂກລາ",
+        "lang": "lo"
+      },
+      {
+        "name": "ཨང་གཽ་ལ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "អាង់កូឡា",
+        "lang": "km"
+      },
+      {
+        "name": "អង់ហ្គោឡា",
+        "lang": "km"
+      },
+      {
+        "name": "ประเทศแองโกลา",
+        "lang": "th"
+      },
+      {
+        "name": "África Ocidental Portuguesa"
+      },
+      {
+        "name": "Ăng-gô-la",
+        "lang": "vi"
+      },
+      {
+        "name": "Ăng-gô-la (Angola)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Angola",
+        "lang": "af"
+      },
+      {
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Angola",
+        "lang": "an"
+      },
+      {
+        "name": "Angola",
+        "lang": "ast"
+      },
+      {
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Angola",
+        "lang": "bs"
+      },
+      {
+        "name": "Angola",
+        "lang": "ca"
+      },
+      {
+        "name": "Angola",
+        "lang": "cs"
+      },
+      {
+        "name": "Angola",
+        "lang": "cy"
+      },
+      {
+        "name": "Angola",
+        "lang": "da"
+      },
+      {
+        "name": "Angola",
+        "lang": "de"
+      },
+      {
+        "isShortName": true,
+        "name": "Angola",
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Angola",
+        "lang": "et"
+      },
+      {
+        "name": "Angola",
+        "lang": "eu"
+      },
+      {
+        "name": "Angola",
+        "lang": "fi"
+      },
+      {
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "name": "Angola",
+        "lang": "fr"
+      },
+      {
+        "name": "Angola",
+        "lang": "gd"
+      },
+      {
+        "name": "Angola",
+        "lang": "gl"
+      },
+      {
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Angola",
+        "lang": "hbs"
+      },
+      {
+        "name": "Angola",
+        "lang": "hr"
+      },
+      {
+        "name": "Angola",
+        "lang": "ht"
+      },
+      {
+        "name": "Angola",
+        "lang": "hu"
+      },
+      {
+        "name": "Angola",
+        "lang": "ia"
+      },
+      {
+        "name": "Angola",
+        "lang": "id"
+      },
+      {
+        "name": "Angola",
+        "lang": "io"
+      },
+      {
+        "name": "Angola",
+        "lang": "it"
+      },
+      {
+        "name": "Angola",
+        "lang": "jv"
+      },
+      {
+        "name": "Angola",
+        "lang": "kg"
+      },
+      {
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Angola",
+        "lang": "ku"
+      },
+      {
+        "name": "Angola",
+        "lang": "kw"
+      },
+      {
+        "name": "Angola",
+        "lang": "lb"
+      },
+      {
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Angola",
+        "lang": "li"
+      },
+      {
+        "name": "Angola",
+        "lang": "lt"
+      },
+      {
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Angola",
+        "lang": "lv"
+      },
+      {
+        "name": "Angola",
+        "lang": "mg"
+      },
+      {
+        "name": "Angola",
+        "lang": "ms"
+      },
+      {
+        "name": "Angola",
+        "lang": "mt"
+      },
+      {
+        "name": "Angola",
+        "lang": "na"
+      },
+      {
+        "name": "Angola",
+        "lang": "nb"
+      },
+      {
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Angola",
+        "lang": "nds"
+      },
+      {
+        "name": "Angola",
+        "lang": "nl"
+      },
+      {
+        "name": "Angola",
+        "lang": "nn"
+      },
+      {
+        "name": "Angola",
+        "lang": "no"
+      },
+      {
+        "name": "Angola",
+        "lang": "pam"
+      },
+      {
+        "name": "Angola",
+        "lang": "pl"
+      },
+      {
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "pt"
+      },
+      {
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Angola",
+        "lang": "ro"
+      },
+      {
+        "name": "Angola",
+        "lang": "scn"
+      },
+      {
+        "name": "Angola",
+        "lang": "se"
+      },
+      {
+        "name": "Angola",
+        "lang": "sk"
+      },
+      {
+        "name": "Angola",
+        "lang": "sl"
+      },
+      {
+        "name": "Angola",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Angola",
+        "lang": "sq"
+      },
+      {
+        "name": "Angola",
+        "lang": "sv"
+      },
+      {
+        "name": "Angola",
+        "lang": "sw"
+      },
+      {
+        "name": "Angola",
+        "lang": "tet"
+      },
+      {
+        "name": "Angola",
+        "lang": "tl"
+      },
+      {
+        "name": "Angola",
+        "lang": "tr"
+      },
+      {
+        "name": "Angola",
+        "lang": "vi"
+      },
+      {
+        "name": "Angola"
+      },
+      {
+        "name": "Angóla",
+        "lang": "ga"
+      },
+      {
+        "name": "Angóla",
+        "isPreferredName": true,
+        "lang": "hu"
+      },
+      {
+        "name": "Angóla",
+        "lang": "is"
+      },
+      {
+        "name": "Angóla",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Angòla",
+        "lang": "oc"
+      },
+      {
+        "name": "Angòla",
+        "lang": "pms"
+      },
+      {
+        "name": "Angoläa",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Angola nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Angolë",
+        "lang": "sq"
+      },
+      {
+        "name": "Angolia",
+        "lang": "la"
+      },
+      {
+        "name": "Angolo",
+        "lang": "eo"
+      },
+      {
+        "name": "Angoola",
+        "lang": "so"
+      },
+      {
+        "name": "Anngolaa",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Colónia de Angola"
+      },
+      {
+        "name": "ʻEnikola",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Estado de Angola"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Angola",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%90%D0%BD%D0%B3%D0%BE%D0%BB%D0%B0",
+        "lang": "link"
+      },
+      {
+        "name": "i-Angola",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Langolän",
+        "lang": "vo"
+      },
+      {
+        "name": "Ngola",
+        "lang": "kg"
+      },
+      {
+        "name": "Orílẹ́ède Ààngólà",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "People’s Republic of Angola"
+      },
+      {
+        "name": "Portugiesisch Westafrika"
+      },
+      {
+        "name": "Portuguese West Africa"
+      },
+      {
+        "name": "Província de Angola"
+      },
+      {
+        "name": "República de Angola",
+        "lang": "pt"
+      },
+      {
+        "name": "República Popular de Angola"
+      },
+      {
+        "name": "Republic of Angola",
+        "lang": "en"
+      },
+      {
+        "name": "أنجولا",
+        "isPreferredName": true,
+        "lang": "ar"
+      },
+      {
+        "name": "أنغولا",
+        "lang": "ar"
+      },
+      {
+        "name": "انغولا",
+        "lang": "ar"
+      },
+      {
+        "name": "آنگولا",
+        "lang": "fa"
+      },
+      {
+        "name": "انگولا",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "آنګولا",
+        "lang": "ps"
+      },
+      {
+        "name": "انګولا",
+        "lang": "ps"
+      },
+      {
+        "name": "ئانگولا",
+        "lang": "ug"
+      },
+      {
+        "name": "ئەنگۆلا",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "אנגולה",
+        "lang": "he"
+      },
+      {
+        "name": "Αγκόλα",
+        "lang": "el"
+      },
+      {
+        "name": "Ανγκόλα",
+        "lang": "el"
+      },
+      {
+        "name": "Ангола",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Ангола",
+        "lang": "bg"
+      },
+      {
+        "name": "Ангола",
+        "lang": "cv"
+      },
+      {
+        "name": "Ангола",
+        "isPreferredName": true,
+        "lang": "kk"
+      },
+      {
+        "name": "Ангола",
+        "lang": "mk"
+      },
+      {
+        "name": "Ангола",
+        "lang": "ru"
+      },
+      {
+        "name": "Ангола",
+        "lang": "sr"
+      },
+      {
+        "name": "Ангола",
+        "lang": "tg"
+      },
+      {
+        "name": "Ангола",
+        "lang": "uk"
+      },
+      {
+        "name": "Анґола",
+        "lang": "be"
+      },
+      {
+        "name": "Анґола",
+        "lang": "uk"
+      },
+      {
+        "name": "Անգոլա",
+        "lang": "hy"
+      },
+      {
+        "name": "ანგოლა",
+        "lang": "ka"
+      },
+      {
+        "name": "अङ्गोला",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "अंगोला",
+        "lang": "hi"
+      },
+      {
+        "name": "अंगोला",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "अंगोला",
+        "lang": "sa"
+      },
+      {
+        "name": "अँगोला",
+        "lang": "mr"
+      },
+      {
+        "name": "અંગોલા",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "అంగోలా",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಅಂಗೋಲಾ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "அங்கோலா",
+        "lang": "ta"
+      },
+      {
+        "name": "അംഗോള",
+        "lang": "ml"
+      },
+      {
+        "name": "অ্যাঙ্গোলা",
+        "lang": "bn"
+      },
+      {
+        "name": "এঙ্গোলা",
+        "lang": "bn"
+      },
+      {
+        "name": "এ্যাঙ্গোলা",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "အင်ဂိုလာ",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "ඇන්ගෝලාව",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "アンゴラ共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "安哥拉",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Angola",
+    "adminCode1": "00",
+    "lng": "18.5",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 1,
+      "gmtOffset": 1,
+      "timeZoneId": "Africa/Luanda"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -18.042076,
+      "east": 24.082119,
+      "north": -4.376826,
+      "west": 11.679219
+    },
+    "name": "Angola",
+    "fcode": "PCLI",
+    "geonameId": 3351879,
+    "asciiName": "Republic of Angola",
+    "lat": "-12.5",
+    "population": 13068161,
+    "adminName1": "",
+    "countryId": "3351879",
+    "fclName": "country, state, region,...",
+    "countryCode": "AO",
+    "srtm3": 1355,
+    "wikipediaURL": "en.wikipedia.org/wiki/Angola",
+    "toponymName": "Republic of Angola",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Benin": 2395170,
+  "2395170": {
+    "alternateNames": [
+      {
+        "name": "베냉",
+        "lang": "ko"
+      },
+      {
+        "name": "베넹",
+        "lang": "ko"
+      },
+      {
+        "name": "ቤኒን",
+        "lang": "am"
+      },
+      {
+        "name": "ቤኒን",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ベナン",
+        "lang": "ja"
+      },
+      {
+        "name": "ベニン",
+        "lang": "ja"
+      },
+      {
+        "name": "เบนิน",
+        "lang": "th"
+      },
+      {
+        "name": "ເບນິນ",
+        "lang": "lo"
+      },
+      {
+        "name": "ବେନିନ୍",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "បេណាំង",
+        "lang": "km"
+      },
+      {
+        "name": "བཱེ་ནིན།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ประเทศเบนิน",
+        "lang": "th"
+      },
+      {
+        "name": "Beinin",
+        "lang": "ga"
+      },
+      {
+        "name": "Beinin",
+        "lang": "gd"
+      },
+      {
+        "name": "Bê-nanh",
+        "lang": "vi"
+      },
+      {
+        "name": "Bê-nanh (Benin)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Bene",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Bene",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Benɛ",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Benee",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Benëen",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Benen",
+        "lang": "ht"
+      },
+      {
+        "name": "Benɛn",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Benim",
+        "lang": "pt"
+      },
+      {
+        "name": "Benin",
+        "lang": "af"
+      },
+      {
+        "name": "Benin",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Benin",
+        "lang": "br"
+      },
+      {
+        "name": "Benin",
+        "lang": "bs"
+      },
+      {
+        "isShortName": true,
+        "name": "Benin",
+        "isPreferredName": true,
+        "lang": "ca"
+      },
+      {
+        "name": "Benin",
+        "lang": "cs"
+      },
+      {
+        "name": "Benin",
+        "lang": "cy"
+      },
+      {
+        "name": "Benin",
+        "lang": "da"
+      },
+      {
+        "name": "Benin",
+        "lang": "de"
+      },
+      {
+        "isShortName": true,
+        "name": "Benin",
+        "lang": "en"
+      },
+      {
+        "name": "Benin",
+        "lang": "et"
+      },
+      {
+        "name": "Benin",
+        "lang": "eu"
+      },
+      {
+        "name": "Benin",
+        "lang": "fi"
+      },
+      {
+        "name": "Benin",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "name": "Benin",
+        "lang": "fr"
+      },
+      {
+        "name": "Benin",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Benin",
+        "lang": "hbs"
+      },
+      {
+        "name": "Benin",
+        "lang": "hr"
+      },
+      {
+        "name": "Benin",
+        "lang": "hu"
+      },
+      {
+        "name": "Benin",
+        "lang": "ia"
+      },
+      {
+        "name": "Benin",
+        "lang": "id"
+      },
+      {
+        "name": "Benin",
+        "lang": "io"
+      },
+      {
+        "name": "Benin",
+        "lang": "it"
+      },
+      {
+        "name": "Benin",
+        "lang": "kw"
+      },
+      {
+        "name": "Benin",
+        "lang": "li"
+      },
+      {
+        "name": "Benin",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Benin",
+        "lang": "ms"
+      },
+      {
+        "name": "Benin",
+        "lang": "mt"
+      },
+      {
+        "name": "Benin",
+        "lang": "na"
+      },
+      {
+        "name": "Benin",
+        "lang": "nb"
+      },
+      {
+        "name": "Benin",
+        "lang": "nds"
+      },
+      {
+        "name": "Benin",
+        "lang": "nl"
+      },
+      {
+        "name": "Benin",
+        "lang": "nn"
+      },
+      {
+        "name": "Benin",
+        "lang": "no"
+      },
+      {
+        "name": "Benin",
+        "lang": "oc"
+      },
+      {
+        "name": "Benin",
+        "lang": "pam"
+      },
+      {
+        "name": "Benin",
+        "lang": "pl"
+      },
+      {
+        "name": "Benin",
+        "lang": "pt"
+      },
+      {
+        "name": "Benin",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Benin",
+        "lang": "ro"
+      },
+      {
+        "name": "Benin",
+        "lang": "scn"
+      },
+      {
+        "name": "Benin",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Benin",
+        "lang": "sk"
+      },
+      {
+        "name": "Benin",
+        "lang": "sl"
+      },
+      {
+        "name": "Benin",
+        "lang": "sv"
+      },
+      {
+        "name": "Benin",
+        "lang": "sw"
+      },
+      {
+        "name": "Benin",
+        "lang": "tl"
+      },
+      {
+        "name": "Benin",
+        "lang": "tr"
+      },
+      {
+        "name": "Benin"
+      },
+      {
+        "name": "Bénin",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "name": "Bénin",
+        "lang": "vi"
+      },
+      {
+        "name": "Bénin"
+      },
+      {
+        "name": "Bènin",
+        "lang": "frp"
+      },
+      {
+        "name": "Bɛnin",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Benín",
+        "lang": "an"
+      },
+      {
+        "name": "Benín",
+        "lang": "ast"
+      },
+      {
+        "name": "Benín",
+        "lang": "ca"
+      },
+      {
+        "isShortName": true,
+        "name": "Benín",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Benín",
+        "lang": "gl"
+      },
+      {
+        "name": "Benín",
+        "lang": "is"
+      },
+      {
+        "name": "Bênîn",
+        "lang": "ku"
+      },
+      {
+        "name": "Benina",
+        "lang": "lv"
+      },
+      {
+        "name": "Beninän",
+        "lang": "vo"
+      },
+      {
+        "name": "Beninas",
+        "lang": "lt"
+      },
+      {
+        "name": "Benini",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Benini",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Benini",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Benini",
+        "lang": "sq"
+      },
+      {
+        "name": "Benini",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Benin nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Benino",
+        "lang": "eo"
+      },
+      {
+        "name": "Beninum",
+        "lang": "la"
+      },
+      {
+        "name": "Bhenini",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Biniin",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Binin",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Binin",
+        "isPreferredName": true,
+        "lang": "ig"
+      },
+      {
+        "name": "Dahome"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Benin",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%91%D0%B5%D0%BD%D0%B8%D0%BD",
+        "lang": "link"
+      },
+      {
+        "name": "i-Benin",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Orílẹ́ède Bẹ̀nẹ̀",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Penini",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "People’s Republic of Benin"
+      },
+      {
+        "name": "República de Benín",
+        "lang": "gl"
+      },
+      {
+        "name": "Republic of Benin",
+        "lang": "en"
+      },
+      {
+        "name": "Republic of Dahomey"
+      },
+      {
+        "name": "République du Bénin",
+        "lang": "fr"
+      },
+      {
+        "name": "République du Dahomey"
+      },
+      {
+        "name": "République Populaire du Bénin"
+      },
+      {
+        "name": "بینن",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "بنین",
+        "lang": "fa"
+      },
+      {
+        "name": "بنین",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "بېنىن",
+        "lang": "ug"
+      },
+      {
+        "name": "بنين",
+        "lang": "ar"
+      },
+      {
+        "name": "בנין",
+        "lang": "he"
+      },
+      {
+        "name": "Μπένιν",
+        "lang": "el"
+      },
+      {
+        "name": "Μπενίν",
+        "lang": "el"
+      },
+      {
+        "name": "Бенин",
+        "lang": "bg"
+      },
+      {
+        "name": "Бенин",
+        "lang": "cv"
+      },
+      {
+        "name": "Бенин",
+        "isPreferredName": true,
+        "lang": "kk"
+      },
+      {
+        "name": "Бенин",
+        "lang": "mk"
+      },
+      {
+        "name": "Бенин",
+        "lang": "ru"
+      },
+      {
+        "name": "Бенин",
+        "lang": "sr"
+      },
+      {
+        "name": "Бенин",
+        "lang": "tg"
+      },
+      {
+        "name": "Бенин",
+        "lang": "udm"
+      },
+      {
+        "name": "Бенін",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Бенін",
+        "lang": "uk"
+      },
+      {
+        "name": "Բենին",
+        "lang": "hy"
+      },
+      {
+        "name": "ბენინი",
+        "lang": "ka"
+      },
+      {
+        "name": "बेनिन",
+        "lang": "hi"
+      },
+      {
+        "name": "बेनिन",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "बेनिन",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "બેનિન",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "బెనిన్",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಬೆನಿನ್",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "பெனின்",
+        "lang": "ta"
+      },
+      {
+        "name": "ബെനിന്‍",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "বেনিন",
+        "lang": "bn"
+      },
+      {
+        "name": "බෙනින්",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "ベニン共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "贝宁",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Benin",
+    "adminCode1": "00",
+    "lng": "2.25",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 1,
+      "gmtOffset": 1,
+      "timeZoneId": "Africa/Porto-Novo"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 6.225748,
+      "east": 3.851701,
+      "north": 12.418347,
+      "west": 0.774575
+    },
+    "name": "Benin",
+    "fcode": "PCLI",
+    "geonameId": 2395170,
+    "asciiName": "Republic of Benin",
+    "lat": "9.5",
+    "population": 9056010,
+    "adminName1": "",
+    "countryId": "2395170",
+    "fclName": "country, state, region,...",
+    "countryCode": "BJ",
+    "srtm3": 334,
+    "wikipediaURL": "en.wikipedia.org/wiki/Benin",
+    "toponymName": "Republic of Benin",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Burkina Faso": 2361809,
+  "2361809": {
+    "alternateNames": [
+      {
+        "name": "ቡርኪና ፋሶ",
+        "lang": "am"
+      },
+      {
+        "name": "ቡርኪና ፋሶ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "부르키나 파소",
+        "isPreferredName": true,
+        "lang": "ko"
+      },
+      {
+        "name": "ބުރުކީނާ ފާސޯ",
+        "lang": "dv"
+      },
+      {
+        "name": "부르키나파소",
+        "lang": "ko"
+      },
+      {
+        "name": "ブルキナファソ",
+        "lang": "ja"
+      },
+      {
+        "name": "ବୁରକିନା ଫାସୋ",
+        "lang": "or"
+      },
+      {
+        "name": "བརཀི་ན། ཕསོ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ବୁର୍କିନୋ ଫାସୋ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "ເບີກິນາຟາໂຊ",
+        "lang": "lo"
+      },
+      {
+        "name": "บูร์กินาฟาโซ",
+        "lang": "th"
+      },
+      {
+        "name": "བུར་ཀི་ན་ཕ་སོ།",
+        "lang": "bo"
+      },
+      {
+        "name": "ប៊ូរគីណាហ្វាសូ",
+        "lang": "km"
+      },
+      {
+        "name": "ประเทศบูร์กินาฟาโซ",
+        "lang": "th"
+      },
+      {
+        "name": "Bhukina Faso",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Boerkina Fasso",
+        "lang": "af"
+      },
+      {
+        "name": "Bɔkina Faso",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Borkėna Fasos",
+        "lang": "sgs"
+      },
+      {
+        "name": "Borkina Faso",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Bòrkinn-a Fäso",
+        "lang": "lij"
+      },
+      {
+        "name": "Boukinafaso",
+        "lang": "ht"
+      },
+      {
+        "name": "Buircíne Fasó",
+        "lang": "ga"
+      },
+      {
+        "name": "Buirciona Faso",
+        "lang": "gd"
+      },
+      {
+        "name": "Bukinafaso",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Bukinafaso",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Bukinafaso",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Bukinafaso",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Bukina Faso",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Buốc-ki-na Pha-xô",
+        "lang": "vi"
+      },
+      {
+        "name": "Buốc-ki-na Pha-xô (Burkina Faso)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Burakina Faso",
+        "lang": "haw"
+      },
+      {
+        "name": "Burchina Fasu",
+        "lang": "scn"
+      },
+      {
+        "name": "Burcina Faso",
+        "lang": "la"
+      },
+      {
+        "name": "Burkibaa Faaso",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Burkiina Faaso",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Burkina",
+        "lang": "sk"
+      },
+      {
+        "name": "Burkina"
+      },
+      {
+        "name": "Burkinaa Faaso",
+        "lang": "wo"
+      },
+      {
+        "name": "Burkinabato",
+        "lang": "na"
+      },
+      {
+        "name": "Burkina Fasas",
+        "lang": "lt"
+      },
+      {
+        "name": "Burkinafaso",
+        "lang": "lv"
+      },
+      {
+        "name": "Burkina faso",
+        "lang": "ha"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "af"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "an"
+      },
+      {
+        "name": "Burkina Faso",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Burkina Faso",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "bs"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "ca"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "cs"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "cy"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "da"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "de"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Burkina Faso",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "et"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "eu"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "fi"
+      },
+      {
+        "name": "Burkina Faso",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "fr"
+      },
+      {
+        "name": "Burkina Faso",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Burkina Faso",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "hbs"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "hr"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "hu"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "ia"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "id"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "ilo"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "io"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "it"
+      },
+      {
+        "name": "Burkina Faso",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "kw"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "li"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "ms"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "mt"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "nb"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "nds"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "nl"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "nn"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "no"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "oc"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "pam"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "pl"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "pt"
+      },
+      {
+        "name": "Burkina Faso",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "ro"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "se"
+      },
+      {
+        "name": "Burkina Faso",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "sk"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "sl"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "sq"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "sv"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "sw"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "tl"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "tr"
+      },
+      {
+        "name": "Burkina Faso",
+        "lang": "vi"
+      },
+      {
+        "name": "Burkina Faso"
+      },
+      {
+        "name": "Burkina-Faso",
+        "lang": "az"
+      },
+      {
+        "name": "Burkina-Faso",
+        "lang": "tk"
+      },
+      {
+        "name": "Bûrkina Faso",
+        "lang": "fy"
+      },
+      {
+        "name": "Burkîna Faso",
+        "lang": "ku"
+      },
+      {
+        "name": "Burkína Fasó",
+        "isPreferredName": true,
+        "lang": "is"
+      },
+      {
+        "name": "Búrkína Fasó",
+        "lang": "is"
+      },
+      {
+        "name": "Bùrkínà Fasò",
+        "lang": "yo"
+      },
+      {
+        "name": "Burkina Fasô",
+        "lang": "frp"
+      },
+      {
+        "name": "Burkina Faso nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Burkina Fasso",
+        "isPreferredName": true,
+        "lang": "pt"
+      },
+      {
+        "name": "Burkina Fasso",
+        "isPreferredName": true,
+        "lang": "ro"
+      },
+      {
+        "name": "Burkina Fasso (Alto Volta)",
+        "lang": "es"
+      },
+      {
+        "name": "Burkina Fasu",
+        "lang": "ast"
+      },
+      {
+        "name": "Burkinän",
+        "lang": "vo"
+      },
+      {
+        "name": "Burkina Paso",
+        "lang": "bjn"
+      },
+      {
+        "name": "Burkina Phasu",
+        "lang": "qu"
+      },
+      {
+        "name": "Burkino",
+        "lang": "eo"
+      },
+      {
+        "name": "Burquina Faso",
+        "lang": "gl"
+      },
+      {
+        "name": "Burquina Faso",
+        "lang": "nah"
+      },
+      {
+        "name": "Burquina Faso",
+        "lang": "pt"
+      },
+      {
+        "name": "Burquina Fasu",
+        "lang": "ext"
+      },
+      {
+        "name": "Burukina Faso",
+        "lang": "bm"
+      },
+      {
+        "name": "Burukina Faso",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Burukina Faso",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Burukina Faso",
+        "lang": "rw"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Burkina_Faso",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%91%D1%83%D1%80%D0%BA%D0%B8%D0%BD%D0%B0_%D0%A4%D0%B0%D1%81%D0%BE",
+        "lang": "link"
+      },
+      {
+        "name": "IBhukhina-Faso",
+        "lang": "ss"
+      },
+      {
+        "name": "IBukhina Faso",
+        "lang": "zu"
+      },
+      {
+        "name": "i-Burkina Faso",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Orílẹ́ède Bùùkíná Fasò",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Pekano Faso",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Republic of Upper Volta"
+      },
+      {
+        "name": "République de Haute-Volta"
+      },
+      {
+        "name": "République Voltaïque"
+      },
+      {
+        "name": "Voltaic Republic"
+      },
+      {
+        "name": "Volta Republic"
+      },
+      {
+        "name": "Volta Superior"
+      },
+      {
+        "name": "بۇركىنا فاسو",
+        "lang": "ug"
+      },
+      {
+        "name": "برکینا فاسو",
+        "lang": "pnb"
+      },
+      {
+        "name": "برکینا فاسو",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "بوركينا فاسو",
+        "lang": "ar"
+      },
+      {
+        "name": "بوركينا فاسو",
+        "lang": "arz"
+      },
+      {
+        "name": "بورکینافاسۆ",
+        "lang": "ckb"
+      },
+      {
+        "name": "بورکینافاسۆ",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "بورکینا فاسو",
+        "isPreferredName": true,
+        "lang": "fa"
+      },
+      {
+        "name": "بورکینا فاسو",
+        "lang": "ps"
+      },
+      {
+        "name": "بورکینافاسو",
+        "lang": "fa"
+      },
+      {
+        "name": "בורקינה פאסו",
+        "lang": "he"
+      },
+      {
+        "name": "בורקינע פאסא",
+        "lang": "yi"
+      },
+      {
+        "name": "Μπουρκίνα Φάσο",
+        "lang": "el"
+      },
+      {
+        "name": "Буркинапасин Орн",
+        "lang": "xal"
+      },
+      {
+        "name": "Буркина Фасо",
+        "lang": "bg"
+      },
+      {
+        "name": "Буркина Фасо",
+        "lang": "ce"
+      },
+      {
+        "name": "Буркина Фасо",
+        "lang": "cv"
+      },
+      {
+        "name": "Буркина Фасо",
+        "lang": "ky"
+      },
+      {
+        "name": "Буркина Фасо",
+        "lang": "mk"
+      },
+      {
+        "name": "Буркина Фасо",
+        "lang": "mrj"
+      },
+      {
+        "name": "Буркина Фасо",
+        "lang": "os"
+      },
+      {
+        "name": "Буркина Фасо",
+        "lang": "ru"
+      },
+      {
+        "name": "Буркина Фасо",
+        "lang": "sah"
+      },
+      {
+        "name": "Буркина Фасо",
+        "lang": "sr"
+      },
+      {
+        "name": "Буркина Фасо",
+        "lang": "tg"
+      },
+      {
+        "name": "Буркина Фасо",
+        "lang": "tt"
+      },
+      {
+        "name": "Буркина-Фасо",
+        "lang": "kk"
+      },
+      {
+        "name": "Буркина-Фасо",
+        "lang": "ru"
+      },
+      {
+        "name": "Буркино-Фасо",
+        "lang": "bxr"
+      },
+      {
+        "name": "Буркіна Фасо",
+        "lang": "rue"
+      },
+      {
+        "name": "Буркіна Фасо",
+        "lang": "uk"
+      },
+      {
+        "name": "Буркіна-Фасо",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Буркіна-Фасо",
+        "lang": "uk"
+      },
+      {
+        "name": "Բուրկինա Ֆասո",
+        "lang": "hy"
+      },
+      {
+        "name": "ბურკინა ფასო",
+        "lang": "ka"
+      },
+      {
+        "name": "ბურკინა-ფასო",
+        "lang": "ka"
+      },
+      {
+        "name": "बर्किना फासो",
+        "lang": "hi"
+      },
+      {
+        "name": "बर्किना फासो",
+        "lang": "mr"
+      },
+      {
+        "name": "बर्किना फासो",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "बुर्किना फासो",
+        "lang": "hi"
+      },
+      {
+        "name": "बुर्किना फासो",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "बुर्किना फासो",
+        "lang": "ne"
+      },
+      {
+        "name": "बुर्किना फासो",
+        "lang": "new"
+      },
+      {
+        "name": "बुर्किना फ़ासो",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "बुर्कीना-फासो",
+        "lang": "ks"
+      },
+      {
+        "name": "बुर्कीना-फासो",
+        "lang": "sa"
+      },
+      {
+        "name": "બુર્કિના ફાસો",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "బర్కీనా ఫాసో",
+        "lang": "te"
+      },
+      {
+        "name": "బుర్కినా ఫాసో",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ਬੁਰਕੀਨਾ ਫ਼ਾਸੋ",
+        "lang": "pa"
+      },
+      {
+        "name": "ಬುರ್ಕಿನಾ ಫಾಸೋ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "ಬುರ್ಕೀನ ಫಾಸೊ",
+        "lang": "kn"
+      },
+      {
+        "name": "புர்கினா ஃபாஸோ",
+        "isPreferredName": true,
+        "lang": "ta"
+      },
+      {
+        "name": "புர்க்கினா பாசோ",
+        "lang": "ta"
+      },
+      {
+        "name": "ബർക്കിനാ ഫാസോ",
+        "lang": "ml"
+      },
+      {
+        "name": "ബുര്‍ക്കിനാ ഫാസോ",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "বুরকিনা ফাসো",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "বুর্কিনা ফাসো",
+        "lang": "bn"
+      },
+      {
+        "name": "বুর্কিনা ফাসো",
+        "lang": "bpy"
+      },
+      {
+        "name": "ဘာကီးနားဖားဆိုနိုင်ငံ",
+        "lang": "my"
+      },
+      {
+        "name": "බර්කිනා ෆාසෝ",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "布吉納法索",
+        "lang": "zh"
+      },
+      {
+        "name": "布基納法索",
+        "lang": "yue"
+      },
+      {
+        "name": "布基纳法索",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Burkina Faso",
+    "adminCode1": "00",
+    "lng": "-1.66667",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 0,
+      "gmtOffset": 0,
+      "timeZoneId": "Africa/Ouagadougou"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 9.401108,
+      "east": 2.405395,
+      "north": 15.082593,
+      "west": -5.518916
+    },
+    "name": "Burkina Faso",
+    "fcode": "PCLI",
+    "geonameId": 2361809,
+    "asciiName": "Burkina Faso",
+    "lat": "12.5",
+    "population": 16241811,
+    "adminName1": "",
+    "countryId": "2361809",
+    "fclName": "country, state, region,...",
+    "countryCode": "BF",
+    "srtm3": 313,
+    "wikipediaURL": "en.wikipedia.org/wiki/Burkina_Faso",
+    "toponymName": "Burkina Faso",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Cameroon": 2233387,
+  "2233387": {
+    "alternateNames": [
+      {
+        "name": "카메룬",
+        "lang": "ko"
+      },
+      {
+        "name": "ካሜሩን",
+        "lang": "am"
+      },
+      {
+        "name": "ካሜሩን",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "カメルーン",
+        "lang": "ja"
+      },
+      {
+        "name": "ຄາເມລູນ",
+        "lang": "lo"
+      },
+      {
+        "name": "កាមេរូន",
+        "lang": "km"
+      },
+      {
+        "name": "କାମେରୁନ୍",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "แคเมอรูน",
+        "lang": "th"
+      },
+      {
+        "name": "ཀ་མེ་རུན།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ประเทศแคเมอรูน",
+        "lang": "th"
+      },
+      {
+        "name": "Camarões",
+        "isPreferredName": true,
+        "lang": "pt"
+      },
+      {
+        "name": "Camarún",
+        "lang": "ga"
+      },
+      {
+        "name": "Cameron",
+        "lang": "frp"
+      },
+      {
+        "name": "Cameron",
+        "lang": "oc"
+      },
+      {
+        "name": "Cameronia",
+        "lang": "la"
+      },
+      {
+        "name": "Cameroon",
+        "isPreferredName": true,
+        "lang": "da"
+      },
+      {
+        "isShortName": true,
+        "name": "Cameroon",
+        "lang": "en"
+      },
+      {
+        "name": "Cameroon",
+        "lang": "gd"
+      },
+      {
+        "name": "Cameroon",
+        "lang": "ms"
+      },
+      {
+        "name": "Cameroon",
+        "lang": "pam"
+      },
+      {
+        "name": "Cameroon",
+        "lang": "tl"
+      },
+      {
+        "name": "Cameroon",
+        "lang": "vi"
+      },
+      {
+        "name": "Cameroon"
+      },
+      {
+        "name": "Cameroun",
+        "lang": "da"
+      },
+      {
+        "name": "Cameroun",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "name": "Cameroun"
+      },
+      {
+        "name": "Camerun",
+        "lang": "ca"
+      },
+      {
+        "name": "Camerun",
+        "lang": "ia"
+      },
+      {
+        "name": "Camerun",
+        "lang": "ilo"
+      },
+      {
+        "name": "Camerun",
+        "lang": "it"
+      },
+      {
+        "name": "Camerun",
+        "lang": "na"
+      },
+      {
+        "name": "Camerun",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Camerun",
+        "lang": "ro"
+      },
+      {
+        "name": "Camerún",
+        "lang": "an"
+      },
+      {
+        "name": "Camerún",
+        "lang": "ast"
+      },
+      {
+        "isShortName": true,
+        "name": "Camerún",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Camerún",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Camerún - Cameroun",
+        "lang": "gl"
+      },
+      {
+        "name": "Camerŵn",
+        "lang": "cy"
+      },
+      {
+        "name": "Ca-mơ-run",
+        "lang": "vi"
+      },
+      {
+        "name": "Ca-mơ-run (Cameroon)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Federal Republic of Cameroon"
+      },
+      {
+        "name": "Federation of the Camerouns"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Cameroon",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%9A%D0%B0%D0%BC%D0%B5%D1%80%D1%83%D0%BD",
+        "lang": "link"
+      },
+      {
+        "name": "i-Cameroon",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Kaameruun",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Kamaru",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Kameroen",
+        "lang": "af"
+      },
+      {
+        "name": "Kameroen",
+        "lang": "nl"
+      },
+      {
+        "name": "Kamerona",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Kameroun",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Kameroun",
+        "lang": "kw"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "az"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "bs"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "cs"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "de"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "et"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "eu"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "fi"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "fo"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "hbs"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "hr"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "hu"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "id"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "io"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "ms"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "mt"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "nb"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "nds"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "nn"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "no"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "pl"
+      },
+      {
+        "name": "Kamerun",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "sk"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "sl"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "sq"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "sv"
+      },
+      {
+        "name": "Kamerun",
+        "lang": "tr"
+      },
+      {
+        "name": "Kamɛrun",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Kamerún",
+        "lang": "is"
+      },
+      {
+        "name": "Kamerûn",
+        "lang": "ku"
+      },
+      {
+        "name": "Kamerūna",
+        "lang": "lv"
+      },
+      {
+        "name": "Kamerunän",
+        "lang": "vo"
+      },
+      {
+        "name": "Kamerūnas",
+        "lang": "lt"
+      },
+      {
+        "name": "Kamerune",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Kamɛrune",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Kamerûne",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Kameruni",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Kameruni",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Kameruni",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Kameruni",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Kameruni",
+        "lang": "sq"
+      },
+      {
+        "name": "Kameruni",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Kamerun nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Kameruno",
+        "lang": "eo"
+      },
+      {
+        "name": "Kameruun",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Kameruuni",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Kemaluni",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Khameruni",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Orílẹ́ède Kamerúúnì",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "República dos Camarões",
+        "lang": "pt"
+      },
+      {
+        "name": "Republic of Cameroon",
+        "lang": "en"
+      },
+      {
+        "name": "République du Cameroun",
+        "lang": "fr"
+      },
+      {
+        "name": "République Fédérale du Cameroun"
+      },
+      {
+        "name": "République Unie du Cameroun"
+      },
+      {
+        "name": "United Republic of Cameroon"
+      },
+      {
+        "name": "Y Camerŵn",
+        "lang": "cy"
+      },
+      {
+        "name": "الكاميرون",
+        "lang": "ar"
+      },
+      {
+        "name": "كامېرون",
+        "lang": "ug"
+      },
+      {
+        "name": "كاميرون",
+        "lang": "ar"
+      },
+      {
+        "name": "کامرون",
+        "lang": "fa"
+      },
+      {
+        "name": "کامیروون",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "کیمرون",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "کېمرون",
+        "lang": "ps"
+      },
+      {
+        "name": "קאמרון",
+        "lang": "he"
+      },
+      {
+        "name": "קמרון",
+        "lang": "he"
+      },
+      {
+        "name": "Καμερούν",
+        "lang": "el"
+      },
+      {
+        "name": "Камерун",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Камерун",
+        "lang": "bg"
+      },
+      {
+        "name": "Камерун",
+        "isPreferredName": true,
+        "lang": "kk"
+      },
+      {
+        "name": "Камерун",
+        "lang": "mk"
+      },
+      {
+        "name": "Камерун",
+        "lang": "ru"
+      },
+      {
+        "name": "Камерун",
+        "lang": "sr"
+      },
+      {
+        "name": "Камерун",
+        "lang": "tg"
+      },
+      {
+        "name": "Камерун",
+        "lang": "uk"
+      },
+      {
+        "name": "Կամերուն",
+        "lang": "hy"
+      },
+      {
+        "name": "კამერუნი",
+        "lang": "ka"
+      },
+      {
+        "name": "कामेरान",
+        "lang": "hi"
+      },
+      {
+        "name": "कामेरून",
+        "lang": "mr"
+      },
+      {
+        "name": "कॅमेरून",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "केमेरून",
+        "lang": "sa"
+      },
+      {
+        "name": "कैमरून",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "क्यामेरून",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "કૅમરૂન",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "కెమరూన్",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಕ್ಯಾಮರೂನ್",
+        "lang": "kn"
+      },
+      {
+        "name": "ಕ್ಯಾಮರೋನ್",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "கேமரூன்",
+        "lang": "ta"
+      },
+      {
+        "name": "കാമറൂണ്‍",
+        "lang": "ml"
+      },
+      {
+        "name": "ক্যামেরুন",
+        "lang": "bn"
+      },
+      {
+        "name": "ကင်မရွန်း",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "කැමරූන්",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "カメルーン共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "喀麦隆",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Cameroon",
+    "adminCode1": "00",
+    "lng": "12.5",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 1,
+      "gmtOffset": 1,
+      "timeZoneId": "Africa/Douala"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 1.652548,
+      "east": 16.192116,
+      "north": 13.078056,
+      "west": 8.494763
+    },
+    "name": "Cameroon",
+    "fcode": "PCLI",
+    "geonameId": 2233387,
+    "asciiName": "Republic of Cameroon",
+    "lat": "6",
+    "population": 19294149,
+    "adminName1": "",
+    "countryId": "2233387",
+    "fclName": "country, state, region,...",
+    "countryCode": "CM",
+    "srtm3": 720,
+    "wikipediaURL": "en.wikipedia.org/wiki/Cameroon",
+    "toponymName": "Republic of Cameroon",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Chad": 2434508,
+  "2434508": {
+    "alternateNames": [
+      {
+        "name": "ቻድ",
+        "lang": "am"
+      },
+      {
+        "name": "ቻድ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "차드",
+        "lang": "ko"
+      },
+      {
+        "name": "챠드",
+        "isPreferredName": true,
+        "lang": "ko"
+      },
+      {
+        "name": "ชาด",
+        "lang": "th"
+      },
+      {
+        "name": "ຊາດ",
+        "lang": "lo"
+      },
+      {
+        "name": "ឆាដ",
+        "lang": "km"
+      },
+      {
+        "name": "チャド",
+        "lang": "ja"
+      },
+      {
+        "name": "ଚାଦ୍",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "ཅཻཌ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ประเทศชาด",
+        "lang": "th"
+      },
+      {
+        "name": "สาธารณรัฐชาด",
+        "lang": "th"
+      },
+      {
+        "name": "Caad",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Caadi",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Cad",
+        "lang": "ms"
+      },
+      {
+        "name": "Čad",
+        "lang": "bs"
+      },
+      {
+        "name": "Čad",
+        "lang": "cs"
+      },
+      {
+        "name": "Čad",
+        "lang": "hbs"
+      },
+      {
+        "name": "Čad",
+        "lang": "hr"
+      },
+      {
+        "name": "Čad",
+        "lang": "sk"
+      },
+      {
+        "name": "Čad",
+        "lang": "sl"
+      },
+      {
+        "name": "Ċad",
+        "lang": "mt"
+      },
+      {
+        "name": "Çad",
+        "lang": "az"
+      },
+      {
+        "name": "Çad",
+        "lang": "ku"
+      },
+      {
+        "name": "Çad",
+        "lang": "sq"
+      },
+      {
+        "name": "Çad",
+        "lang": "tr"
+      },
+      {
+        "name": "Čada",
+        "lang": "lv"
+      },
+      {
+        "name": "Čadas",
+        "lang": "lt"
+      },
+      {
+        "name": "Cadi",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Cadi",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Cadi",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Çadi",
+        "lang": "sq"
+      },
+      {
+        "name": "Ĉado",
+        "lang": "eo"
+      },
+      {
+        "name": "Chad",
+        "lang": "an"
+      },
+      {
+        "name": "Chad",
+        "lang": "ang"
+      },
+      {
+        "name": "Chad",
+        "lang": "ast"
+      },
+      {
+        "name": "Chad",
+        "lang": "cy"
+      },
+      {
+        "isShortName": true,
+        "name": "Chad",
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Chad",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Chad",
+        "lang": "gd"
+      },
+      {
+        "name": "Chad",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Chad",
+        "lang": "id"
+      },
+      {
+        "name": "Chad",
+        "lang": "io"
+      },
+      {
+        "name": "Chad",
+        "lang": "jv"
+      },
+      {
+        "name": "Chad",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Chad",
+        "lang": "kw"
+      },
+      {
+        "name": "Chad",
+        "lang": "ms"
+      },
+      {
+        "name": "Chad",
+        "lang": "na"
+      },
+      {
+        "name": "Chad",
+        "lang": "oc"
+      },
+      {
+        "name": "Chad",
+        "lang": "pam"
+      },
+      {
+        "name": "Chad",
+        "lang": "sco"
+      },
+      {
+        "name": "Chad",
+        "lang": "sw"
+      },
+      {
+        "name": "Chad",
+        "lang": "tl"
+      },
+      {
+        "name": "Chad"
+      },
+      {
+        "name": "Chade",
+        "lang": "pt"
+      },
+      {
+        "name": "Chadi",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Chadi",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Chadi",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Chadi",
+        "lang": "sw"
+      },
+      {
+        "name": "Chad - Tchad",
+        "lang": "gl"
+      },
+      {
+        "name": "Ciad",
+        "lang": "it"
+      },
+      {
+        "name": "Ciad",
+        "lang": "ro"
+      },
+      {
+        "name": "Ciad",
+        "lang": "scn"
+      },
+      {
+        "name": "Cjad",
+        "lang": "lmo"
+      },
+      {
+        "name": "Colonie du Chad"
+      },
+      {
+        "name": "Csád",
+        "lang": "hu"
+      },
+      {
+        "name": "Czad",
+        "lang": "pl"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Chad",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%A7%D0%B0%D0%B4_%28%D0%B3%D0%BE%D1%81%D1%83%D0%B4%D0%B0%D1%80%D1%81%D1%82%D0%B2%D0%BE%29",
+        "lang": "link"
+      },
+      {
+        "name": "i-Chad",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Jaad",
+        "lang": "so"
+      },
+      {
+        "name": "Kjad",
+        "lang": "fo"
+      },
+      {
+        "name": "Kyad",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Orílẹ́ède ṣààdì",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Republic of Chad",
+        "lang": "en"
+      },
+      {
+        "name": "République du Tchad",
+        "lang": "fr"
+      },
+      {
+        "name": "Sát",
+        "lang": "vi"
+      },
+      {
+        "name": "Sát (Chad)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Sead",
+        "lang": "ga"
+      },
+      {
+        "name": "Seti",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Tasadi",
+        "lang": "kg"
+      },
+      {
+        "name": "Tčad",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Tchad",
+        "lang": "br"
+      },
+      {
+        "name": "Tchad",
+        "lang": "da"
+      },
+      {
+        "name": "Tchad",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "name": "Tchad",
+        "lang": "ht"
+      },
+      {
+        "name": "Tchad",
+        "lang": "ia"
+      },
+      {
+        "name": "Tchad",
+        "lang": "nn"
+      },
+      {
+        "name": "Tchad",
+        "lang": "sv"
+      },
+      {
+        "name": "Tchad",
+        "lang": "vi"
+      },
+      {
+        "name": "Tchad",
+        "lang": "wa"
+      },
+      {
+        "name": "Tchad"
+      },
+      {
+        "name": "Tch·ad",
+        "lang": "frp"
+      },
+      {
+        "name": "Territoire du Tchad"
+      },
+      {
+        "name": "Tiaad",
+        "isPreferredName": true,
+        "lang": "et"
+      },
+      {
+        "name": "Tjadän",
+        "lang": "vo"
+      },
+      {
+        "name": "Tšaad",
+        "lang": "et"
+      },
+      {
+        "name": "Tsad",
+        "isPreferredName": true,
+        "lang": "fi"
+      },
+      {
+        "name": "Tšad",
+        "lang": "fi"
+      },
+      {
+        "name": "Tsádi",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Tsad nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Tsady",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Tschad",
+        "lang": "de"
+      },
+      {
+        "name": "Tschad",
+        "lang": "nds"
+      },
+      {
+        "name": "Tschad",
+        "lang": "rm"
+      },
+      {
+        "name": "Tshadi",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Tsjaad",
+        "lang": "af"
+      },
+      {
+        "name": "Tsjaad",
+        "lang": "nl"
+      },
+      {
+        "name": "Tsjad",
+        "lang": "is"
+      },
+      {
+        "name": "Tsjad",
+        "isPreferredName": true,
+        "lang": "nb"
+      },
+      {
+        "name": "Tsjad",
+        "lang": "nn"
+      },
+      {
+        "name": "Tsjad",
+        "lang": "no"
+      },
+      {
+        "name": "Txad",
+        "lang": "ca"
+      },
+      {
+        "name": "Txad",
+        "lang": "eu"
+      },
+      {
+        "name": "Tyâde",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Tzadia",
+        "lang": "la"
+      },
+      {
+        "name": "تشاد",
+        "lang": "ar"
+      },
+      {
+        "name": "چاډ",
+        "lang": "ps"
+      },
+      {
+        "name": "چاد",
+        "lang": "fa"
+      },
+      {
+        "name": "چاد",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "چاد",
+        "lang": "ug"
+      },
+      {
+        "name": "چاڈ",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "צ'אד",
+        "lang": "he"
+      },
+      {
+        "name": "צ׳אד",
+        "lang": "he"
+      },
+      {
+        "name": "Τσαντ",
+        "lang": "el"
+      },
+      {
+        "name": "Республіка Чад",
+        "isPreferredName": true,
+        "lang": "uk"
+      },
+      {
+        "name": "Чад",
+        "lang": "be"
+      },
+      {
+        "name": "Чад",
+        "lang": "bg"
+      },
+      {
+        "name": "Чад",
+        "lang": "mk"
+      },
+      {
+        "name": "Чад",
+        "lang": "ru"
+      },
+      {
+        "name": "Чад",
+        "lang": "sr"
+      },
+      {
+        "name": "Чад",
+        "lang": "tg"
+      },
+      {
+        "name": "Чад",
+        "lang": "uk"
+      },
+      {
+        "name": "Չադ",
+        "lang": "hy"
+      },
+      {
+        "name": "ჩადი",
+        "lang": "ka"
+      },
+      {
+        "name": "चड",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "चाड",
+        "lang": "hi"
+      },
+      {
+        "name": "चाड",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "चाड",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "ચાડ",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "చాద్",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಚಾಡ್",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "சாட்",
+        "lang": "ta"
+      },
+      {
+        "name": "ചാഡ്",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "চাদ",
+        "lang": "bn"
+      },
+      {
+        "name": "চ্যাড",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "ချဒ်",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "乍得",
+        "lang": "zh"
+      },
+      {
+        "name": "チャド共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      }
+    ],
+    "countryName": "Chad",
+    "adminCode1": "00",
+    "lng": "19",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 1,
+      "gmtOffset": 1,
+      "timeZoneId": "Africa/Ndjamena"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 7.441068,
+      "east": 24.002661,
+      "north": 23.450369,
+      "west": 13.473475
+    },
+    "name": "Chad",
+    "fcode": "PCLI",
+    "geonameId": 2434508,
+    "asciiName": "Republic of Chad",
+    "lat": "15",
+    "population": 10543464,
+    "adminName1": "",
+    "countryId": "2434508",
+    "fclName": "country, state, region,...",
+    "countryCode": "TD",
+    "srtm3": 340,
+    "wikipediaURL": "en.wikipedia.org/wiki/Chad",
+    "toponymName": "Republic of Chad",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Boutoto": 2567388,
+  "2567388": {
+    "alternateNames": [
+
+    ],
+    "countryName": "Republic of the Congo",
+    "adminCode1": "04",
+    "lng": "11.97056",
+    "adminName2": "",
+    "fcodeName": "locality",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 1,
+      "gmtOffset": 1,
+      "timeZoneId": "Africa/Brazzaville"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "name": "Boutoto",
+    "fcode": "LCTY",
+    "geonameId": 2567388,
+    "asciiName": "Boutoto",
+    "lat": "-4.67528",
+    "population": 0,
+    "adminName1": "Kouilou",
+    "countryId": "2260494",
+    "adminId1": "2258738",
+    "fclName": "parks,area, ...",
+    "countryCode": "CG",
+    "srtm3": 130,
+    "toponymName": "Boutoto",
+    "fcl": "L",
+    "continentCode": "AF"
+  },
+  "DR Congo": 203312,
+  "203312": {
+    "alternateNames": [
+      {
+        "name": "콩고 민주 공화국",
+        "isPreferredName": true,
+        "lang": "ko"
+      },
+      {
+        "name": "콩고-킨샤사",
+        "lang": "ko"
+      },
+      {
+        "name": "ኮንጎ",
+        "lang": "am"
+      },
+      {
+        "name": "ኮንጎ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ኮንጎ ዲሞክራሲያዊ ሪፐብሊክ",
+        "lang": "am"
+      },
+      {
+        "name": "ކޮންގޯ",
+        "lang": "dv"
+      },
+      {
+        "name": "ザイール",
+        "lang": "ja"
+      },
+      {
+        "name": "କଙ୍ଗୋ",
+        "lang": "or"
+      },
+      {
+        "name": "କଙ୍ଗୋ-କିନସାସା",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "คองโก-กินชาซา",
+        "isPreferredName": true,
+        "lang": "th"
+      },
+      {
+        "name": "ܩܘܛܢܝܘܬܐ ܕܩܘܢܓܘ ܕܝܡܘܩܪܛܝܬܐ",
+        "lang": "arc"
+      },
+      {
+        "name": "ཀོང་གོ་མི་དམངས་དམངས་གཙོ།",
+        "lang": "bo"
+      },
+      {
+        "name": "สาธารณรัฐประชาธิปไตยคองโก",
+        "lang": "th"
+      },
+      {
+        "name": "Austur-Kongó",
+        "lang": "is"
+      },
+      {
+        "name": "Belgian Congo",
+        "isHistoric": true,
+        "lang": "en"
+      },
+      {
+        "name": "Belgisch Congo",
+        "isHistoric": true,
+        "lang": "de"
+      },
+      {
+        "name": "Belgisch Kongo",
+        "isHistoric": true,
+        "lang": "de"
+      },
+      {
+        "name": "Công-gô (DRC)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Cộng hòa Dân chủ Congo",
+        "lang": "vi"
+      },
+      {
+        "isShortName": true,
+        "isColloquial": true,
+        "name": "Congo",
+        "lang": "en"
+      },
+      {
+        "name": "Congo Belge",
+        "isHistoric": true,
+        "lang": "fr"
+      },
+      {
+        "name": "Congo Bîn-chú Kiōng-hô-kok",
+        "lang": "nan"
+      },
+      {
+        "name": "Congo [DRC]",
+        "lang": "en"
+      },
+      {
+        "name": "Congo [DRC]",
+        "isPreferredName": true,
+        "lang": "ms"
+      },
+      {
+        "name": "Congo [DRC]",
+        "isPreferredName": true,
+        "lang": "nl"
+      },
+      {
+        "name": "Congo Free State"
+      },
+      {
+        "name": "Congo - Kinshasa",
+        "isPreferredName": true,
+        "lang": "ca"
+      },
+      {
+        "name": "Congo-Kinshasa",
+        "lang": "en"
+      },
+      {
+        "name": "Congo-Kinshasa",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "name": "Congo-Kinshasa",
+        "lang": "nl"
+      },
+      {
+        "name": "Congo-Kinshasa",
+        "isPreferredName": true,
+        "lang": "pt"
+      },
+      {
+        "name": "Congo-Kinshasa",
+        "lang": "vls"
+      },
+      {
+        "name": "Còngo - Kinshasa",
+        "isPreferredName": true,
+        "lang": "oc"
+      },
+      {
+        "name": "Congo, Republica Democratică",
+        "lang": "ro"
+      },
+      {
+        "name": "Congo, The Democratic Republic Of",
+        "lang": "en"
+      },
+      {
+        "name": "Cumhuriyetê Kongoyê Demokratiki",
+        "lang": "diq"
+      },
+      {
+        "name": "Democratic Republic de Congo",
+        "lang": "ie"
+      },
+      {
+        "name": "Democratic Republic of Congo",
+        "lang": "en"
+      },
+      {
+        "name": "Democratic Republic of the Congo",
+        "lang": "en"
+      },
+      {
+        "name": "Democratic Republic of the Congo",
+        "lang": "mt"
+      },
+      {
+        "name": "Democratic Republic of the Congo",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Democratic Republic of the Congo",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Democratic Republic o the Congo",
+        "lang": "sco"
+      },
+      {
+        "name": "Demokraatsche Republik Kongo",
+        "lang": "nds"
+      },
+      {
+        "name": "Demokratesch Republik Kongo",
+        "lang": "lb"
+      },
+      {
+        "name": "Demokratial Republiko Kongo",
+        "lang": "io"
+      },
+      {
+        "name": "Demokratia Respubliko Kongo",
+        "lang": "eo"
+      },
+      {
+        "name": "Demokratická republika Kongo",
+        "lang": "cs"
+      },
+      {
+        "name": "Demokratična republika Kongo",
+        "lang": "sl"
+      },
+      {
+        "name": "Demokratiese Republiek van die Kongo",
+        "lang": "af"
+      },
+      {
+        "name": "Demokratika Republika ning Kongo",
+        "lang": "pam"
+      },
+      {
+        "name": "Demokratik Kongo Cumhuriyeti",
+        "lang": "tr"
+      },
+      {
+        "name": "Demokratiko a Republika iti Kongo",
+        "lang": "ilo"
+      },
+      {
+        "name": "Demokratikong Republika kan Kongo",
+        "lang": "bcl"
+      },
+      {
+        "name": "Demokratikong Republika ng Konggo",
+        "lang": "tl"
+      },
+      {
+        "name": "Demokratik Repablik o t Kongo",
+        "lang": "pih"
+      },
+      {
+        "name": "Demokrati Republike de Kongo",
+        "lang": "nov"
+      },
+      {
+        "name": "Demokratische Republek Kongo",
+        "lang": "ksh"
+      },
+      {
+        "name": "Demokratische Republik Kongo",
+        "lang": "als"
+      },
+      {
+        "name": "Demokratische Republik Kongo",
+        "lang": "de"
+      },
+      {
+        "name": "Demokratiska republika Kongo",
+        "lang": "dsb"
+      },
+      {
+        "name": "Demokratiska republika Kongo",
+        "lang": "hsb"
+      },
+      {
+        "name": "Demokratiska Republiken Kongo",
+        "isPreferredName": true,
+        "lang": "sv"
+      },
+      {
+        "name": "Demokratiske Republik Congo",
+        "lang": "da"
+      },
+      {
+        "name": "Demokratiske Republik Kongo",
+        "lang": "stq"
+      },
+      {
+        "name": "Demokratska Republika Kongo",
+        "lang": "bs"
+      },
+      {
+        "name": "Demokratska Republika Kongo",
+        "lang": "hbs"
+      },
+      {
+        "name": "Demokratska Republika Kongo",
+        "lang": "hr"
+      },
+      {
+        "name": "Demokratyczna Republika Konga",
+        "lang": "pl"
+      },
+      {
+        "name": "Demokratyske Republyk Kongo",
+        "lang": "fy"
+      },
+      {
+        "name": "Den Demokratiske Republik Congo",
+        "lang": "da"
+      },
+      {
+        "name": "Den demokratiske republikken Kongo",
+        "lang": "no"
+      },
+      {
+        "name": "Ditunga wa Kongu",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "isShortName": true,
+        "name": "DR Congo",
+        "lang": "en"
+      },
+      {
+        "name": "Dymokratyczno Republika Kůnga",
+        "lang": "szl"
+      },
+      {
+        "name": "e-Congo [DRC]",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Federal Republic of the Congo"
+      },
+      {
+        "name": "Federation of the Congo"
+      },
+      {
+        "name": "Folcrīcelicu Cynewīse þæs Congwes",
+        "lang": "ang"
+      },
+      {
+        "name": "Fólkaræðiliga Lýðveldið Kongo",
+        "lang": "fo"
+      },
+      {
+        "name": "Ganggoj Minzcuj Gunghozgoz",
+        "lang": "za"
+      },
+      {
+        "name": "Gweriniaeth Ddemocrataidd Congo",
+        "lang": "cy"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Democratic_Republic_of_the_Congo",
+        "lang": "link"
+      },
+      {
+        "name": "IKhongo",
+        "lang": "ss"
+      },
+      {
+        "name": "IRiphabliki Labantu weKongo",
+        "lang": "zu"
+      },
+      {
+        "name": "Jamhuri ya Kidemokrasia ya Kongo",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Jamhuri ya Kidemokrasia ya Kongo",
+        "lang": "sw"
+      },
+      {
+        "name": "Jamhuriyar dimokuradiyya Kwango",
+        "lang": "ha"
+      },
+      {
+        "name": "Jamhuriyar Dimokuraɗiyyar Kongo",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Jamhuuriyada Dimuqaraadiga Kongo",
+        "lang": "so"
+      },
+      {
+        "name": "Jamhuuriyadda Dimuquraadiga Kongo",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Kéyah Káango Shádiʼááhjí Siʼánígíí",
+        "lang": "nv"
+      },
+      {
+        "name": "Ködörösêse tî Ngunuhalëzo tî kongö",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Konga Demokratiskuo Republika",
+        "lang": "ltg"
+      },
+      {
+        "name": "Kongo",
+        "lang": "crh"
+      },
+      {
+        "name": "Kongo",
+        "lang": "ht"
+      },
+      {
+        "name": "Kongo",
+        "lang": "li"
+      },
+      {
+        "isShortName": true,
+        "name": "Kongo",
+        "isPreferredName": true,
+        "lang": "nb"
+      },
+      {
+        "isShortName": true,
+        "name": "Kongo",
+        "isPreferredName": true,
+        "lang": "nn"
+      },
+      {
+        "name": "Kongo",
+        "lang": "sk"
+      },
+      {
+        "name": "Kongoän",
+        "lang": "vo"
+      },
+      {
+        "name": "Kongo Cumhuriyeti",
+        "isPreferredName": true,
+        "lang": "tr"
+      },
+      {
+        "name": "Kongo Demokraatlik Vabariik",
+        "lang": "et"
+      },
+      {
+        "name": "Kongo demokráhtalaš dásseváldi",
+        "lang": "se"
+      },
+      {
+        "name": "Kongo, demokratická republika",
+        "isPreferredName": true,
+        "lang": "sk"
+      },
+      {
+        "name": "Kongo, demokratična republika",
+        "isPreferredName": true,
+        "lang": "sl"
+      },
+      {
+        "name": "Kongo Demokratik Cumhuriyeti",
+        "lang": "tr"
+      },
+      {
+        "name": "Kongo Demokratik Respublikasi",
+        "lang": "uz"
+      },
+      {
+        "name": "Kongo Demokratik Respublikası",
+        "lang": "gag"
+      },
+      {
+        "name": "Kongo Demokratik Respublikasy",
+        "lang": "tk"
+      },
+      {
+        "name": "Kongó, Demokratikus köztársaság",
+        "lang": "hu"
+      },
+      {
+        "name": "Kongo Demokratinė Respublika",
+        "lang": "lt"
+      },
+      {
+        "name": "Kongo Demokrātiskā Republika",
+        "lang": "lv"
+      },
+      {
+        "name": "Kongo, Demokratska Republika",
+        "lang": "hr"
+      },
+      {
+        "name": "Kongo DR",
+        "lang": "lv"
+      },
+      {
+        "name": "Kongo [DRC]",
+        "isPreferredName": true,
+        "lang": "bs"
+      },
+      {
+        "name": "Kongo [DRC]",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Kongo - DRK",
+        "isPreferredName": true,
+        "lang": "cs"
+      },
+      {
+        "name": "Kongo (DRK)",
+        "isPreferredName": true,
+        "lang": "af"
+      },
+      {
+        "name": "Kongo DV",
+        "lang": "et"
+      },
+      {
+        "name": "Kongói Demokratikus Köztársaság",
+        "lang": "hu"
+      },
+      {
+        "name": "Kongo [Jamhuri ya Kidemokrasia]",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Kongo ka Bɛjɛfanga Fasojamana",
+        "lang": "bm"
+      },
+      {
+        "name": "Kongo ka republiki demɔkratiki",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Kongo [KED]",
+        "isPreferredName": true,
+        "lang": "eu"
+      },
+      {
+        "name": "Kongó-Kinsásá",
+        "lang": "ln"
+      },
+      {
+        "name": "Kongo - Kinshasa",
+        "isPreferredName": true,
+        "lang": "id"
+      },
+      {
+        "name": "Kongo (Kinshasa)",
+        "lang": "fi"
+      },
+      {
+        "name": "Kongo-Kinshasa",
+        "isPreferredName": true,
+        "lang": "et"
+      },
+      {
+        "name": "Kongo-Kinshasa",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "name": "Kongo-Kinshasa",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Kongo-Kinshasa",
+        "isPreferredName": true,
+        "lang": "lt"
+      },
+      {
+        "name": "Kongo-Kinshasa",
+        "isPreferredName": true,
+        "lang": "lv"
+      },
+      {
+        "name": "Kongo-Kinshasa",
+        "lang": "nb"
+      },
+      {
+        "name": "Kongo-Kinshasa",
+        "lang": "nn"
+      },
+      {
+        "name": "Kongo-Kinshasa",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Kongo-Kinshasa",
+        "lang": "sv"
+      },
+      {
+        "name": "Kongó - Kinshasa",
+        "isPreferredName": true,
+        "lang": "hu"
+      },
+      {
+        "name": "Kongo Kinshasa nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Kongoko Errepublika Demokratikoa",
+        "lang": "eu"
+      },
+      {
+        "name": "Kongó, lýðveldið",
+        "isPreferredName": true,
+        "lang": "is"
+      },
+      {
+        "name": "Kongon demokraattinen tasavalta",
+        "lang": "fi"
+      },
+      {
+        "name": "Kongóo-Kinshasa",
+        "lang": "wo"
+      },
+      {
+        "name": "Kongo [RDK]",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Kongo, Republika Demokratyczna",
+        "lang": "pl"
+      },
+      {
+        "name": "Kongoya Demokratîk",
+        "lang": "ku"
+      },
+      {
+        "name": "Kongo (Zair)",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Kongo - Zayire",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Konqo Demokratik Respublikası",
+        "lang": "az"
+      },
+      {
+        "name": "Konqo - Kinşasa",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Konžská demokratická republika",
+        "lang": "sk"
+      },
+      {
+        "name": "Kungu Runakamaq Ripuwlika",
+        "lang": "qu"
+      },
+      {
+        "name": "Kùodùorùosêse tî Ngunuhalëzo tî Kongö",
+        "lang": "sg"
+      },
+      {
+        "name": "Kuonga Demuokratėnė Respoblėka",
+        "lang": "sgs"
+      },
+      {
+        "name": "Ndenndaandi Demokaraasiire Konngo",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Orilẹ́ède Kóngò",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Orílẹ̀-èdè Olómìnira Olóṣèlú ilẹ̀ Kóngò",
+        "lang": "yo"
+      },
+      {
+        "name": "Pobblaght Gheynlagh ny Congo",
+        "lang": "gv"
+      },
+      {
+        "name": "Poblachd Dheamocrach na Congo",
+        "lang": "gd"
+      },
+      {
+        "name": "Poblacht Dhaonlathach an Chongó",
+        "lang": "ga"
+      },
+      {
+        "isShortName": true,
+        "name": "RDC",
+        "lang": "fr"
+      },
+      {
+        "name": "Repibiki demokratiki ya Kongó",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Repoblek Werinel Kongo",
+        "lang": "kw"
+      },
+      {
+        "name": "Repoblika Demokratikani Kongo",
+        "lang": "mg"
+      },
+      {
+        "name": "Repoblikan'i Kongo",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Repubblica Democratica del Congo",
+        "lang": "it"
+      },
+      {
+        "name": "Repubblika Demokratika tal-Kongo",
+        "lang": "mt"
+      },
+      {
+        "name": "Repubbrica Democratica do Congo",
+        "lang": "lij"
+      },
+      {
+        "name": "Repubilika ya Kôngo ya Dimokalasi",
+        "lang": "kg"
+      },
+      {
+        "name": "Republica Democrată Congo",
+        "lang": "ro"
+      },
+      {
+        "name": "Republica Democratica dal Congo",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Republica Democratica de Còngo",
+        "lang": "oc"
+      },
+      {
+        "name": "Republica Democratica del Congo",
+        "lang": "vec"
+      },
+      {
+        "name": "República Democrática del Congo",
+        "lang": "es"
+      },
+      {
+        "name": "República Democrática dEl Congo",
+        "lang": "ast"
+      },
+      {
+        "name": "República Democràtica del Congo",
+        "lang": "ca"
+      },
+      {
+        "name": "Repùblica Democràtica dël Còngo",
+        "lang": "pms"
+      },
+      {
+        "name": "Republica Democratica do Congo",
+        "lang": "an"
+      },
+      {
+        "name": "República Democrática do Congo",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "República Democrática do Congo",
+        "lang": "pt"
+      },
+      {
+        "name": "República Democrática do Congo - République Démocratique du Congo",
+        "lang": "gl"
+      },
+      {
+        "name": "Rèpublica dèmocratica du Congô",
+        "lang": "frp"
+      },
+      {
+        "name": "Republica Democratic del Congo",
+        "lang": "ia"
+      },
+      {
+        "name": "Repüblica Demucratica del Congo",
+        "lang": "lmo"
+      },
+      {
+        "name": "Republic of Zaire",
+        "isHistoric": true,
+        "lang": "en"
+      },
+      {
+        "name": "Republika demokratika di Kongo",
+        "lang": "pap"
+      },
+      {
+        "name": "Republika Demokratika han Congo",
+        "lang": "war"
+      },
+      {
+        "name": "Republika Demokratike e Kongos",
+        "lang": "sq"
+      },
+      {
+        "name": "Republikang Demokratiko sa Congo",
+        "lang": "ceb"
+      },
+      {
+        "name": "Republik Demokratel Kongo",
+        "lang": "br"
+      },
+      {
+        "name": "Republik Demokratik Congo",
+        "lang": "ms"
+      },
+      {
+        "name": "Republik Demokratik Kongo",
+        "lang": "ace"
+      },
+      {
+        "name": "Republik Demokratik Kongo",
+        "lang": "id"
+      },
+      {
+        "name": "Républik Démokratik Kongo",
+        "lang": "su"
+      },
+      {
+        "name": "Republik Dhémokratis Kongo",
+        "lang": "jv"
+      },
+      {
+        "name": "Republike democratike do Congo",
+        "lang": "wa"
+      },
+      {
+        "name": "République démocratique du Congo",
+        "lang": "fr"
+      },
+      {
+        "name": "République Démocratique du Congo",
+        "lang": "fr"
+      },
+      {
+        "name": "République du Zaïre",
+        "isHistoric": true,
+        "lang": "fr"
+      },
+      {
+        "name": "Repúbrica Democrática del Congu",
+        "lang": "ext"
+      },
+      {
+        "name": "Repùbrica Democràtiga de su Congo",
+        "lang": "sc"
+      },
+      {
+        "name": "Repubulika Iharanira Demokarasi ya Kongo",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Repubulika Iharanira Demokarasi ya Kongo",
+        "lang": "rw"
+      },
+      {
+        "name": "Repuvlika Demokratika del Kongo",
+        "lang": "lad"
+      },
+      {
+        "name": "Res publica democratica Congensis",
+        "lang": "la"
+      },
+      {
+        "name": "Ripùbbrica Dimucràtica dû Congu",
+        "lang": "scn"
+      },
+      {
+        "name": "Ripublik Demokratik Kongo",
+        "lang": "bjn"
+      },
+      {
+        "name": "Ripubrikit Engame Kongo",
+        "lang": "na"
+      },
+      {
+        "name": "roltrusio zei.kongos",
+        "lang": "jbo"
+      },
+      {
+        "name": "Tetã Jekopytyjoja Kongo",
+        "lang": "gn"
+      },
+      {
+        "name": "Tlācatlahtohcāyōtl Tlācatēpacholiztli in Congo",
+        "lang": "nah"
+      },
+      {
+        "name": "Y Congo - Kinshasa",
+        "isPreferredName": true,
+        "lang": "cy"
+      },
+      {
+        "name": "Zair",
+        "isPreferredName": true,
+        "isHistoric": true,
+        "lang": "ro"
+      },
+      {
+        "name": "Zaire",
+        "isPreferredName": true,
+        "isHistoric": true,
+        "lang": "da"
+      },
+      {
+        "name": "Zaire",
+        "isPreferredName": true,
+        "isHistoric": true,
+        "lang": "de"
+      },
+      {
+        "isShortName": true,
+        "name": "Zaire",
+        "isPreferredName": true,
+        "isHistoric": true,
+        "lang": "es"
+      },
+      {
+        "name": "Zaire",
+        "isHistoric": true,
+        "lang": "fi"
+      },
+      {
+        "name": "Zaire",
+        "isHistoric": true,
+        "lang": "it"
+      },
+      {
+        "name": "Zaire",
+        "isHistoric": true,
+        "lang": "sv"
+      },
+      {
+        "name": "Zaire",
+        "isHistoric": true
+      },
+      {
+        "name": "الكونغو - كينشاسا",
+        "isPreferredName": true,
+        "lang": "ar"
+      },
+      {
+        "name": "جمهوری دموکراتیک کنگو",
+        "lang": "fa"
+      },
+      {
+        "name": "جمهورية الكونغو الديمقراطية",
+        "lang": "ar"
+      },
+      {
+        "name": "جمهورية كونجو الديموقراطيه",
+        "lang": "arz"
+      },
+      {
+        "name": "جمہوری جمہوریہ کانگو",
+        "lang": "ur"
+      },
+      {
+        "name": "كونگو دېموكراتىك جۇمھۇرىيىتى",
+        "lang": "ug"
+      },
+      {
+        "name": "کانگو [DRC]",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "کۆماری دیموکراتیی کۆنگۆ",
+        "lang": "ckb"
+      },
+      {
+        "name": "کۆنگۆ کینشاسا",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "کنگو - کینشاسا",
+        "isPreferredName": true,
+        "lang": "fa"
+      },
+      {
+        "name": "لوکراج کانگو",
+        "lang": "pnb"
+      },
+      {
+        "name": "דעמאקראטישע רעפובליק פון קאנגא",
+        "lang": "yi"
+      },
+      {
+        "name": "הרפובליקה הדמוקרטית של קונגו",
+        "lang": "he"
+      },
+      {
+        "name": "קונגו - קינשאסה",
+        "isPreferredName": true,
+        "lang": "he"
+      },
+      {
+        "name": "Κονγκό, Δημοκρατία του",
+        "isPreferredName": true,
+        "lang": "el"
+      },
+      {
+        "name": "Κονγκό, Λαϊκή Δημοκρατία του",
+        "lang": "el"
+      },
+      {
+        "name": "Λαϊκή Δημοκρατία του Κονγκό",
+        "lang": "el"
+      },
+      {
+        "name": "Ардчилсан Конго Улас",
+        "lang": "bxr"
+      },
+      {
+        "name": "Бүгд Найрамдах Ардчилсан Конго Улс",
+        "lang": "mn"
+      },
+      {
+        "name": "Демократин Республика Конго",
+        "lang": "ce"
+      },
+      {
+        "name": "Демократическая Республика Конго",
+        "lang": "ru"
+      },
+      {
+        "name": "Демократична република Конго",
+        "lang": "bg"
+      },
+      {
+        "name": "Демократична республіка Конго",
+        "isPreferredName": true,
+        "lang": "uk"
+      },
+      {
+        "name": "Демократична Республіка Конго",
+        "lang": "uk"
+      },
+      {
+        "name": "Демократиядин Республика Конго",
+        "lang": "lez"
+      },
+      {
+        "name": "Демократічна Републіка Конґо",
+        "lang": "rue"
+      },
+      {
+        "name": "Демократска република Конго",
+        "lang": "sr"
+      },
+      {
+        "name": "Демократска Република Конго",
+        "lang": "mk"
+      },
+      {
+        "name": "Демократска Република Конго",
+        "lang": "sr"
+      },
+      {
+        "name": "Дэмакратычная Рэспубліка Конга",
+        "lang": "be"
+      },
+      {
+        "name": "Заир",
+        "isPreferredName": true,
+        "lang": "ru"
+      },
+      {
+        "name": "Конга, Дэмакратычная Рэспубліка",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Конго Демократик Җөмһүрияте",
+        "lang": "tt"
+      },
+      {
+        "name": "Конго Демократик Республикаһы",
+        "lang": "ba"
+      },
+      {
+        "name": "Конго Демократиллĕ Республики",
+        "lang": "cv"
+      },
+      {
+        "name": "Конго, Демократическая Республика",
+        "lang": "ru"
+      },
+      {
+        "name": "Конго, Демократична Республіка",
+        "lang": "uk"
+      },
+      {
+        "name": "Конго Демократиялық Республикасы",
+        "lang": "kk"
+      },
+      {
+        "name": "Конго Демократ Өрөспүүбүлүкэтэ",
+        "lang": "sah"
+      },
+      {
+        "name": "Конго, Демократска Република",
+        "isPreferredName": true,
+        "lang": "sr"
+      },
+      {
+        "name": "Конго [ДРК]",
+        "isPreferredName": true,
+        "lang": "bg"
+      },
+      {
+        "name": "Конгойы Демократон Республикæ",
+        "lang": "os"
+      },
+      {
+        "name": "Конго - Киншаса",
+        "isPreferredName": true,
+        "lang": "mk"
+      },
+      {
+        "name": "Конһлмудин Улс Орн",
+        "lang": "xal"
+      },
+      {
+        "name": "Կոնգոյի Դեմոկրատական Հանրապետություն",
+        "lang": "hy"
+      },
+      {
+        "name": "კონგო - კინშასა",
+        "isPreferredName": true,
+        "lang": "ka"
+      },
+      {
+        "name": "კონგოს დემოკრატიული რესპუბლიკა",
+        "lang": "ka"
+      },
+      {
+        "name": "कांगो लोकतान्त्रिक गणराज्य",
+        "lang": "hi"
+      },
+      {
+        "name": "काँगो [ङीआरसी]",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "काँगोचे लोकशाही प्रजासत्ताक",
+        "lang": "mr"
+      },
+      {
+        "name": "कोङ्गो-किन्शासा",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "कोंगो [डीआरसी]",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "प्रजातान्त्रिक गणतन्त्र कंगो",
+        "lang": "ne"
+      },
+      {
+        "name": "કોંગો [ડીઆરસી]",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "కాంగో- కిన్షాసా",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ਕਾਂਗੋ ਲੋਕਤੰਤਰੀ ਗਣਰਾਜ",
+        "lang": "pa"
+      },
+      {
+        "name": "ಕಾಂಗೋ [DRC]",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "ಕಾಂಗೋ ಪ್ರಜಾಸತ್ತಾತ್ಮಕ ಗಣರಾಜ್ಯ",
+        "lang": "kn"
+      },
+      {
+        "name": "காங்கோ [டிசிஆர்]",
+        "isPreferredName": true,
+        "lang": "ta"
+      },
+      {
+        "name": "காங்கோ மக்களாட்சிக் குடியரசு",
+        "lang": "ta"
+      },
+      {
+        "name": "കോംഗോ [DRC]",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "ഡെമോക്രാറ്റിക് റിപബ്ലിക്ക് ഓഫ് കോംഗോ",
+        "lang": "ml"
+      },
+      {
+        "name": "কঙ্গো[DRC]",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "গণতান্ত্রিক কঙ্গো প্রজাতন্ত্র",
+        "lang": "bn"
+      },
+      {
+        "name": "গনতান্ত্রিক কঙ্গো প্রজাতন্ত্র",
+        "lang": "bpy"
+      },
+      {
+        "name": "ကွန်ဂိုဒီမိုကရက်တစ်သမ္မတနိုင်ငံ",
+        "lang": "my"
+      },
+      {
+        "name": "කොන්ගෝ ප්‍රජාතන්ත්‍රවාදී ජනරජය",
+        "lang": "si"
+      },
+      {
+        "name": "කොන්ගෝව",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "刚果民主共和国",
+        "lang": "wuu"
+      },
+      {
+        "name": "刚果民主共和国",
+        "lang": "zh"
+      },
+      {
+        "name": "剛果民主共和國",
+        "lang": "gan"
+      },
+      {
+        "name": "剛果民主共和國",
+        "lang": "lzh"
+      },
+      {
+        "name": "剛果民主共和國",
+        "lang": "yue"
+      },
+      {
+        "name": "扎伊尔",
+        "isPreferredName": true,
+        "lang": "zh"
+      },
+      {
+        "name": "コンゴ民主共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      }
+    ],
+    "countryName": "Democratic Republic of the Congo",
+    "adminCode1": "00",
+    "lng": "23.5",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -13.455675,
+      "east": 31.305912,
+      "north": 5.386098,
+      "west": 12.204144
+    },
+    "name": "DR Congo",
+    "fcode": "PCLI",
+    "geonameId": 203312,
+    "asciiName": "Democratic Republic of the Congo",
+    "lat": "-2.5",
+    "population": 70916439,
+    "adminName1": "",
+    "countryId": "203312",
+    "fclName": "country, state, region,...",
+    "countryCode": "CD",
+    "srtm3": 441,
+    "wikipediaURL": "en.wikipedia.org/wiki/Democratic_Republic_of_the_Congo",
+    "toponymName": "Democratic Republic of the Congo",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Ivory Coast": 2287781,
+  "2287781": {
+    "alternateNames": [
+      {
+        "name": "ኮት ዲቯር",
+        "lang": "am"
+      },
+      {
+        "name": "ኮት ዲቯር",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "아이보리 코스트",
+        "lang": "ko"
+      },
+      {
+        "name": "ଆଇବରୀ କୋଷ୍ଟ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "코트디부아르",
+        "isPreferredName": true,
+        "lang": "ko"
+      },
+      {
+        "name": "កូដឌីវ័រ",
+        "lang": "km"
+      },
+      {
+        "name": "コートジボワール",
+        "lang": "ja"
+      },
+      {
+        "name": "ཀོ་ཊེ་ཌི། ཨི་ཝོ་རེ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ไอวอรี่โคสต์",
+        "isPreferredName": true,
+        "lang": "th"
+      },
+      {
+        "name": "ຝັ່ງທະເລໄອວໍລິ",
+        "lang": "lo"
+      },
+      {
+        "name": "ประเทศโกตดิวัวร์",
+        "lang": "th"
+      },
+      {
+        "name": "Aibari Kwas",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Aibori Kot",
+        "lang": "na"
+      },
+      {
+        "name": "An Cósta Eabhair",
+        "lang": "ga"
+      },
+      {
+        "name": "Aod an Olifant",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Berderya Aç",
+        "lang": "ku"
+      },
+      {
+        "name": "Bjelokosna Obala",
+        "lang": "hr"
+      },
+      {
+        "name": "BK",
+        "isPreferredName": true,
+        "lang": "eu"
+      },
+      {
+        "name": "Bờ Biển Ngà",
+        "lang": "vi"
+      },
+      {
+        "name": "Bregu i Fildishtë",
+        "lang": "sq"
+      },
+      {
+        "name": "Coasta de Fildeș",
+        "lang": "ro"
+      },
+      {
+        "name": "Costa d'Avorio",
+        "lang": "it"
+      },
+      {
+        "name": "Costa d'Avoriu",
+        "lang": "scn"
+      },
+      {
+        "name": "Costa de Bori",
+        "lang": "an"
+      },
+      {
+        "name": "Costa de Ebore",
+        "lang": "ia"
+      },
+      {
+        "name": "Costa de Marfil",
+        "lang": "ast"
+      },
+      {
+        "isShortName": true,
+        "name": "Costa de Marfil",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Costa de Marfil"
+      },
+      {
+        "name": "Còsta d'Evòri",
+        "lang": "oc"
+      },
+      {
+        "name": "Costa d'Ivori",
+        "lang": "ca"
+      },
+      {
+        "name": "Costa d’Ivori",
+        "lang": "ca"
+      },
+      {
+        "name": "Costa d'Ivur",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Costa do Marfil",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Costa do Marfil - Côte d'Ivoire",
+        "lang": "gl"
+      },
+      {
+        "name": "Costa do Marfim",
+        "lang": "pt"
+      },
+      {
+        "name": "Costa Ivoria",
+        "lang": "ilo"
+      },
+      {
+        "name": "Côte de l’Ivoire",
+        "isPreferredName": true
+      },
+      {
+        "name": "Côte d'Iviéthe",
+        "lang": "nrm"
+      },
+      {
+        "name": "Cote d'Ivoire",
+        "lang": "sw"
+      },
+      {
+        "name": "Cote d’Ivoire",
+        "lang": "et"
+      },
+      {
+        "name": "Côte d'Ivoire",
+        "lang": "cy"
+      },
+      {
+        "name": "Côte d'Ivoire",
+        "lang": "en"
+      },
+      {
+        "name": "Côte d'Ivoire",
+        "isPreferredName": true,
+        "lang": "fi"
+      },
+      {
+        "isShortName": true,
+        "name": "Côte d'Ivoire",
+        "lang": "fr"
+      },
+      {
+        "name": "Côte d'Ivoire",
+        "lang": "gd"
+      },
+      {
+        "name": "Côte d'Ivoire",
+        "isPreferredName": true,
+        "lang": "id"
+      },
+      {
+        "name": "Côte d'Ivoire",
+        "lang": "kw"
+      },
+      {
+        "name": "Côte d'Ivoire",
+        "isPreferredName": true,
+        "lang": "lt"
+      },
+      {
+        "name": "Côte d'Ivoire",
+        "lang": "ms"
+      },
+      {
+        "name": "Côte d'Ivoire",
+        "lang": "pam"
+      },
+      {
+        "name": "Côte d'Ivoire",
+        "isPreferredName": true,
+        "lang": "ro"
+      },
+      {
+        "name": "Côte d'Ivoire",
+        "lang": "vi"
+      },
+      {
+        "name": "Côte d’Ivoire",
+        "lang": "cy"
+      },
+      {
+        "name": "Côte d’Ivoire",
+        "lang": "en"
+      },
+      {
+        "name": "Côte d’Ivoire",
+        "isPreferredName": true,
+        "lang": "et"
+      },
+      {
+        "name": "Côte d’Ivoire",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "name": "Côte d’Ivoire",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Côte d’Ivoire",
+        "lang": "tl"
+      },
+      {
+        "name": "Couta d’Ivouèro",
+        "lang": "frp"
+      },
+      {
+        "name": "Dramblio Kaulo Krantas",
+        "lang": "lt"
+      },
+      {
+        "name": "Dramblio KKR",
+        "lang": "lt"
+      },
+      {
+        "name": "Eburbordo",
+        "lang": "eo"
+      },
+      {
+        "name": "Ebur-Bordo",
+        "lang": "eo"
+      },
+      {
+        "name": "Elefántcsontpart",
+        "lang": "hu"
+      },
+      {
+        "name": "Elevandiluurannik",
+        "lang": "et"
+      },
+      {
+        "name": "Elfenbeenküst",
+        "lang": "nds"
+      },
+      {
+        "name": "Elfenbeinküste",
+        "isPreferredName": true,
+        "lang": "de"
+      },
+      {
+        "name": "Elfenbein-Küste"
+      },
+      {
+        "name": "Elfenbeinskysten",
+        "lang": "nn"
+      },
+      {
+        "name": "Elfenbenariddu",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Elfenbenskusten",
+        "lang": "sv"
+      },
+      {
+        "name": "Elfenbenskysten",
+        "lang": "da"
+      },
+      {
+        "name": "Elfenbenskysten",
+        "lang": "nb"
+      },
+      {
+        "name": "Elfenbenskysten",
+        "lang": "nn"
+      },
+      {
+        "name": "Elfenbenskysten",
+        "lang": "no"
+      },
+      {
+        "name": "Fílabeinsstrondin",
+        "lang": "fo"
+      },
+      {
+        "name": "Fílabeinsströndin",
+        "lang": "is"
+      },
+      {
+        "name": "Fildişi Kıyısı",
+        "lang": "tr"
+      },
+      {
+        "name": "Fildişi Sahili",
+        "lang": "tr"
+      },
+      {
+        "name": "Fil Dişi Sahili",
+        "lang": "az"
+      },
+      {
+        "name": "Fildişi Sahilleri",
+        "lang": "tr"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/C%C3%B4te_d%27Ivoire",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%9A%D0%BE%D1%82-%D0%B4%E2%80%99%D0%98%D0%B2%D1%83%D0%B0%D1%80",
+        "lang": "link"
+      },
+      {
+        "name": "i-Ivory Coast",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Ivoarkust",
+        "lang": "fy"
+      },
+      {
+        "name": "Ivoorkus",
+        "lang": "af"
+      },
+      {
+        "name": "Ivoorkust",
+        "lang": "nl"
+      },
+      {
+        "name": "Ivora Rivo",
+        "lang": "io"
+      },
+      {
+        "name": "İvori Sahili",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Ivory coast",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Ivory Coast",
+        "isPreferredName": true,
+        "lang": "en"
+      },
+      {
+        "name": "Ivory Coast",
+        "isPreferredName": true,
+        "lang": "ms"
+      },
+      {
+        "name": "Ivory Coast",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Ivory Coast",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Ivory Coast"
+      },
+      {
+        "name": "Ivory Kost nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Kodduwaar",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Kodivaa",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Kodivaa",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Kôdivüära",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Kodiwari",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Kosta ta’ l-Avorju",
+        "lang": "mt"
+      },
+      {
+        "name": "Kotdivuāra",
+        "lang": "lv"
+      },
+      {
+        "name": "Kotdivuaro",
+        "lang": "eo"
+      },
+      {
+        "name": "Kotedivuale",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Kotedivuware",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Kote Divwa",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Kotídivualɛ",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "La Côte d'Ivoire",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Litus Eburneum",
+        "lang": "la"
+      },
+      {
+        "name": "Matafonua ʻAivili",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Obala Bjelokosti",
+        "lang": "hr"
+      },
+      {
+        "name": "Obala Slonovače",
+        "lang": "bs"
+      },
+      {
+        "name": "Obala Slonovače",
+        "lang": "hbs"
+      },
+      {
+        "name": "Obala Slonovače",
+        "isPreferredName": true,
+        "lang": "hr"
+      },
+      {
+        "name": "Orílẹ́ède Kóútè forà",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Pantai Gading",
+        "lang": "id"
+      },
+      {
+        "name": "Pobrežie Slonoviny",
+        "lang": "sk"
+      },
+      {
+        "name": "Pobřeží slonoviny",
+        "lang": "cs"
+      },
+      {
+        "name": "Republic of Côte d’Ivoire",
+        "lang": "en"
+      },
+      {
+        "name": "République de Côte d'Ivoire",
+        "lang": "fr"
+      },
+      {
+        "name": "Slonokoščena obala",
+        "lang": "sl"
+      },
+      {
+        "name": "Wybrzeże Kości Słoniowej",
+        "lang": "pl"
+      },
+      {
+        "name": "آئیوری کوسٹ",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "ساحل العاج",
+        "lang": "ar"
+      },
+      {
+        "name": "ساحل عاج",
+        "lang": "fa"
+      },
+      {
+        "name": "عاج ساحل",
+        "lang": "ps"
+      },
+      {
+        "name": "كوتى دى ئىۋۇئېر",
+        "lang": "ug"
+      },
+      {
+        "name": "کۆتدیڤوار",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "חוף השנהב",
+        "lang": "he"
+      },
+      {
+        "name": "Ακτή Ελεφαντόδοντος",
+        "lang": "el"
+      },
+      {
+        "name": "Ακτή Ελεφαντοστού",
+        "lang": "el"
+      },
+      {
+        "name": "Брег на Слонова Коска",
+        "isPreferredName": true,
+        "lang": "mk"
+      },
+      {
+        "name": "Бряг на слоновата кост",
+        "isPreferredName": true,
+        "lang": "bg"
+      },
+      {
+        "name": "Кот д'Ивоар",
+        "lang": "bg"
+      },
+      {
+        "name": "Кот д’Ивоар",
+        "lang": "bg"
+      },
+      {
+        "name": "Кот д’Ивуар",
+        "lang": "ru"
+      },
+      {
+        "name": "Кот-д'Ивуар",
+        "isPreferredName": true,
+        "lang": "ru"
+      },
+      {
+        "name": "Кот-д’Ивуар",
+        "lang": "ru"
+      },
+      {
+        "name": "Кот д’Івуар",
+        "isPreferredName": true,
+        "lang": "uk"
+      },
+      {
+        "name": "Кот-д'Івуар",
+        "lang": "uk"
+      },
+      {
+        "name": "Обала Слоноваче",
+        "lang": "sr"
+      },
+      {
+        "name": "Փղոսկրի Ափ",
+        "lang": "hy"
+      },
+      {
+        "name": "კოტ-დ'ივუარი",
+        "lang": "ka"
+      },
+      {
+        "name": "სპილოს ძვლის სანაპირო",
+        "lang": "ka"
+      },
+      {
+        "name": "आइभोरी कोष्ट",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "आइवरी कोस्ट",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "आयव्हरी कोस्ट",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "આઇવરી કોસ્ટ",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "ఐవరీ కోస్ట్",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಐವರಿ ಕೋಸ್ಟ್",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "ஐவரி கோஸ்ட்",
+        "lang": "ta"
+      },
+      {
+        "name": "ഐവറി കോസ്റ്റ്",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "আইভরি কোস্ট",
+        "lang": "bn"
+      },
+      {
+        "name": "আভরি কোস্ট",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "အိုင်ဗရီကိုစ့်",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "අයිවරි කෝස්ට්",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "科特迪瓦",
+        "lang": "zh"
+      },
+      {
+        "name": "象牙海岸",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "象牙海岸",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Ivory Coast",
+    "adminCode1": "00",
+    "lng": "-5.5",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 0,
+      "gmtOffset": 0,
+      "timeZoneId": "Africa/Abidjan"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 4.357067,
+      "east": -2.494897,
+      "north": 10.736642,
+      "west": -8.599302
+    },
+    "name": "Ivory Coast",
+    "fcode": "PCLI",
+    "geonameId": 2287781,
+    "asciiName": "Republic of Cote d'Ivoire",
+    "lat": "8",
+    "population": 21058798,
+    "adminName1": "",
+    "countryId": "2287781",
+    "fclName": "country, state, region,...",
+    "countryCode": "CI",
+    "srtm3": 257,
+    "wikipediaURL": "en.wikipedia.org/wiki/C%C3%B4te_d%27Ivoire",
+    "toponymName": "Republic of Côte d’Ivoire",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Equatorial Guinea": 2309096,
+  "2309096": {
+    "alternateNames": [
+      {
+        "name": "적도 기니",
+        "lang": "ko"
+      },
+      {
+        "name": "ኢኳቶሪያል ጊኒ",
+        "lang": "am"
+      },
+      {
+        "name": "ኢኳቶሪያል ጊኒ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ኢኳቶሪያል ጊኔ",
+        "lang": "am"
+      },
+      {
+        "name": "ଇକ୍ବାଟେରିଆଲ୍ ଗୁଇନିଆ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "ហ្គីណេអេក្វាទ័រ",
+        "lang": "km"
+      },
+      {
+        "name": "อิเควทอเรียลกินี",
+        "lang": "th"
+      },
+      {
+        "name": "ເອຄົວໂທເລຍລະກິນີ",
+        "lang": "lo"
+      },
+      {
+        "name": "ประเทศอิเควทอเรียลกินี",
+        "lang": "th"
+      },
+      {
+        "name": "Ækvatorialguinea",
+        "lang": "da"
+      },
+      {
+        "name": "Ækvatorial Guinea",
+        "isPreferredName": true,
+        "lang": "da"
+      },
+      {
+        "name": "An Ghuine Mheánchriosach",
+        "lang": "ga"
+      },
+      {
+        "name": "Äquatoriaal-Guinea",
+        "lang": "nds"
+      },
+      {
+        "name": "Äquatorialguinea",
+        "lang": "de"
+      },
+      {
+        "name": "Egyenlítďi Guinea",
+        "lang": "hu"
+      },
+      {
+        "name": "Egyenlítői-Guinea",
+        "lang": "hu"
+      },
+      {
+        "name": "Ekuatore Ginea",
+        "lang": "eu"
+      },
+      {
+        "name": "Ekuatorial Guini nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "ʻEkueta Kini",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Ekvatora Gvineo",
+        "lang": "eo"
+      },
+      {
+        "name": "Ekvator Ginesi",
+        "lang": "tr"
+      },
+      {
+        "name": "Ekvator Guinea",
+        "lang": "fo"
+      },
+      {
+        "name": "Ekvatoriaal-Guinea",
+        "lang": "et"
+      },
+      {
+        "name": "Ekvatoriála Guinea",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Ekvatoriālā Gvineja",
+        "lang": "lv"
+      },
+      {
+        "name": "Ekvatorialguinea",
+        "lang": "sv"
+      },
+      {
+        "name": "Ekvatorial-Guinea",
+        "lang": "nb"
+      },
+      {
+        "name": "Ekvatorial-Guinea",
+        "lang": "nn"
+      },
+      {
+        "name": "Ekvatorial-Guinea",
+        "lang": "no"
+      },
+      {
+        "name": "Ekvatorialna Gvineja",
+        "lang": "sl"
+      },
+      {
+        "name": "Ekvatorijalna Gvineja",
+        "lang": "bs"
+      },
+      {
+        "name": "Ekvatorijalna Gvineja",
+        "lang": "hbs"
+      },
+      {
+        "name": "Ekvator Qineya",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Ekvatorska Gvineja",
+        "lang": "hr"
+      },
+      {
+        "name": "Ekwatoriaal-Guinee",
+        "lang": "af"
+      },
+      {
+        "name": "Equatorala Guinea",
+        "lang": "io"
+      },
+      {
+        "name": "Equatoriaal-Guinea",
+        "lang": "nl"
+      },
+      {
+        "name": "Equatoriaal Guinee",
+        "lang": "li"
+      },
+      {
+        "isShortName": true,
+        "name": "Equatorial Guinea",
+        "isPreferredName": true,
+        "lang": "en"
+      },
+      {
+        "name": "Equatorial Guinea",
+        "isPreferredName": true,
+        "lang": "id"
+      },
+      {
+        "name": "Equatorial Guinea",
+        "lang": "ms"
+      },
+      {
+        "name": "Equatorial Guinea",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Equatorial Guinea",
+        "lang": "pam"
+      },
+      {
+        "name": "Equatorial Guinea",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Equatorial Guinea",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Gayana ey'oku ekweta",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Ghi-nê Xích-đạo",
+        "lang": "vi"
+      },
+      {
+        "name": "Ghi-nê Xích-đạo (Equatorial Guinea)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Ginea ar Cʼheheder",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Ginea Ekwatorjali",
+        "lang": "mt"
+      },
+      {
+        "name": "Gineang Ekwatoriyal",
+        "lang": "tl"
+      },
+      {
+        "name": "Ginee Ekuwaatoriyaal",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Gine Ekwatele",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Gine ekwatɔri",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Ginëe tî Ekuatëre",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Ginɛ́kwatɛ́lɛ",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Ginekweta",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Ginekweta",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Gineya Ekwatoriyali",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Gini Gyhydeddol",
+        "lang": "cy"
+      },
+      {
+        "name": "Gini Ikuweta",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Gini Ta Ikwaita",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Guinea Aequatoriensis",
+        "lang": "la"
+      },
+      {
+        "name": "Guinea Ecuatorial",
+        "lang": "ast"
+      },
+      {
+        "isShortName": true,
+        "name": "Guinea Ecuatorial",
+        "lang": "es"
+      },
+      {
+        "name": "Guinea Ecuatorial",
+        "lang": "gl"
+      },
+      {
+        "name": "Guinea Ekoatera",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Guinea equatorial",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Guinea Equatorial",
+        "lang": "an"
+      },
+      {
+        "name": "Guinea Equatorial",
+        "lang": "ca"
+      },
+      {
+        "name": "Guinea Equatoriala",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Guinèa Eqüatoriala",
+        "lang": "oc"
+      },
+      {
+        "name": "Guinea Equatoriale",
+        "lang": "it"
+      },
+      {
+        "name": "Guinea Española",
+        "lang": "es"
+      },
+      {
+        "name": "Guinea Española"
+      },
+      {
+        "name": "Guinea Khatulistiwa",
+        "lang": "id"
+      },
+      {
+        "name": "Guinea Khatulistiwa",
+        "lang": "ms"
+      },
+      {
+        "name": "Guinea Xích Đạo",
+        "lang": "vi"
+      },
+      {
+        "name": "Guineea Ecuatorială",
+        "lang": "ro"
+      },
+      {
+        "name": "Guinée équatoriale",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "isShortName": true,
+        "name": "Guinee Espagnol",
+        "isPreferredName": true
+      },
+      {
+        "name": "Guiné Equatorial",
+        "lang": "pt"
+      },
+      {
+        "name": "Guinê èquatoriâla",
+        "lang": "frp"
+      },
+      {
+        "name": "Guineja Ekuatoriale",
+        "lang": "sq"
+      },
+      {
+        "name": "Gwinea Równikowa",
+        "lang": "pl"
+      },
+      {
+        "name": "Gyni Ekwadoriel",
+        "lang": "kw"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Equatorial_Guinea",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%AD%D0%BA%D0%B2%D0%B0%D1%82%D0%BE%D1%80%D0%B8%D0%B0%D0%BB%D1%8C%D0%BD%D0%B0%D1%8F_%D0%93%D0%B2%D0%B8%D0%BD%D0%B5%D1%8F",
+        "lang": "link"
+      },
+      {
+        "name": "http://www.dgecnstat-ge.org/",
+        "lang": "link"
+      },
+      {
+        "name": "i-Equatorial Guinea",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Kveatora-Gineyän",
+        "lang": "vo"
+      },
+      {
+        "name": "Miðbaugs-Gínea",
+        "lang": "is"
+      },
+      {
+        "name": "Orílẹ́ède Ekutoria Gini",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Päiväntasaajan Guinea",
+        "lang": "fi"
+      },
+      {
+        "name": "Posesiones Españolas del Golfo de Guinea",
+        "lang": "es"
+      },
+      {
+        "name": "Posesiones Españolas del Golfo de Guinea"
+      },
+      {
+        "name": "Provincia de la Guinea Ecuatorial",
+        "lang": "es"
+      },
+      {
+        "name": "Provincia de la Guinea Ecuatorial"
+      },
+      {
+        "name": "Pusiaujo Gvinėja",
+        "lang": "lt"
+      },
+      {
+        "name": "República de Guinea Ecuatorial",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Republic of Equatorial Guinea",
+        "lang": "en"
+      },
+      {
+        "name": "Rovníková Guinea",
+        "lang": "cs"
+      },
+      {
+        "name": "Rovníková Guinea",
+        "lang": "sk"
+      },
+      {
+        "name": "Spanish Guinea",
+        "lang": "en"
+      },
+      {
+        "name": "Spanish Guinea"
+      },
+      {
+        "name": "Territorios Españoles del Golfo de Guinea",
+        "lang": "es"
+      },
+      {
+        "name": "Territorios Españoles del Golfo de Guinea"
+      },
+      {
+        "name": "استوائی گیانا",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "ایکواتریال گوینیا",
+        "isPreferredName": true,
+        "lang": "fa"
+      },
+      {
+        "name": "اېکواټوريال ګوينا",
+        "lang": "ps"
+      },
+      {
+        "name": "غينيا الاستوائية",
+        "lang": "ar"
+      },
+      {
+        "name": "گینه استوایی",
+        "lang": "fa"
+      },
+      {
+        "name": "گینهٔ استوایی",
+        "lang": "fa"
+      },
+      {
+        "name": "ئېكۋاتور گۋىنېيىسى",
+        "lang": "ug"
+      },
+      {
+        "name": "גינאה המשוונית",
+        "lang": "he"
+      },
+      {
+        "name": "גיניאה המשוונית",
+        "lang": "he"
+      },
+      {
+        "name": "Ισημερινή Γουινέα",
+        "lang": "el"
+      },
+      {
+        "name": "Гвинеяи Истивоӣ",
+        "lang": "tg"
+      },
+      {
+        "name": "Екваториална Гвинея",
+        "lang": "bg"
+      },
+      {
+        "name": "Екваторијална Гвинеја",
+        "lang": "sr"
+      },
+      {
+        "name": "Екваторіальна Гвінея",
+        "lang": "uk"
+      },
+      {
+        "name": "Екваторіальна Ґвінея",
+        "isPreferredName": true,
+        "lang": "uk"
+      },
+      {
+        "name": "Екваторска Гвинеја",
+        "lang": "mk"
+      },
+      {
+        "name": "Экватарыяльная Гвінея",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Экватарыяльная Гвінэя",
+        "lang": "be"
+      },
+      {
+        "name": "Экваториальная Гвинея",
+        "lang": "ru"
+      },
+      {
+        "name": "Հասարակածային Գվինեա",
+        "lang": "hy"
+      },
+      {
+        "name": "ეკვატორული გვინეა",
+        "lang": "ka"
+      },
+      {
+        "name": "इक्वेटोरियल गिनी",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "इक्वेटोरियल गिनी",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "भू-मध्यीय गिनी",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "ઇક્વેટોરિયલ ગિની",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "ఎక్వేటోరియాల్ గినియా",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಈಕ್ವೆಟೋರಿಯಲ್ ಗಿನಿ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "ஈக்குவாடோரியல் கினி",
+        "isPreferredName": true,
+        "lang": "ta"
+      },
+      {
+        "name": "ഇക്വിറ്റോറിയല്‍ ഗ്വിനിയ",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "নিরক্ষীয় গিনি",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "အီကွေတာ ဂီရာနာ",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "සමක ගිනියාව",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "赤道ギニア",
+        "lang": "ja"
+      },
+      {
+        "name": "赤道ギニア共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "赤道几内亚",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Equatorial Guinea",
+    "adminCode1": "00",
+    "lng": "10.5",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 1,
+      "gmtOffset": 1,
+      "timeZoneId": "Africa/Malabo"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -1.459946,
+      "east": 11.335724,
+      "north": 3.78598,
+      "west": 5.602367
+    },
+    "name": "Equatorial Guinea",
+    "fcode": "PCLI",
+    "geonameId": 2309096,
+    "asciiName": "Republic of Equatorial Guinea",
+    "lat": "1.7",
+    "population": 1014999,
+    "adminName1": "",
+    "countryId": "2309096",
+    "fclName": "country, state, region,...",
+    "countryCode": "GQ",
+    "srtm3": 741,
+    "wikipediaURL": "en.wikipedia.org/wiki/Equatorial_Guinea",
+    "toponymName": "Republic of Equatorial Guinea",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Ethiopia": 337996,
+  "337996": {
+    "alternateNames": [
+      {
+        "name": "ኢትዮጵያ",
+        "lang": "am"
+      },
+      {
+        "name": "ኢትዮጵያ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "エチオピア",
+        "lang": "ja"
+      },
+      {
+        "name": "에티오피아",
+        "lang": "ko"
+      },
+      {
+        "name": "이디오피아",
+        "lang": "ko"
+      },
+      {
+        "name": "ଇଥିଓପିଆ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "អេត្យូពី",
+        "lang": "km"
+      },
+      {
+        "name": "ເອທິໂອເປຍ",
+        "lang": "lo"
+      },
+      {
+        "name": "เอธิโอเปีย",
+        "lang": "th"
+      },
+      {
+        "name": "ཨི་ཐིའོ་པི་ཡ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ประเทศเอธิโอเปีย",
+        "lang": "th"
+      },
+      {
+        "name": "Abessinien"
+      },
+      {
+        "name": "Abissinia"
+      },
+      {
+        "name": "Abyssinia"
+      },
+      {
+        "name": "Abyssinie"
+      },
+      {
+        "name": "Aethiopia",
+        "lang": "la"
+      },
+      {
+        "name": "An Aetiòp",
+        "lang": "gd"
+      },
+      {
+        "name": "An Aetóip",
+        "lang": "ga"
+      },
+      {
+        "name": "Äthiopien",
+        "lang": "de"
+      },
+      {
+        "name": "Äthiopien",
+        "lang": "nds"
+      },
+      {
+        "name": "Äthiopien"
+      },
+      {
+        "name": "Ecoppi",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Efiopiya",
+        "lang": "az"
+      },
+      {
+        "name": "El Habesha"
+      },
+      {
+        "name": "Esyopya",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Ethiopi",
+        "lang": "kw"
+      },
+      {
+        "name": "Ethiopia",
+        "lang": "cy"
+      },
+      {
+        "isShortName": true,
+        "name": "Ethiopia",
+        "lang": "en"
+      },
+      {
+        "name": "Ethiopia",
+        "lang": "ia"
+      },
+      {
+        "name": "Ethiopia",
+        "lang": "id"
+      },
+      {
+        "name": "Ethiopia",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Ethiopia",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Ethiopia",
+        "lang": "ms"
+      },
+      {
+        "name": "Ethiopia",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Ethiopia",
+        "lang": "pam"
+      },
+      {
+        "name": "Ethiopia",
+        "lang": "sw"
+      },
+      {
+        "name": "Ethiopia",
+        "lang": "vi"
+      },
+      {
+        "name": "Éthiopie",
+        "lang": "fr"
+      },
+      {
+        "name": "Ethiopië",
+        "lang": "af"
+      },
+      {
+        "name": "Ethiopië",
+        "lang": "li"
+      },
+      {
+        "name": "Ethiopië",
+        "lang": "nl"
+      },
+      {
+        "name": "Etijopja",
+        "lang": "mt"
+      },
+      {
+        "name": "Etioopia",
+        "lang": "et"
+      },
+      {
+        "name": "Etiopi",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Etiopi",
+        "lang": "sq"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "an"
+      },
+      {
+        "name": "Etiopia",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "eu"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "fi"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "fo"
+      },
+      {
+        "name": "Etiopia",
+        "isPreferredName": true,
+        "lang": "id"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "io"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "it"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "mg"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "nb"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "nn"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "no"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "oc"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "pl"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "rm"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "ro"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "scn"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "se"
+      },
+      {
+        "name": "Etiopia",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Etiopia",
+        "lang": "sq"
+      },
+      {
+        "name": "Etiopia"
+      },
+      {
+        "name": "Etiópia",
+        "lang": "hu"
+      },
+      {
+        "name": "Etiópia",
+        "lang": "pt"
+      },
+      {
+        "name": "Etiópia",
+        "lang": "sk"
+      },
+      {
+        "name": "Etiòpia",
+        "lang": "ca"
+      },
+      {
+        "name": "Ê-ti-ô-pi-a",
+        "lang": "vi"
+      },
+      {
+        "name": "Etiopía",
+        "lang": "ast"
+      },
+      {
+        "isShortName": true,
+        "name": "Etiopía",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Etiopía",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Ê-ti-ô-pi-a (Ethiopia)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Etiopía - Ityop'iya",
+        "lang": "gl"
+      },
+      {
+        "name": "Etiopia nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Etiopie",
+        "lang": "cs"
+      },
+      {
+        "name": "Ètiopie",
+        "lang": "frp"
+      },
+      {
+        "name": "Etiopien",
+        "lang": "da"
+      },
+      {
+        "name": "Etiopien",
+        "lang": "sv"
+      },
+      {
+        "name": "Etiopïi",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Etiopija",
+        "lang": "bs"
+      },
+      {
+        "name": "Etiopija",
+        "lang": "hbs"
+      },
+      {
+        "name": "Etiopija",
+        "lang": "hr"
+      },
+      {
+        "name": "Etiopija",
+        "lang": "lt"
+      },
+      {
+        "name": "Etiopija",
+        "lang": "lv"
+      },
+      {
+        "name": "Etiopija",
+        "lang": "sl"
+      },
+      {
+        "name": "Etiopio",
+        "lang": "eo"
+      },
+      {
+        "name": "Etiopiska",
+        "lang": "hsb"
+      },
+      {
+        "name": "Etiopujo",
+        "lang": "eo"
+      },
+      {
+        "name": "Etiyopiya",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Etiyopiya",
+        "lang": "tl"
+      },
+      {
+        "name": "Etiyopya",
+        "lang": "tr"
+      },
+      {
+        "name": "Etshiopi",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Etsíopi",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Etyopi",
+        "lang": "ht"
+      },
+      {
+        "name": "Etyopia",
+        "lang": "ilo"
+      },
+      {
+        "name": "Eþíópía",
+        "lang": "is"
+      },
+      {
+        "name": "Federal Democratic Republic of Ethiopia",
+        "lang": "en"
+      },
+      {
+        "name": "Habasha",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Habsyah",
+        "lang": "ms"
+      },
+      {
+        "name": "Hibreteseb’āwīt Ītyop’iya"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Ethiopia",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%AD%D1%84%D0%B8%D0%BE%D0%BF%D0%B8%D1%8F",
+        "lang": "link"
+      },
+      {
+        "name": "i-Ethiopia",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Ithiopia",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "ʻItiōpea",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Itiopia",
+        "lang": "kg"
+      },
+      {
+        "name": "Itiyopiya",
+        "lang": "na"
+      },
+      {
+        "name": "Itoobbiya",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Itoobiya",
+        "lang": "so"
+      },
+      {
+        "name": "Itoophiyaa",
+        "lang": "om"
+      },
+      {
+        "name": "Ītyop’iya",
+        "lang": "am"
+      },
+      {
+        "name": "Ītyop’yā"
+      },
+      {
+        "name": "Lätiopän",
+        "lang": "vo"
+      },
+      {
+        "name": "Orílẹ́ède Etopia",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Otobbia",
+        "lang": "aa"
+      },
+      {
+        "name": "People’s Democratic Republic of Ethiopia"
+      },
+      {
+        "name": "Socialist Ethiopia"
+      },
+      {
+        "name": "Uhabeshi",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Uhabeshi",
+        "lang": "sw"
+      },
+      {
+        "name": "Ye’ Etiyop’iya Niguse Negast Mengist"
+      },
+      {
+        "name": "YeĪtyop’iya Fēdēralawī Dēmokrasīyawī Rīpeblīk",
+        "lang": "am"
+      },
+      {
+        "name": "YeĪtyop’iya Hizbawī Dīmokrasīyawī Rīpublīk",
+        "lang": "am"
+      },
+      {
+        "name": "اتیوپی",
+        "lang": "fa"
+      },
+      {
+        "name": "ایتھوپیا",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "اېتوپیا",
+        "lang": "ps"
+      },
+      {
+        "name": "إثيوبيا",
+        "lang": "ar"
+      },
+      {
+        "name": "اثيوبيا",
+        "lang": "ar"
+      },
+      {
+        "name": "حبشه",
+        "lang": "ps"
+      },
+      {
+        "name": "ئەتیۆپیا",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "ئېفىئوپىيە",
+        "lang": "ug"
+      },
+      {
+        "name": "אתיופיה",
+        "lang": "he"
+      },
+      {
+        "name": "Αιθιοπία",
+        "lang": "el"
+      },
+      {
+        "name": "Етиопија",
+        "lang": "mk"
+      },
+      {
+        "name": "Етиопија",
+        "lang": "sr"
+      },
+      {
+        "name": "Етиопия",
+        "lang": "bg"
+      },
+      {
+        "name": "Ефіопія",
+        "lang": "uk"
+      },
+      {
+        "name": "Этыёпія",
+        "lang": "be"
+      },
+      {
+        "name": "Эфиопия",
+        "lang": "ru"
+      },
+      {
+        "name": "Эфиопия",
+        "lang": "tg"
+      },
+      {
+        "name": "Эфіопія",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Եթովպիա",
+        "lang": "hy"
+      },
+      {
+        "name": "ეთიოპია",
+        "lang": "ka"
+      },
+      {
+        "name": "इथिओपिया",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "इथियोपिया",
+        "lang": "hi"
+      },
+      {
+        "name": "इथोपिया",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "ईथ्योपिया",
+        "lang": "sa"
+      },
+      {
+        "name": "ઇથિઓપિયા",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "ఇథియోపియా",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಇಥಿಯೋಪಿಯಾ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "எதியோப்பியா",
+        "lang": "ta"
+      },
+      {
+        "name": "എത്യോപ്യ",
+        "lang": "ml"
+      },
+      {
+        "name": "ইথিওপিয়া",
+        "lang": "bn"
+      },
+      {
+        "name": "ইফিওপিয়া",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "အီသီယိုးပီးယား",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "ඉතියෝපියාව",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "埃塞俄比亚",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Ethiopia",
+    "adminCode1": "00",
+    "lng": "39.5",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Addis_Ababa"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 3.402422,
+      "east": 47.986179,
+      "north": 14.89375,
+      "west": 32.999939
+    },
+    "name": "Ethiopia",
+    "fcode": "PCLI",
+    "geonameId": 337996,
+    "asciiName": "Federal Democratic Republic of Ethiopia",
+    "lat": "9",
+    "population": 88013491,
+    "adminName1": "",
+    "countryId": "337996",
+    "fclName": "country, state, region,...",
+    "countryCode": "ET",
+    "srtm3": 1721,
+    "wikipediaURL": "en.wikipedia.org/wiki/Ethiopia",
+    "toponymName": "Federal Democratic Republic of Ethiopia",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Gabon": 2400553,
+  "2400553": {
+    "alternateNames": [
+      {
+        "name": "가봉",
+        "lang": "ko"
+      },
+      {
+        "name": "ጋቦን",
+        "lang": "am"
+      },
+      {
+        "name": "ጋቦን",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ガボン",
+        "lang": "ja"
+      },
+      {
+        "name": "กาบอง",
+        "lang": "th"
+      },
+      {
+        "name": "ກາບອນ",
+        "lang": "lo"
+      },
+      {
+        "name": "ଗାବୋନ୍",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "གེ་བཽན།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ហ្គាបុង",
+        "lang": "km"
+      },
+      {
+        "name": "ประเทศกาบอง",
+        "lang": "th"
+      },
+      {
+        "name": "An Ghabúin",
+        "lang": "ga"
+      },
+      {
+        "name": "El Gabon",
+        "isPreferredName": true,
+        "lang": "ca"
+      },
+      {
+        "name": "Gaaboon",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Gabão",
+        "lang": "pt"
+      },
+      {
+        "name": "Gabhoni",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Gabo",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Gabɔ",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Gaboen",
+        "lang": "af"
+      },
+      {
+        "name": "Gabon",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Gabon",
+        "lang": "bs"
+      },
+      {
+        "name": "Gabon",
+        "lang": "ca"
+      },
+      {
+        "name": "Gabon",
+        "lang": "cs"
+      },
+      {
+        "name": "Gabon",
+        "lang": "cy"
+      },
+      {
+        "name": "Gabon",
+        "lang": "da"
+      },
+      {
+        "isShortName": true,
+        "name": "Gabon",
+        "lang": "en"
+      },
+      {
+        "name": "Gabon",
+        "lang": "et"
+      },
+      {
+        "name": "Gabon",
+        "lang": "eu"
+      },
+      {
+        "name": "Gabon",
+        "lang": "fi"
+      },
+      {
+        "name": "Gabon",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "isShortName": true,
+        "name": "Gabon",
+        "lang": "fr"
+      },
+      {
+        "name": "Gabon",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Gabon",
+        "lang": "hr"
+      },
+      {
+        "name": "Gabon",
+        "lang": "hu"
+      },
+      {
+        "name": "Gabon",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Gabon",
+        "lang": "id"
+      },
+      {
+        "name": "Gabon",
+        "lang": "io"
+      },
+      {
+        "name": "Gabon",
+        "lang": "is"
+      },
+      {
+        "name": "Gabon",
+        "lang": "it"
+      },
+      {
+        "name": "Gabon",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Gabon",
+        "lang": "kw"
+      },
+      {
+        "name": "Gabon",
+        "lang": "li"
+      },
+      {
+        "name": "Gabon",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Gabon",
+        "lang": "ms"
+      },
+      {
+        "name": "Gabon",
+        "lang": "mt"
+      },
+      {
+        "name": "Gabon",
+        "lang": "nb"
+      },
+      {
+        "name": "Gabon",
+        "lang": "nl"
+      },
+      {
+        "name": "Gabon",
+        "lang": "nn"
+      },
+      {
+        "name": "Gabon",
+        "lang": "no"
+      },
+      {
+        "name": "Gabon",
+        "lang": "oc"
+      },
+      {
+        "name": "Gabon",
+        "lang": "pam"
+      },
+      {
+        "name": "Gabon",
+        "lang": "pl"
+      },
+      {
+        "name": "Gabon",
+        "lang": "ro"
+      },
+      {
+        "name": "Gabon",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Gabon",
+        "lang": "sk"
+      },
+      {
+        "name": "Gabon",
+        "lang": "sl"
+      },
+      {
+        "name": "Gabon",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Gabon",
+        "lang": "sv"
+      },
+      {
+        "name": "Gabon",
+        "lang": "sw"
+      },
+      {
+        "name": "Gabon",
+        "lang": "tl"
+      },
+      {
+        "name": "Gabon",
+        "lang": "tpi"
+      },
+      {
+        "name": "Gabon",
+        "lang": "tr"
+      },
+      {
+        "name": "Gabon",
+        "lang": "vi"
+      },
+      {
+        "name": "Gabón",
+        "lang": "an"
+      },
+      {
+        "name": "Gabón",
+        "lang": "ast"
+      },
+      {
+        "isShortName": true,
+        "name": "Gabón",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Gabón",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Gabɔn",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Gabona",
+        "lang": "lv"
+      },
+      {
+        "name": "Gabonas",
+        "lang": "lt"
+      },
+      {
+        "name": "Gabonese Republic",
+        "lang": "en"
+      },
+      {
+        "name": "Ga-bông",
+        "lang": "vi"
+      },
+      {
+        "name": "Gaboŋ",
+        "lang": "wo"
+      },
+      {
+        "name": "Gabɔŋ",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Gabón - Gabon",
+        "lang": "gl"
+      },
+      {
+        "name": "Ga-bông (Gabon)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Gaboni",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Gaboni",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Gaboni",
+        "lang": "sq"
+      },
+      {
+        "name": "Gaboni",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Gabonia",
+        "lang": "la"
+      },
+      {
+        "name": "Gabonia",
+        "lang": "sq"
+      },
+      {
+        "name": "Gabɔn nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Gabono",
+        "lang": "eo"
+      },
+      {
+        "name": "Gaboo",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Gaböon",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Gaboon Republic"
+      },
+      {
+        "name": "Gabun",
+        "lang": "de"
+      },
+      {
+        "name": "Gabun",
+        "lang": "nds"
+      },
+      {
+        "name": "Gabun",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Gabun"
+      },
+      {
+        "name": "Gabunän",
+        "lang": "vo"
+      },
+      {
+        "name": "Gjabon",
+        "lang": "sq"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Gabon",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%93%D0%B0%D0%B1%D0%BE%D0%BD",
+        "lang": "link"
+      },
+      {
+        "name": "i-Gabon",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Kaponi",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Ngabu",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Orílẹ́ède Gabon",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Qabon",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "République Gabonaise",
+        "lang": "fr"
+      },
+      {
+        "name": "Territoire du Gabon"
+      },
+      {
+        "name": "الجابون",
+        "isPreferredName": true,
+        "lang": "ar"
+      },
+      {
+        "name": "الغابون",
+        "lang": "ar"
+      },
+      {
+        "name": "غابون",
+        "lang": "ar"
+      },
+      {
+        "name": "گابن",
+        "lang": "fa"
+      },
+      {
+        "name": "گابن",
+        "lang": "ps"
+      },
+      {
+        "name": "گابۆن",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "گابون",
+        "lang": "fa"
+      },
+      {
+        "name": "گابون",
+        "lang": "ug"
+      },
+      {
+        "name": "گیبون",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "גאבאן",
+        "lang": "yi"
+      },
+      {
+        "name": "גאבון",
+        "lang": "he"
+      },
+      {
+        "name": "גבון",
+        "lang": "he"
+      },
+      {
+        "name": "Γκαμπόν",
+        "lang": "el"
+      },
+      {
+        "name": "Габон",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Габон",
+        "lang": "bg"
+      },
+      {
+        "name": "Габон",
+        "lang": "mk"
+      },
+      {
+        "name": "Габон",
+        "lang": "ru"
+      },
+      {
+        "name": "Габон",
+        "lang": "sr"
+      },
+      {
+        "name": "Габон",
+        "lang": "tg"
+      },
+      {
+        "name": "Габон",
+        "lang": "uk"
+      },
+      {
+        "name": "Ґабон",
+        "lang": "uk"
+      },
+      {
+        "name": "Գաբոն",
+        "lang": "hy"
+      },
+      {
+        "name": "გაბონი",
+        "lang": "ka"
+      },
+      {
+        "name": "गाबोन",
+        "lang": "sa"
+      },
+      {
+        "name": "गावोन",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "गॅबॉन",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "गैबॉन",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "ગેબન",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "గేబన్",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಗೆಬೊನ್",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "கேபான்",
+        "isPreferredName": true,
+        "lang": "ta"
+      },
+      {
+        "name": "ഗാബോണ്‍",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "গাবন",
+        "lang": "bn"
+      },
+      {
+        "name": "ගැබොන්",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "ガボン共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "加蓬",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Gabon",
+    "adminCode1": "00",
+    "lng": "11.75",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 1,
+      "gmtOffset": 1,
+      "timeZoneId": "Africa/Libreville"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -3.978806,
+      "east": 14.502347,
+      "north": 2.322612,
+      "west": 8.695471
+    },
+    "name": "Gabon",
+    "fcode": "PCLI",
+    "geonameId": 2400553,
+    "asciiName": "Gabonese Republic",
+    "lat": "-1",
+    "population": 1545255,
+    "adminName1": "",
+    "countryId": "2400553",
+    "fclName": "country, state, region,...",
+    "countryCode": "GA",
+    "srtm3": 328,
+    "wikipediaURL": "en.wikipedia.org/wiki/Gabon",
+    "toponymName": "Gabonese Republic",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Ghana": 2300660,
+  "2300660": {
+    "alternateNames": [
+      {
+        "name": "ጋና",
+        "lang": "am"
+      },
+      {
+        "name": "ጋና",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "가나",
+        "lang": "ko"
+      },
+      {
+        "name": "ガーナ",
+        "lang": "ja"
+      },
+      {
+        "name": "ଘାନା",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "กานา",
+        "isPreferredName": true,
+        "lang": "th"
+      },
+      {
+        "name": "ཀ་ན།",
+        "lang": "bo"
+      },
+      {
+        "name": "กาน่า",
+        "lang": "th"
+      },
+      {
+        "name": "ການ່າ",
+        "lang": "lo"
+      },
+      {
+        "name": "གྷ་ན།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ហ្កាណា",
+        "lang": "km"
+      },
+      {
+        "name": "ประเทศกานา",
+        "lang": "th"
+      },
+      {
+        "name": "Gaana",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Gaana",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Gana",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Gana",
+        "lang": "bs"
+      },
+      {
+        "name": "Gana",
+        "lang": "frp"
+      },
+      {
+        "name": "Gana",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Gana",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Gana",
+        "lang": "hbs"
+      },
+      {
+        "name": "Gana",
+        "lang": "hr"
+      },
+      {
+        "name": "Gana",
+        "lang": "is"
+      },
+      {
+        "name": "Gana",
+        "lang": "ku"
+      },
+      {
+        "name": "Gana",
+        "lang": "la"
+      },
+      {
+        "name": "Gana",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Gana",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Gana",
+        "lang": "lt"
+      },
+      {
+        "name": "Gana",
+        "lang": "lv"
+      },
+      {
+        "name": "Gana",
+        "lang": "mt"
+      },
+      {
+        "name": "Gana",
+        "lang": "na"
+      },
+      {
+        "name": "Gana",
+        "lang": "pt"
+      },
+      {
+        "name": "Gana",
+        "lang": "qu"
+      },
+      {
+        "name": "Gana",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Gana",
+        "lang": "scn"
+      },
+      {
+        "name": "Gana",
+        "lang": "sl"
+      },
+      {
+        "name": "Gana",
+        "lang": "sq"
+      },
+      {
+        "name": "Gana",
+        "lang": "tet"
+      },
+      {
+        "name": "Gana",
+        "lang": "tk"
+      },
+      {
+        "name": "Gana",
+        "lang": "tr"
+      },
+      {
+        "name": "Gana",
+        "lang": "wa"
+      },
+      {
+        "name": "Gána",
+        "lang": "ga"
+      },
+      {
+        "name": "Ganaa",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Ganäa",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Gana - Ghana",
+        "lang": "gl"
+      },
+      {
+        "name": "Ganän",
+        "lang": "vo"
+      },
+      {
+        "name": "Ganao",
+        "lang": "eo"
+      },
+      {
+        "name": "Ganë",
+        "lang": "sq"
+      },
+      {
+        "name": "Ghana",
+        "lang": "af"
+      },
+      {
+        "name": "Ghana",
+        "lang": "an"
+      },
+      {
+        "name": "Ghana",
+        "lang": "ast"
+      },
+      {
+        "name": "Ghana",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Ghana",
+        "lang": "ca"
+      },
+      {
+        "name": "Ghana",
+        "lang": "cs"
+      },
+      {
+        "name": "Ghana",
+        "lang": "cy"
+      },
+      {
+        "name": "Ghana",
+        "lang": "da"
+      },
+      {
+        "name": "Ghana",
+        "lang": "de"
+      },
+      {
+        "name": "Ghana",
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Ghana",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Ghana",
+        "lang": "et"
+      },
+      {
+        "name": "Ghana",
+        "lang": "eu"
+      },
+      {
+        "name": "Ghana",
+        "lang": "fi"
+      },
+      {
+        "name": "Ghana",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "name": "Ghana",
+        "lang": "fr"
+      },
+      {
+        "name": "Ghana",
+        "lang": "hu"
+      },
+      {
+        "name": "Ghana",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Ghana",
+        "lang": "id"
+      },
+      {
+        "name": "Ghana",
+        "lang": "ilo"
+      },
+      {
+        "name": "Ghana",
+        "lang": "io"
+      },
+      {
+        "name": "Ghana",
+        "lang": "it"
+      },
+      {
+        "name": "Ghana",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Ghana",
+        "lang": "kw"
+      },
+      {
+        "name": "Ghana",
+        "lang": "li"
+      },
+      {
+        "name": "Ghana",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Ghana",
+        "lang": "ms"
+      },
+      {
+        "name": "Ghana",
+        "lang": "nb"
+      },
+      {
+        "name": "Ghana",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Ghana",
+        "lang": "nds"
+      },
+      {
+        "name": "Ghana",
+        "lang": "nl"
+      },
+      {
+        "name": "Ghana",
+        "lang": "nn"
+      },
+      {
+        "name": "Ghana",
+        "lang": "no"
+      },
+      {
+        "name": "Ghana",
+        "lang": "oc"
+      },
+      {
+        "name": "Ghana",
+        "lang": "pam"
+      },
+      {
+        "name": "Ghana",
+        "lang": "pl"
+      },
+      {
+        "name": "Ghana",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Ghana",
+        "lang": "ro"
+      },
+      {
+        "name": "Ghana",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Ghana",
+        "lang": "sk"
+      },
+      {
+        "name": "Ghana",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Ghana",
+        "lang": "sv"
+      },
+      {
+        "name": "Ghana",
+        "lang": "sw"
+      },
+      {
+        "name": "Ghana",
+        "lang": "tl"
+      },
+      {
+        "name": "Ghana",
+        "lang": "tw"
+      },
+      {
+        "name": "Ghana",
+        "lang": "vi"
+      },
+      {
+        "name": "Gha-na",
+        "lang": "vi"
+      },
+      {
+        "name": "Ghána",
+        "lang": "hu"
+      },
+      {
+        "name": "Gha-na (Ghana)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Ghana nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Gold Coast",
+        "isHistoric": true
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Ghana",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%93%D0%B0%D0%BD%D0%B0",
+        "lang": "link"
+      },
+      {
+        "name": "i-Ghana",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Kana",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Ngana",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Ngana",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Orílẹ́ède Gana",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Qana",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Republic of Ghana"
+      },
+      {
+        "name": "ګانا",
+        "lang": "ps"
+      },
+      {
+        "name": "غانا",
+        "lang": "ar"
+      },
+      {
+        "name": "غەنا",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "غنا",
+        "lang": "fa"
+      },
+      {
+        "name": "قانا",
+        "isPreferredName": true,
+        "lang": "fa"
+      },
+      {
+        "name": "گھانا",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "گانا جۇمھۇرىيىتى",
+        "lang": "ug"
+      },
+      {
+        "name": "גאנה",
+        "lang": "he"
+      },
+      {
+        "name": "Γκάνα",
+        "lang": "el"
+      },
+      {
+        "name": "Гана",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Гана",
+        "lang": "bg"
+      },
+      {
+        "name": "Гана",
+        "lang": "mk"
+      },
+      {
+        "name": "Гана",
+        "lang": "ru"
+      },
+      {
+        "name": "Гана",
+        "lang": "sr"
+      },
+      {
+        "name": "Гана",
+        "lang": "tg"
+      },
+      {
+        "name": "Гана",
+        "lang": "uk"
+      },
+      {
+        "name": "Գանա",
+        "lang": "hy"
+      },
+      {
+        "name": "განა",
+        "lang": "ka"
+      },
+      {
+        "name": "घाना",
+        "lang": "hi"
+      },
+      {
+        "name": "घाना",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "घाना",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "ઘાના",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "ఘానా",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಘಾನಾ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "கானா",
+        "lang": "ta"
+      },
+      {
+        "name": "ഖാന",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "ഘാന",
+        "lang": "ml"
+      },
+      {
+        "name": "গানা",
+        "lang": "bn"
+      },
+      {
+        "name": "ঘানা",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "ဂါနာ",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "ඝානාව",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "ガーナ共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "加纳",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Ghana",
+    "adminCode1": "00",
+    "lng": "-1.2",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 0,
+      "gmtOffset": 0,
+      "timeZoneId": "Africa/Accra"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 4.736723,
+      "east": 1.191781,
+      "north": 11.173301,
+      "west": -3.25542
+    },
+    "name": "Ghana",
+    "fcode": "PCLI",
+    "geonameId": 2300660,
+    "asciiName": "Republic of Ghana",
+    "lat": "8.1",
+    "population": 24339838,
+    "adminName1": "",
+    "countryId": "2300660",
+    "fclName": "country, state, region,...",
+    "countryCode": "GH",
+    "srtm3": 137,
+    "wikipediaURL": "en.wikipedia.org/wiki/Ghana",
+    "toponymName": "Republic of Ghana",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Guinea": 2420477,
+  "2420477": {
+    "alternateNames": [
+      {
+        "name": "ጊኒ",
+        "lang": "am"
+      },
+      {
+        "name": "ጊኒ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ጊኔ",
+        "lang": "am"
+      },
+      {
+        "name": "기니",
+        "lang": "ko"
+      },
+      {
+        "name": "ギニア",
+        "lang": "ja"
+      },
+      {
+        "name": "กินี",
+        "lang": "th"
+      },
+      {
+        "name": "ກິວນີ",
+        "lang": "lo"
+      },
+      {
+        "name": "ଗୁଏନେଆ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "ហ្គីណេ",
+        "lang": "km"
+      },
+      {
+        "name": "གྷི་ནི་ཡ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ประเทศกินี",
+        "lang": "th"
+      },
+      {
+        "name": "An Ghuine",
+        "lang": "ga"
+      },
+      {
+        "name": "Französisch-Guinea"
+      },
+      {
+        "name": "French Guinea"
+      },
+      {
+        "name": "Ghi-nê",
+        "lang": "vi"
+      },
+      {
+        "name": "Ghi-nê (Guinea)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Gine",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Gine",
+        "lang": "ff"
+      },
+      {
+        "name": "Gine",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Gine",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Gine",
+        "lang": "tr"
+      },
+      {
+        "name": "Ginɛ",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Ginea",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Ginea",
+        "lang": "eu"
+      },
+      {
+        "name": "Ginea",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Ginea",
+        "lang": "tl"
+      },
+      {
+        "name": "Gínea",
+        "lang": "is"
+      },
+      {
+        "name": "Ginëe",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Gineja",
+        "lang": "mt"
+      },
+      {
+        "name": "Gini",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Gini",
+        "lang": "cy"
+      },
+      {
+        "name": "Gini",
+        "lang": "gd"
+      },
+      {
+        "name": "Gini",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Gini",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Gini",
+        "lang": "na"
+      },
+      {
+        "name": "Gini",
+        "lang": "so"
+      },
+      {
+        "name": "Guine",
+        "lang": "sq"
+      },
+      {
+        "name": "Guiné",
+        "lang": "pt"
+      },
+      {
+        "name": "Guinea",
+        "lang": "an"
+      },
+      {
+        "name": "Guinea",
+        "lang": "ast"
+      },
+      {
+        "name": "Guinea",
+        "lang": "ca"
+      },
+      {
+        "name": "Guinea",
+        "lang": "cs"
+      },
+      {
+        "name": "Guinea",
+        "lang": "da"
+      },
+      {
+        "name": "Guinea",
+        "lang": "de"
+      },
+      {
+        "isShortName": true,
+        "name": "Guinea",
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Guinea",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Guinea",
+        "lang": "et"
+      },
+      {
+        "name": "Guinea",
+        "lang": "fi"
+      },
+      {
+        "name": "Guinea",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "name": "Guinea",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Guinea",
+        "lang": "hu"
+      },
+      {
+        "name": "Guinea",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Guinea",
+        "lang": "id"
+      },
+      {
+        "name": "Guinea",
+        "lang": "io"
+      },
+      {
+        "name": "Guinea",
+        "lang": "it"
+      },
+      {
+        "name": "Guinea",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Guinea",
+        "lang": "la"
+      },
+      {
+        "name": "Guinea",
+        "lang": "ms"
+      },
+      {
+        "name": "Guinea",
+        "lang": "nb"
+      },
+      {
+        "name": "Guinea",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Guinea",
+        "lang": "nds"
+      },
+      {
+        "name": "Guinea",
+        "lang": "nl"
+      },
+      {
+        "name": "Guinea",
+        "lang": "nn"
+      },
+      {
+        "name": "Guinea",
+        "lang": "no"
+      },
+      {
+        "name": "Guinea",
+        "lang": "pam"
+      },
+      {
+        "name": "Guinea",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Guinea",
+        "isPreferredName": true,
+        "lang": "ro"
+      },
+      {
+        "name": "Guinea",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Guinea",
+        "lang": "sk"
+      },
+      {
+        "name": "Guinea",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Guinea",
+        "lang": "sv"
+      },
+      {
+        "name": "Guinea",
+        "lang": "sw"
+      },
+      {
+        "name": "Guinea"
+      },
+      {
+        "name": "Guinèa",
+        "lang": "oc"
+      },
+      {
+        "name": "Guinea - Guinée",
+        "lang": "gl"
+      },
+      {
+        "name": "Guinean People’s Republic"
+      },
+      {
+        "name": "Guinee",
+        "lang": "af"
+      },
+      {
+        "name": "Guinee",
+        "lang": "nl"
+      },
+      {
+        "name": "Guinée",
+        "lang": "cy"
+      },
+      {
+        "isShortName": true,
+        "name": "Guinée",
+        "lang": "fr"
+      },
+      {
+        "name": "Guinée"
+      },
+      {
+        "name": "Guineea",
+        "lang": "ro"
+      },
+      {
+        "name": "Guinée-Conakry",
+        "lang": "fr"
+      },
+      {
+        "name": "Guinée Française"
+      },
+      {
+        "name": "Guineja",
+        "lang": "sq"
+      },
+      {
+        "name": "Guini nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Guneya",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Gvineja",
+        "lang": "bs"
+      },
+      {
+        "name": "Gvineja",
+        "lang": "hr"
+      },
+      {
+        "name": "Gvineja",
+        "lang": "lv"
+      },
+      {
+        "name": "Gvineja",
+        "lang": "sl"
+      },
+      {
+        "name": "Gvinėja",
+        "lang": "lt"
+      },
+      {
+        "name": "Gvineo",
+        "lang": "eo"
+      },
+      {
+        "name": "Gwinea",
+        "lang": "pl"
+      },
+      {
+        "name": "Gyni",
+        "lang": "kw"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Guinea",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%93%D0%B2%D0%B8%D0%BD%D0%B5%D1%8F",
+        "lang": "link"
+      },
+      {
+        "name": "i-Guinea",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Kini",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Ngine",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Orílẹ́ède Gene",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "People’s Revolutionary Republic of Guinea"
+      },
+      {
+        "name": "Popular and Revolutionary Republic of Guinea"
+      },
+      {
+        "name": "Qvineya",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Republic of Guinea",
+        "lang": "en"
+      },
+      {
+        "name": "République de Guinée",
+        "lang": "fr"
+      },
+      {
+        "name": "Revolutionary People’s Republic of Guinea"
+      },
+      {
+        "name": "ګیانا",
+        "lang": "ps"
+      },
+      {
+        "name": "غينيا",
+        "lang": "ar"
+      },
+      {
+        "name": "گنی",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "گینێ",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "گینه",
+        "lang": "fa"
+      },
+      {
+        "name": "گوینیا",
+        "isPreferredName": true,
+        "lang": "fa"
+      },
+      {
+        "name": "ګونې",
+        "lang": "ps"
+      },
+      {
+        "name": "ۋىنېيە",
+        "lang": "ug"
+      },
+      {
+        "name": "גינאה",
+        "lang": "he"
+      },
+      {
+        "name": "גיניאה",
+        "lang": "he"
+      },
+      {
+        "name": "Γουινέα",
+        "lang": "el"
+      },
+      {
+        "name": "Гвинеја",
+        "lang": "mk"
+      },
+      {
+        "name": "Гвинеја",
+        "lang": "sr"
+      },
+      {
+        "name": "Гвинея",
+        "lang": "bg"
+      },
+      {
+        "name": "Гвинея",
+        "lang": "ru"
+      },
+      {
+        "name": "Гвінея",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Гвінея",
+        "lang": "uk"
+      },
+      {
+        "name": "Ґвінея",
+        "isPreferredName": true,
+        "lang": "uk"
+      },
+      {
+        "name": "Գվինեա",
+        "lang": "hy"
+      },
+      {
+        "name": "გვინეა",
+        "lang": "ka"
+      },
+      {
+        "name": "गिनी",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "गिनी",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "गिनी",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "गिनी",
+        "lang": "sa"
+      },
+      {
+        "name": "ગિની",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "గినియా",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಗಿನಿ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "கினி",
+        "lang": "ta"
+      },
+      {
+        "name": "கினியா",
+        "lang": "ta"
+      },
+      {
+        "name": "ഗ്വിനിയ",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "গিনি",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "ဂီရာနာ",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "ගිණියාව",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "ギニア共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "几内亚",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Guinea",
+    "adminCode1": "00",
+    "lng": "-10.66667",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 0,
+      "gmtOffset": 0,
+      "timeZoneId": "Africa/Conakry"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 7.193553,
+      "east": -7.641071,
+      "north": 12.67622,
+      "west": -15.086256
+    },
+    "name": "Guinea",
+    "fcode": "PCLI",
+    "geonameId": 2420477,
+    "asciiName": "Republic of Guinea",
+    "lat": "10.83333",
+    "population": 10324025,
+    "adminName1": "",
+    "countryId": "2420477",
+    "fclName": "country, state, region,...",
+    "countryCode": "GN",
+    "srtm3": 428,
+    "wikipediaURL": "en.wikipedia.org/wiki/Guinea",
+    "toponymName": "Republic of Guinea",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Guinea-Bissau": 2372248,
+  "2372248": {
+    "alternateNames": [
+      {
+        "name": "ጊኔ-ቢሳው",
+        "lang": "am"
+      },
+      {
+        "name": "ቢሳዎ",
+        "lang": "am"
+      },
+      {
+        "name": "ቢሳዎ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "기네비소",
+        "isPreferredName": true,
+        "lang": "ko"
+      },
+      {
+        "name": "기네비쏘",
+        "lang": "ko"
+      },
+      {
+        "name": "กินี-บิสเซา",
+        "lang": "th"
+      },
+      {
+        "name": "기니비사우",
+        "lang": "ko"
+      },
+      {
+        "name": "ກິວນີ-ບິສໂຊ",
+        "lang": "lo"
+      },
+      {
+        "name": "ギニアビサウ",
+        "lang": "ja"
+      },
+      {
+        "name": "ଗୁଇନିଆ-ବିସାଉ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "กินีบิสเซา",
+        "isPreferredName": true,
+        "lang": "th"
+      },
+      {
+        "name": "ประเทศกินี-บิสเซา",
+        "lang": "th"
+      },
+      {
+        "name": "ហ្គីណេប៊ីសូ",
+        "lang": "km"
+      },
+      {
+        "name": "གྷི་ནི་ཡ་བིས྄་སོ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "An Ghuine-Bhissau",
+        "lang": "ga"
+      },
+      {
+        "name": "Bisau Gvinėja",
+        "lang": "lt"
+      },
+      {
+        "name": "Bissau-Guinea",
+        "lang": "hu"
+      },
+      {
+        "name": "Ghi-nê Bít-xao",
+        "lang": "vi"
+      },
+      {
+        "name": "Ghi-nê Bít xao (Guinea-Bissau)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Gínea-Bissá",
+        "lang": "is"
+      },
+      {
+        "name": "Ginea Bissau",
+        "isPreferredName": true,
+        "lang": "eu"
+      },
+      {
+        "name": "Ginea-Bissau",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Ginea-Bissau",
+        "lang": "eu"
+      },
+      {
+        "name": "Ginea-Bissau",
+        "lang": "tl"
+      },
+      {
+        "name": "Ginea-Bissaw",
+        "lang": "mt"
+      },
+      {
+        "name": "Gine-Bisaawo",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Giné-Bisao",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Ginebisau",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Ginebisau",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Giné-Bisau",
+        "lang": "tet"
+      },
+      {
+        "name": "Ginɛbisau",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Gine Bisawo",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Gine-Biso",
+        "lang": "ff"
+      },
+      {
+        "name": "Gine-Biso",
+        "isPreferredName": true,
+        "lang": "tr"
+      },
+      {
+        "name": "Gine Bissau",
+        "lang": "tr"
+      },
+      {
+        "name": "Gine-Bissau",
+        "lang": "tr"
+      },
+      {
+        "name": "Gîne-Bissau",
+        "lang": "ku"
+      },
+      {
+        "name": "Gineya Bisawu",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Gineyän-Bisauän",
+        "lang": "vo"
+      },
+      {
+        "name": "Gini-Bisaaw",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Gini-Bisao nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Gini Bisau",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Gini Bisaw",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Gini-Bisawu",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Gini-Bitau",
+        "lang": "na"
+      },
+      {
+        "name": "Gninëe-Bisau",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Guinea Bisau",
+        "lang": "io"
+      },
+      {
+        "name": "Guinea Bisau",
+        "lang": "sq"
+      },
+      {
+        "name": "Guinea Bisau",
+        "lang": "sw"
+      },
+      {
+        "name": "Guinea-Bisau",
+        "lang": "gl"
+      },
+      {
+        "name": "Guinea-Bisáu",
+        "lang": "ast"
+      },
+      {
+        "name": "Guinea Bissau",
+        "lang": "ca"
+      },
+      {
+        "name": "Guinea Bissau",
+        "lang": "fo"
+      },
+      {
+        "name": "Guinea Bissau",
+        "lang": "id"
+      },
+      {
+        "name": "Guinea Bissau",
+        "lang": "ms"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "an"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "cs"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "cy"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "da"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "de"
+      },
+      {
+        "isShortName": true,
+        "name": "Guinea-Bissau",
+        "lang": "en"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "es"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "et"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "fi"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "hu"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "id"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "it"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "ms"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "nb"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "nds"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "nn"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "no"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "pam"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "isPreferredName": true,
+        "lang": "ro"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "sk"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Guinea-Bissau",
+        "lang": "sv"
+      },
+      {
+        "name": "Guinèa Bissau",
+        "lang": "oc"
+      },
+      {
+        "isShortName": true,
+        "name": "Guinea-Bissáu",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Guinea Bissaviensis",
+        "lang": "la"
+      },
+      {
+        "name": "Guine Bisau",
+        "lang": "sq"
+      },
+      {
+        "name": "Guinê-Bissaou",
+        "lang": "frp"
+      },
+      {
+        "name": "Guiné Bissau",
+        "lang": "pt"
+      },
+      {
+        "name": "Guiné-Bissau",
+        "lang": "pt"
+      },
+      {
+        "name": "Guiné-Bissau",
+        "lang": "vi"
+      },
+      {
+        "name": "Guineea-Bissau",
+        "lang": "ro"
+      },
+      {
+        "name": "Guinée Bissao"
+      },
+      {
+        "name": "Guinee-Bissau",
+        "lang": "af"
+      },
+      {
+        "name": "Guinee-Bissau",
+        "lang": "nl"
+      },
+      {
+        "name": "Guinée-Bissau",
+        "lang": "fr"
+      },
+      {
+        "name": "Guinée-Bissau"
+      },
+      {
+        "name": "Guiné Portuguesa"
+      },
+      {
+        "name": "Gvineja-Bisao",
+        "isPreferredName": true,
+        "lang": "bs"
+      },
+      {
+        "name": "Gvineja Bisau",
+        "lang": "hbs"
+      },
+      {
+        "name": "Gvineja Bisau",
+        "lang": "hr"
+      },
+      {
+        "name": "Gvineja-Bisau",
+        "lang": "bs"
+      },
+      {
+        "name": "Gvineja-Bisava",
+        "lang": "lv"
+      },
+      {
+        "name": "Gvineja Bissau",
+        "lang": "sl"
+      },
+      {
+        "name": "Gvineo Bisaŭa",
+        "lang": "eo"
+      },
+      {
+        "name": "Gvineo-Bisaŭo",
+        "lang": "eo"
+      },
+      {
+        "name": "Gwinea Bissau",
+        "lang": "pl"
+      },
+      {
+        "name": "Gyni-Bissaw",
+        "lang": "kw"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Guinea-Bissau",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%93%D0%B2%D0%B8%D0%BD%D0%B5%D1%8F-%D0%91%D0%B8%D1%81%D0%B0%D1%83",
+        "lang": "link"
+      },
+      {
+        "name": "i-Guinea-Bissau",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Kini-Pisau",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Nginebisau",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Orílẹ́ède Gene-Busau",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Portuguese Guinea"
+      },
+      {
+        "name": "Província da Guiné"
+      },
+      {
+        "name": "Qvineya-Bisau",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "República da Guiné-Bissau",
+        "lang": "pt"
+      },
+      {
+        "name": "Republic of Guinea-Bissau",
+        "lang": "en"
+      },
+      {
+        "name": "غينيا بيساو",
+        "lang": "ar"
+      },
+      {
+        "name": "گینێ بیساو",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "گنی بساؤ",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "گینه بیسائو",
+        "lang": "fa"
+      },
+      {
+        "name": "گینهٔ بیسائو",
+        "lang": "fa"
+      },
+      {
+        "name": "گوینیا-بیساو",
+        "isPreferredName": true,
+        "lang": "fa"
+      },
+      {
+        "name": "گۋىنېيە بىسسائۇ",
+        "lang": "ug"
+      },
+      {
+        "name": "ګوينې بېساو",
+        "lang": "ps"
+      },
+      {
+        "name": "גינאה ביסאו",
+        "lang": "he"
+      },
+      {
+        "name": "גינאה־ביסאו",
+        "isPreferredName": true,
+        "lang": "he"
+      },
+      {
+        "name": "גיניאה-ביסאו",
+        "lang": "he"
+      },
+      {
+        "name": "Γουινέα-Μπισάου",
+        "lang": "el"
+      },
+      {
+        "name": "Γουινέα-Μπισσάου",
+        "lang": "el"
+      },
+      {
+        "name": "Гвинеа-Биса",
+        "lang": "mk"
+      },
+      {
+        "name": "Гвинеа-Бисау",
+        "isPreferredName": true,
+        "lang": "sr"
+      },
+      {
+        "name": "Гвинеја Бисао",
+        "lang": "sr"
+      },
+      {
+        "name": "Гвинеја-Бисао",
+        "lang": "mk"
+      },
+      {
+        "name": "Гвинеја-Бисао",
+        "lang": "sr"
+      },
+      {
+        "name": "Гвинея Бисау",
+        "isPreferredName": true,
+        "lang": "bg"
+      },
+      {
+        "name": "Гвинея Бисау",
+        "lang": "tg"
+      },
+      {
+        "name": "Гвинея-Бисау",
+        "lang": "bg"
+      },
+      {
+        "name": "Гвинея-Бисау",
+        "lang": "ru"
+      },
+      {
+        "name": "Гвинея-Биссау",
+        "lang": "ru"
+      },
+      {
+        "name": "Гвінея-Бісау",
+        "isPreferredName": true,
+        "lang": "uk"
+      },
+      {
+        "name": "Ґвінея-Бісау",
+        "lang": "uk"
+      },
+      {
+        "name": "Гвінея-Бісаў",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Гвінея-Біссау",
+        "lang": "uk"
+      },
+      {
+        "name": "Գվինեա-Բիսաու",
+        "lang": "hy"
+      },
+      {
+        "name": "გვინეა-ბისაუ",
+        "lang": "ka"
+      },
+      {
+        "name": "गिनी-बिसाउ",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "गिनी-बिसाउ",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "गिनी-बिसाऊ",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "गीनी-बिसाउ",
+        "lang": "hi"
+      },
+      {
+        "name": "ગિની-બિસાઉ",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "గినియా-బిస్సావ్",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಗಿನಿ-ಬಿಸ್ಸಾವ್",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "கினி-பிஸ்ஸாவ்",
+        "lang": "ta"
+      },
+      {
+        "name": "ഗിനി-ബിസോ",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "গিনি-বিসাউ",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "ギニアビサウ共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "几内亚比绍",
+        "lang": "zh"
+      },
+      {
+        "name": "幾內亞比索",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Guinea-Bissau",
+    "adminCode1": "00",
+    "lng": "-15",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 0,
+      "gmtOffset": 0,
+      "timeZoneId": "Africa/Bissau"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 10.85997,
+      "east": -13.636522,
+      "north": 12.680789,
+      "west": -16.717535
+    },
+    "name": "Guinea-Bissau",
+    "fcode": "PCLI",
+    "geonameId": 2372248,
+    "asciiName": "Republic of Guinea-Bissau",
+    "lat": "12",
+    "population": 1565126,
+    "adminName1": "",
+    "countryId": "2372248",
+    "fclName": "country, state, region,...",
+    "countryCode": "GW",
+    "srtm3": 29,
+    "wikipediaURL": "en.wikipedia.org/wiki/Guinea-Bissau",
+    "toponymName": "Republic of Guinea-Bissau",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Malawi": 927384,
+  "927384": {
+    "alternateNames": [
+      {
+        "name": "ማላዊ",
+        "lang": "am"
+      },
+      {
+        "name": "ማላዊ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "말라위",
+        "lang": "ko"
+      },
+      {
+        "name": "マラウィ",
+        "lang": "ja"
+      },
+      {
+        "name": "マラウイ",
+        "lang": "ja"
+      },
+      {
+        "name": "ମାଲୱି",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "มาลาวี",
+        "lang": "th"
+      },
+      {
+        "name": "མཱ་ལཱ་ཝི།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ประเทศมาลาวี",
+        "lang": "th"
+      },
+      {
+        "name": "An Mhaláiv",
+        "lang": "ga"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Malawi",
+        "lang": "link"
+      },
+      {
+        "name": "http://id.loc.gov/authorities/names/n80089996",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%9C%D0%B0%D0%BB%D0%B0%D0%B2%D0%B8",
+        "lang": "link"
+      },
+      {
+        "name": "i-Malawi",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Malaawi",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Malaawi",
+        "lang": "so"
+      },
+      {
+        "name": "Malaoì",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Malaui",
+        "lang": "an"
+      },
+      {
+        "name": "Malaui",
+        "lang": "ast"
+      },
+      {
+        "name": "Malaui",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Malaui",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Malaui",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Malauí",
+        "isPreferredName": true,
+        "lang": "pt"
+      },
+      {
+        "name": "Malaui - Malawi",
+        "lang": "gl"
+      },
+      {
+        "name": "Ma-la-uy",
+        "lang": "vi"
+      },
+      {
+        "name": "Ma-la-uy (Malawi)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Malavi",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Malavi",
+        "lang": "bs"
+      },
+      {
+        "name": "Malavi",
+        "lang": "fo"
+      },
+      {
+        "name": "Malavi",
+        "lang": "frp"
+      },
+      {
+        "name": "Malavi",
+        "lang": "hbs"
+      },
+      {
+        "name": "Malavi",
+        "lang": "hr"
+      },
+      {
+        "name": "Malavi",
+        "lang": "sl"
+      },
+      {
+        "name": "Malavi",
+        "lang": "sq"
+      },
+      {
+        "name": "Malavi",
+        "lang": "tr"
+      },
+      {
+        "name": "Malaví",
+        "lang": "is"
+      },
+      {
+        "name": "Malavî",
+        "lang": "ku"
+      },
+      {
+        "name": "Malāvija",
+        "lang": "lv"
+      },
+      {
+        "name": "Malavio",
+        "lang": "eo"
+      },
+      {
+        "name": "Malavis",
+        "lang": "lt"
+      },
+      {
+        "name": "Malavium",
+        "lang": "la"
+      },
+      {
+        "name": "Malaviyän",
+        "lang": "vo"
+      },
+      {
+        "name": "Malawi",
+        "lang": "af"
+      },
+      {
+        "name": "Malawi",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Malawi",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Malawi",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Malawi",
+        "lang": "ca"
+      },
+      {
+        "name": "Malawi",
+        "lang": "cs"
+      },
+      {
+        "name": "Malawi",
+        "lang": "cy"
+      },
+      {
+        "name": "Malawi",
+        "lang": "da"
+      },
+      {
+        "name": "Malawi",
+        "lang": "de"
+      },
+      {
+        "name": "Malawi",
+        "lang": "en"
+      },
+      {
+        "name": "Malawi",
+        "lang": "et"
+      },
+      {
+        "name": "Malawi",
+        "lang": "eu"
+      },
+      {
+        "name": "Malawi",
+        "lang": "fi"
+      },
+      {
+        "name": "Malawi",
+        "lang": "fr"
+      },
+      {
+        "name": "Malawi",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Malawi",
+        "lang": "hu"
+      },
+      {
+        "name": "Malawi",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Malawi",
+        "lang": "id"
+      },
+      {
+        "name": "Malawi",
+        "lang": "io"
+      },
+      {
+        "name": "Malawi",
+        "lang": "it"
+      },
+      {
+        "name": "Malawi",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Malawi",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Malawi",
+        "lang": "kw"
+      },
+      {
+        "name": "Malawi",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Malawi",
+        "lang": "li"
+      },
+      {
+        "name": "Malawi",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Malawi",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Malawi",
+        "lang": "ms"
+      },
+      {
+        "name": "Malawi",
+        "lang": "mt"
+      },
+      {
+        "name": "Malawi",
+        "lang": "nb"
+      },
+      {
+        "name": "Malawi",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Malawi",
+        "lang": "nds"
+      },
+      {
+        "name": "Malawi",
+        "lang": "nl"
+      },
+      {
+        "name": "Malawi",
+        "lang": "nn"
+      },
+      {
+        "name": "Malawi",
+        "lang": "no"
+      },
+      {
+        "name": "Malawi",
+        "lang": "oc"
+      },
+      {
+        "name": "Malawi",
+        "lang": "pam"
+      },
+      {
+        "name": "Malawi",
+        "lang": "pl"
+      },
+      {
+        "name": "Malawi",
+        "lang": "pt"
+      },
+      {
+        "name": "Malawi",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Malawi",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Malawi",
+        "lang": "ro"
+      },
+      {
+        "name": "Malawi",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Malawi",
+        "lang": "sk"
+      },
+      {
+        "name": "Malawi",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Malawi",
+        "lang": "sv"
+      },
+      {
+        "name": "Malawi",
+        "lang": "sw"
+      },
+      {
+        "name": "Malawi",
+        "lang": "tl"
+      },
+      {
+        "name": "Malawi",
+        "lang": "tum"
+      },
+      {
+        "name": "Malawi",
+        "lang": "vi"
+      },
+      {
+        "name": "Malawi"
+      },
+      {
+        "name": "Malaŵi",
+        "lang": "ny"
+      },
+      {
+        "name": "Malawïi",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Malawi nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Malevia",
+        "lang": "sq"
+      },
+      {
+        "name": "Nyasaland"
+      },
+      {
+        "name": "Orílẹ́ède Malawi",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Republic of Malawi"
+      },
+      {
+        "name": "مالاوی",
+        "lang": "fa"
+      },
+      {
+        "name": "مالاوی",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "مالاۋى",
+        "lang": "ug"
+      },
+      {
+        "name": "ملاوی",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "ملاوي",
+        "lang": "ar"
+      },
+      {
+        "name": "מלאווי",
+        "lang": "he"
+      },
+      {
+        "name": "Μαλάουι",
+        "lang": "el"
+      },
+      {
+        "name": "Малави",
+        "lang": "bg"
+      },
+      {
+        "name": "Малави",
+        "lang": "mk"
+      },
+      {
+        "name": "Малави",
+        "lang": "ru"
+      },
+      {
+        "name": "Малави",
+        "lang": "sr"
+      },
+      {
+        "name": "Малави",
+        "lang": "tg"
+      },
+      {
+        "name": "Малаві",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Малаві",
+        "lang": "uk"
+      },
+      {
+        "name": "Մալավի",
+        "lang": "hy"
+      },
+      {
+        "name": "მალავი",
+        "lang": "ka"
+      },
+      {
+        "name": "मलावी",
+        "lang": "hi"
+      },
+      {
+        "name": "मलावी",
+        "lang": "ks"
+      },
+      {
+        "name": "मलावी",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "मलावी",
+        "lang": "sa"
+      },
+      {
+        "name": "मालावी",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "માલાવી",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "మాలావి",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಮಲಾವಿ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "மலாவி",
+        "lang": "ta"
+      },
+      {
+        "name": "மாலவி",
+        "isPreferredName": true,
+        "lang": "ta"
+      },
+      {
+        "name": "മലാവി",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "মালাউই",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "မာလာဝီ",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "マラウイ共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "马拉维",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Malawi",
+    "adminCode1": "00",
+    "lng": "34",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 2,
+      "gmtOffset": 2,
+      "timeZoneId": "Africa/Blantyre"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -17.125,
+      "east": 35.916821,
+      "north": -9.367541,
+      "west": 32.67395
+    },
+    "name": "Malawi",
+    "fcode": "PCLI",
+    "geonameId": 927384,
+    "asciiName": "Republic of Malawi",
+    "lat": "-13.5",
+    "population": 15447500,
+    "adminName1": "",
+    "countryId": "927384",
+    "fclName": "country, state, region,...",
+    "countryCode": "MW",
+    "srtm3": 1180,
+    "wikipediaURL": "en.wikipedia.org/wiki/Malawi",
+    "toponymName": "Republic of Malawi",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Mali": 2453866,
+  "2453866": {
+    "alternateNames": [
+      {
+        "name": "ማሊ",
+        "lang": "am"
+      },
+      {
+        "name": "ማሊ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "マリ",
+        "lang": "ja"
+      },
+      {
+        "name": "말리",
+        "lang": "ko"
+      },
+      {
+        "name": "ମାଳୀ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "มาลี",
+        "lang": "th"
+      },
+      {
+        "name": "ມາລິ",
+        "lang": "lo"
+      },
+      {
+        "name": "མ་ལི།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ម៉ាលី",
+        "lang": "km"
+      },
+      {
+        "name": "ประเทศมาลี",
+        "lang": "th"
+      },
+      {
+        "name": "French Sudan",
+        "isHistoric": true
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Mali",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%9C%D0%B0%D0%BB%D0%B8",
+        "lang": "link"
+      },
+      {
+        "name": "i-Mali",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Maali",
+        "lang": "ff"
+      },
+      {
+        "name": "Maali",
+        "lang": "so"
+      },
+      {
+        "name": "Mailí",
+        "lang": "ga"
+      },
+      {
+        "name": "Mali",
+        "lang": "af"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Mali",
+        "lang": "an"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Mali",
+        "lang": "bm"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Mali",
+        "lang": "bs"
+      },
+      {
+        "name": "Mali",
+        "lang": "ca"
+      },
+      {
+        "name": "Mali",
+        "lang": "cs"
+      },
+      {
+        "name": "Mali",
+        "lang": "cy"
+      },
+      {
+        "name": "Mali",
+        "lang": "da"
+      },
+      {
+        "name": "Mali",
+        "lang": "de"
+      },
+      {
+        "name": "Mali",
+        "lang": "en"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Mali",
+        "lang": "et"
+      },
+      {
+        "name": "Mali",
+        "lang": "eu"
+      },
+      {
+        "name": "Mali",
+        "lang": "fi"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "isShortName": true,
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "name": "Mali",
+        "lang": "frp"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Mali",
+        "lang": "hbs"
+      },
+      {
+        "name": "Mali",
+        "lang": "hr"
+      },
+      {
+        "name": "Mali",
+        "lang": "hu"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Mali",
+        "lang": "id"
+      },
+      {
+        "name": "Mali",
+        "lang": "ilo"
+      },
+      {
+        "name": "Mali",
+        "lang": "io"
+      },
+      {
+        "name": "Mali",
+        "lang": "it"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Mali",
+        "lang": "kw"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Mali",
+        "lang": "li"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Mali",
+        "lang": "lv"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Mali",
+        "lang": "ms"
+      },
+      {
+        "name": "Mali",
+        "lang": "mt"
+      },
+      {
+        "name": "Mali",
+        "lang": "nb"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Mali",
+        "lang": "nds"
+      },
+      {
+        "name": "Mali",
+        "lang": "nl"
+      },
+      {
+        "name": "Mali",
+        "lang": "nn"
+      },
+      {
+        "name": "Mali",
+        "lang": "no"
+      },
+      {
+        "name": "Mali",
+        "lang": "oc"
+      },
+      {
+        "name": "Mali",
+        "lang": "pam"
+      },
+      {
+        "name": "Mali",
+        "lang": "pl"
+      },
+      {
+        "name": "Mali",
+        "lang": "pt"
+      },
+      {
+        "name": "Mali",
+        "lang": "qu"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Mali",
+        "lang": "ro"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Mali",
+        "lang": "sk"
+      },
+      {
+        "name": "Mali",
+        "lang": "sl"
+      },
+      {
+        "name": "Mali",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Mali",
+        "lang": "sq"
+      },
+      {
+        "name": "Mali",
+        "lang": "sv"
+      },
+      {
+        "name": "Mali",
+        "lang": "sw"
+      },
+      {
+        "name": "Mali",
+        "lang": "tk"
+      },
+      {
+        "name": "Mali",
+        "lang": "tl"
+      },
+      {
+        "name": "Mali",
+        "lang": "tr"
+      },
+      {
+        "name": "Mali",
+        "lang": "vi"
+      },
+      {
+        "name": "Ma-li",
+        "lang": "vi"
+      },
+      {
+        "name": "Māli",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Malí",
+        "lang": "ast"
+      },
+      {
+        "name": "Malí",
+        "lang": "is"
+      },
+      {
+        "name": "Malí",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Mālī",
+        "lang": "ks"
+      },
+      {
+        "name": "Malïi",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Malí - Mali",
+        "lang": "gl"
+      },
+      {
+        "name": "Mali nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Malio",
+        "lang": "eo"
+      },
+      {
+        "name": "Malis",
+        "lang": "lt"
+      },
+      {
+        "name": "Maliyän",
+        "lang": "vo"
+      },
+      {
+        "name": "Orílẹ́ède Mali",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Republic of Mali"
+      },
+      {
+        "name": "République du Mali",
+        "lang": "fr"
+      },
+      {
+        "name": "République du Mali"
+      },
+      {
+        "name": "République Soudanaise"
+      },
+      {
+        "name": "Soudan"
+      },
+      {
+        "name": "Soudanese Republic"
+      },
+      {
+        "name": "Soudan Français"
+      },
+      {
+        "name": "Sudán Francés"
+      },
+      {
+        "name": "مالی",
+        "lang": "fa"
+      },
+      {
+        "name": "مالی",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "مالی",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "مالي",
+        "lang": "ar"
+      },
+      {
+        "name": "מאלי",
+        "lang": "he"
+      },
+      {
+        "name": "Μάλι",
+        "lang": "el"
+      },
+      {
+        "name": "Мали",
+        "lang": "bg"
+      },
+      {
+        "name": "Мали",
+        "lang": "mk"
+      },
+      {
+        "name": "Мали",
+        "lang": "ru"
+      },
+      {
+        "name": "Мали",
+        "lang": "sr"
+      },
+      {
+        "name": "Малӣ",
+        "lang": "tg"
+      },
+      {
+        "name": "Малі",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Малі",
+        "lang": "uk"
+      },
+      {
+        "name": "Մալի",
+        "lang": "hy"
+      },
+      {
+        "name": "მალი",
+        "lang": "ka"
+      },
+      {
+        "name": "माली",
+        "lang": "hi"
+      },
+      {
+        "name": "माली",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "माली",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "माली",
+        "lang": "sa"
+      },
+      {
+        "name": "માલી",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "మాలి",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಮಾಲಿ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "மாலீ",
+        "lang": "ta"
+      },
+      {
+        "name": "മാലി",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "মালি",
+        "lang": "bn"
+      },
+      {
+        "name": "မာလီ",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "මාලි",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "マリ共和国",
+        "lang": "ja"
+      },
+      {
+        "name": "马里",
+        "lang": "zh"
+      },
+      {
+        "name": "马里共和国",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Mali",
+    "adminCode1": "00",
+    "lng": "-2",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 0,
+      "gmtOffset": 0,
+      "timeZoneId": "Africa/Bamako"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 10.159513,
+      "east": 4.244968,
+      "north": 25.000002,
+      "west": -12.242614
+    },
+    "name": "Mali",
+    "fcode": "PCLI",
+    "geonameId": 2453866,
+    "asciiName": "Republic of Mali",
+    "lat": "18",
+    "population": 13796354,
+    "adminName1": "",
+    "countryId": "2453866",
+    "fclName": "country, state, region,...",
+    "countryCode": "ML",
+    "srtm3": 297,
+    "wikipediaURL": "en.wikipedia.org/wiki/Mali",
+    "toponymName": "Republic of Mali",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Mozambique": 1036973,
+  "1036973": {
+    "alternateNames": [
+      {
+        "name": "모잠비크",
+        "lang": "ko"
+      },
+      {
+        "name": "ሞዛምቢክ",
+        "lang": "am"
+      },
+      {
+        "name": "ሞዛምቢክ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "モザンビーク",
+        "lang": "ja"
+      },
+      {
+        "name": "โมซัมบิก",
+        "isPreferredName": true,
+        "lang": "th"
+      },
+      {
+        "name": "โมแซมบิค",
+        "lang": "th"
+      },
+      {
+        "name": "ໂມແຊມບິກ",
+        "lang": "lo"
+      },
+      {
+        "name": "མོ་ཛམ་བིག།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ମୋଜାମ୍ବିକ୍ୟୁ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "ម៉ូហ្សាំប៊ិក",
+        "lang": "km"
+      },
+      {
+        "name": "ประเทศโมซัมบิก",
+        "lang": "th"
+      },
+      {
+        "name": "Colónia de Moçambique"
+      },
+      {
+        "name": "Estado de Moçambique"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Mozambique",
+        "lang": "link"
+      },
+      {
+        "name": "http://id.loc.gov/authorities/names/n81082759",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%9C%D0%BE%D0%B7%D0%B0%D0%BC%D0%B1%D0%B8%D0%BA",
+        "lang": "link"
+      },
+      {
+        "name": "i-Mozambique",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Mazambik",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Moçambic",
+        "lang": "ca"
+      },
+      {
+        "name": "Moçambic",
+        "lang": "oc"
+      },
+      {
+        "name": "Moçambique",
+        "isPreferredName": true,
+        "lang": "da"
+      },
+      {
+        "name": "Moçambique",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Moçambique",
+        "lang": "pt"
+      },
+      {
+        "name": "Moçambique",
+        "lang": "sv"
+      },
+      {
+        "name": "Mô-dăm-bích",
+        "lang": "vi"
+      },
+      {
+        "name": "Mô-dăm- bích (Mozambique)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Mósaimbíc",
+        "lang": "ga"
+      },
+      {
+        "name": "Mosambic",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Mosambice",
+        "lang": "ang"
+      },
+      {
+        "name": "Mosambiek",
+        "lang": "af"
+      },
+      {
+        "name": "Mosambiik",
+        "lang": "et"
+      },
+      {
+        "name": "Mosambik",
+        "lang": "cs"
+      },
+      {
+        "name": "Mosambik",
+        "lang": "de"
+      },
+      {
+        "name": "Mosambik",
+        "lang": "fi"
+      },
+      {
+        "name": "Mosambik",
+        "lang": "fo"
+      },
+      {
+        "name": "Mosambik",
+        "lang": "kw"
+      },
+      {
+        "name": "Mosambik",
+        "lang": "nb"
+      },
+      {
+        "name": "Mosambik",
+        "lang": "nds"
+      },
+      {
+        "name": "Mosambik",
+        "lang": "nn"
+      },
+      {
+        "name": "Mosambik",
+        "lang": "no"
+      },
+      {
+        "name": "Mosambik",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Mósambík",
+        "lang": "is"
+      },
+      {
+        "name": "Mosambikän",
+        "lang": "vo"
+      },
+      {
+        "name": "Mosambike",
+        "lang": "ilo"
+      },
+      {
+        "name": "Mosambike",
+        "lang": "tet"
+      },
+      {
+        "name": "Mosammbik",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Mosenipiki",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Mozambic",
+        "lang": "ro"
+      },
+      {
+        "name": "Mozambico",
+        "isPreferredName": true,
+        "lang": "it"
+      },
+      {
+        "name": "Mozambicum",
+        "lang": "la"
+      },
+      {
+        "name": "Mozambiiki",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Mozambik",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Mozambik",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Mozambik",
+        "lang": "bs"
+      },
+      {
+        "name": "Mozambik",
+        "isPreferredName": true,
+        "lang": "cs"
+      },
+      {
+        "name": "Mozambik",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Mozambik",
+        "lang": "hbs"
+      },
+      {
+        "name": "Mozambik",
+        "lang": "hr"
+      },
+      {
+        "name": "Mozambik",
+        "lang": "hu"
+      },
+      {
+        "name": "Mozambik",
+        "lang": "id"
+      },
+      {
+        "name": "Mozambik",
+        "lang": "io"
+      },
+      {
+        "name": "Mozambik",
+        "lang": "ms"
+      },
+      {
+        "name": "Mozambik",
+        "lang": "pl"
+      },
+      {
+        "name": "Mozambik",
+        "lang": "sk"
+      },
+      {
+        "name": "Mozambik",
+        "lang": "sl"
+      },
+      {
+        "name": "Mozambik",
+        "lang": "sq"
+      },
+      {
+        "name": "Mozambik",
+        "lang": "tr"
+      },
+      {
+        "name": "Możambik",
+        "lang": "mt"
+      },
+      {
+        "name": "Mozambîk",
+        "lang": "ku"
+      },
+      {
+        "name": "Mozambika",
+        "lang": "lv"
+      },
+      {
+        "name": "Mozambika",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Mözämbîka",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Mozambikas",
+        "lang": "lt"
+      },
+      {
+        "name": "Mozambike",
+        "lang": "eu"
+      },
+      {
+        "name": "Mozambiki",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Mozambiki",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Mozambíki",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Mozambiki nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Mozambiko",
+        "lang": "eo"
+      },
+      {
+        "name": "Mozambiku",
+        "lang": "sq"
+      },
+      {
+        "name": "Mozambique",
+        "lang": "an"
+      },
+      {
+        "name": "Mozambique",
+        "lang": "ast"
+      },
+      {
+        "name": "Mozambique",
+        "lang": "cy"
+      },
+      {
+        "name": "Mozambique",
+        "lang": "da"
+      },
+      {
+        "isShortName": true,
+        "name": "Mozambique",
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Mozambique",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Mozambique",
+        "lang": "fr"
+      },
+      {
+        "name": "Mozambique",
+        "lang": "frp"
+      },
+      {
+        "name": "Mozambique",
+        "lang": "gd"
+      },
+      {
+        "name": "Mozambique",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Mozambique",
+        "lang": "ia"
+      },
+      {
+        "name": "Mozambique",
+        "lang": "id"
+      },
+      {
+        "name": "Mozambique",
+        "lang": "ms"
+      },
+      {
+        "name": "Mozambique",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Mozambique",
+        "lang": "nl"
+      },
+      {
+        "name": "Mozambique",
+        "lang": "pam"
+      },
+      {
+        "name": "Mozambique",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Mozambique",
+        "lang": "tl"
+      },
+      {
+        "name": "Mozambique",
+        "lang": "ts"
+      },
+      {
+        "name": "Mozambique",
+        "lang": "vi"
+      },
+      {
+        "name": "Mozambique - Moçambique",
+        "lang": "gl"
+      },
+      {
+        "name": "Mozanbiki",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Msumbiji",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Msumbiji",
+        "lang": "sw"
+      },
+      {
+        "name": "Musambiig",
+        "lang": "so"
+      },
+      {
+        "name": "Orílẹ́ède Moṣamibiku",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "People’s Republic of Mozambique"
+      },
+      {
+        "name": "Portuguese East Africa"
+      },
+      {
+        "name": "Província de Moçambique"
+      },
+      {
+        "name": "República de Moçambique",
+        "lang": "pt"
+      },
+      {
+        "name": "República Popular de Moçambique"
+      },
+      {
+        "name": "Republic of Mozambique",
+        "lang": "en"
+      },
+      {
+        "name": "State of Mozambique"
+      },
+      {
+        "name": "مۆزامبیک",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "موزامبیک",
+        "lang": "fa"
+      },
+      {
+        "name": "موزامبىك",
+        "lang": "ug"
+      },
+      {
+        "name": "موزمبیق",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "موزمبيق",
+        "lang": "ar"
+      },
+      {
+        "name": "מוזמביק",
+        "lang": "he"
+      },
+      {
+        "name": "Μοζαμβίκη",
+        "lang": "el"
+      },
+      {
+        "name": "Мазамбік",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Мозамбе",
+        "lang": "mk"
+      },
+      {
+        "name": "Мозамбик",
+        "lang": "bg"
+      },
+      {
+        "name": "Мозамбик",
+        "lang": "mk"
+      },
+      {
+        "name": "Мозамбик",
+        "lang": "os"
+      },
+      {
+        "name": "Мозамбик",
+        "lang": "ru"
+      },
+      {
+        "name": "Мозамбик",
+        "lang": "sr"
+      },
+      {
+        "name": "Мозамбик",
+        "lang": "tg"
+      },
+      {
+        "name": "Мозамбік",
+        "lang": "uk"
+      },
+      {
+        "name": "Մոզամբիկ",
+        "lang": "hy"
+      },
+      {
+        "name": "მოზამბიკი",
+        "lang": "ka"
+      },
+      {
+        "name": "मोजम्बीक",
+        "lang": "ks"
+      },
+      {
+        "name": "मोजम्बीक",
+        "lang": "sa"
+      },
+      {
+        "name": "मोजाम्बिक",
+        "lang": "hi"
+      },
+      {
+        "name": "मोजाम्बिक",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "मोज़ाम्बिक",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "मोझाम्बिक",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "मोस़ाम्बीक",
+        "lang": "hi"
+      },
+      {
+        "name": "મોઝામ્બિક",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "మొజాంబిక్",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಮೊಜಾಂಬಿಕ್",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "மொசாம்பிக்",
+        "isPreferredName": true,
+        "lang": "ta"
+      },
+      {
+        "name": "മൊസാംബിക്ക്",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "মোজাম্বিক",
+        "lang": "bn"
+      },
+      {
+        "name": "မိုဇန်ဘစ်",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "මොසැම්බික්",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "モザンビーク共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "莫桑比克",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Mozambique",
+    "adminCode1": "00",
+    "lng": "35",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 2,
+      "gmtOffset": 2,
+      "timeZoneId": "Africa/Maputo"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -26.868685,
+      "east": 40.844471,
+      "north": -10.471883,
+      "west": 30.217319
+    },
+    "name": "Mozambique",
+    "fcode": "PCLI",
+    "geonameId": 1036973,
+    "asciiName": "Republic of Mozambique",
+    "lat": "-18.25",
+    "population": 22061451,
+    "adminName1": "",
+    "countryId": "1036973",
+    "fclName": "country, state, region,...",
+    "countryCode": "MZ",
+    "srtm3": 138,
+    "wikipediaURL": "en.wikipedia.org/wiki/Mozambique",
+    "toponymName": "Republic of Mozambique",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Nigeria": 2328926,
+  "2328926": {
+    "alternateNames": [
+      {
+        "name": "ናይጄሪያ",
+        "lang": "am"
+      },
+      {
+        "name": "ናይጄሪያ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "나이지리아",
+        "lang": "ko"
+      },
+      {
+        "name": "ナイジェリア",
+        "lang": "ja"
+      },
+      {
+        "name": "ໄນຈີເລຍ",
+        "lang": "lo"
+      },
+      {
+        "name": "ନାଇଜେରିଆ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "ไนจีเรีย",
+        "lang": "th"
+      },
+      {
+        "name": "នីហ្សេរីយ៉ា",
+        "lang": "km"
+      },
+      {
+        "name": "ནཱའི་ཇི་རི་ཡ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ประเทศไนจีเรีย",
+        "lang": "th"
+      },
+      {
+        "name": "An Nigéir",
+        "lang": "ga"
+      },
+      {
+        "name": "Federal Republic of Nigeria"
+      },
+      {
+        "name": "Federation of Nigeria"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Nigeria",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%9D%D0%B8%D0%B3%D0%B5%D1%80%D0%B8%D1%8F",
+        "lang": "link"
+      },
+      {
+        "name": "i-Nigeria",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "INigeria",
+        "lang": "xh"
+      },
+      {
+        "name": "Naegyeria",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Naigeria",
+        "lang": "ig"
+      },
+      {
+        "name": "Nàìjíríà",
+        "lang": "yo"
+      },
+      {
+        "name": "Naijiriya",
+        "lang": "yo"
+      },
+      {
+        "name": "Nainjeria",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Naisilia",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Naisīlia",
+        "lang": "to"
+      },
+      {
+        "name": "Najeriya",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Nayijerya",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Nayjeeriya",
+        "lang": "so"
+      },
+      {
+        "name": "Nicheria",
+        "lang": "an"
+      },
+      {
+        "name": "Nidjeria",
+        "lang": "wa"
+      },
+      {
+        "name": "Nigeeria",
+        "lang": "et"
+      },
+      {
+        "name": "Nìgeiria",
+        "lang": "gd"
+      },
+      {
+        "name": "Nigeri",
+        "lang": "sq"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "ang"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "br"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "cy"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "da"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "de"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Nigeria",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "eu"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "fi"
+      },
+      {
+        "name": "Nigeria",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "name": "Nigeria",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "name": "Nigeria",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "id"
+      },
+      {
+        "name": "Nigeria",
+        "isPreferredName": true,
+        "lang": "ig"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "ilo"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "io"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "it"
+      },
+      {
+        "name": "Nigeria",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "la"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "li"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "ms"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "nb"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "nds"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "nl"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "nn"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "no"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "pam"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "pl"
+      },
+      {
+        "name": "Nigeria",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "ro"
+      },
+      {
+        "name": "Nigeria",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Nigeria",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "sq"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "sv"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "sw"
+      },
+      {
+        "name": "Nigeria",
+        "lang": "vi"
+      },
+      {
+        "name": "Nigeria"
+      },
+      {
+        "name": "Nigéria",
+        "lang": "fr"
+      },
+      {
+        "name": "Nigéria",
+        "lang": "hu"
+      },
+      {
+        "name": "Nigéria",
+        "lang": "pt"
+      },
+      {
+        "name": "Nigéria",
+        "lang": "sk"
+      },
+      {
+        "name": "Nigèria",
+        "lang": "ca"
+      },
+      {
+        "name": "Nigèria",
+        "lang": "oc"
+      },
+      {
+        "name": "Nig·èria",
+        "lang": "frp"
+      },
+      {
+        "name": "Nígería",
+        "lang": "is"
+      },
+      {
+        "name": "Nigeria nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Nigérie",
+        "lang": "cs"
+      },
+      {
+        "name": "Nigerië",
+        "lang": "af"
+      },
+      {
+        "name": "Nigerija",
+        "lang": "bs"
+      },
+      {
+        "name": "Nigerija",
+        "lang": "hbs"
+      },
+      {
+        "name": "Nigerija",
+        "lang": "hr"
+      },
+      {
+        "name": "Nigerija",
+        "lang": "lt"
+      },
+      {
+        "name": "Nigerija",
+        "lang": "sl"
+      },
+      {
+        "name": "Nigērija",
+        "lang": "lv"
+      },
+      {
+        "name": "Niĝerio",
+        "lang": "eo"
+      },
+      {
+        "name": "Nigeriya",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Nigeriýa",
+        "lang": "tk"
+      },
+      {
+        "name": "Nigeriyän",
+        "lang": "vo"
+      },
+      {
+        "name": "Niġerja",
+        "lang": "mt"
+      },
+      {
+        "name": "Nigerya",
+        "lang": "tl"
+      },
+      {
+        "name": "Ni-giê-ri-a",
+        "lang": "vi"
+      },
+      {
+        "name": "Ni-giê-ri-a (Nigeria)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Nijeri",
+        "lang": "kw"
+      },
+      {
+        "name": "Nijeria",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Nijeriya",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Nijeriya",
+        "lang": "ha"
+      },
+      {
+        "name": "Nijeriya",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Nijeriya",
+        "lang": "rw"
+      },
+      {
+        "name": "Nijeriyaa",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Nijerya",
+        "lang": "ht"
+      },
+      {
+        "name": "Nijerya",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Nijerya",
+        "lang": "tr"
+      },
+      {
+        "name": "Nixeria",
+        "lang": "ast"
+      },
+      {
+        "name": "Nixeria",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Nixeria - Nigeria",
+        "lang": "gl"
+      },
+      {
+        "name": "Nizeria",
+        "lang": "kg"
+      },
+      {
+        "name": "Nizeria",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Nizerïa",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Nizeriya",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Nizerya",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Orílẹ́ède Nàìjíríà",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Republic of Nigeria"
+      },
+      {
+        "name": "Republic of Songhai"
+      },
+      {
+        "name": "نایجیریا",
+        "lang": "ps"
+      },
+      {
+        "name": "نائجیریا",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "نیجریه",
+        "lang": "fa"
+      },
+      {
+        "name": "نيجيريا",
+        "lang": "ar"
+      },
+      {
+        "name": "نىگېرىيە",
+        "lang": "ug"
+      },
+      {
+        "name": "ניגריה",
+        "lang": "he"
+      },
+      {
+        "name": "Νιγηρία",
+        "lang": "el"
+      },
+      {
+        "name": "Нигери",
+        "lang": "cv"
+      },
+      {
+        "name": "Нигерија",
+        "lang": "mk"
+      },
+      {
+        "name": "Нигерија",
+        "lang": "sr"
+      },
+      {
+        "name": "Нигерия",
+        "lang": "bg"
+      },
+      {
+        "name": "Нигерия",
+        "lang": "ru"
+      },
+      {
+        "name": "Ниҷерия",
+        "lang": "tg"
+      },
+      {
+        "name": "Нігерія",
+        "lang": "uk"
+      },
+      {
+        "name": "Ніґерія",
+        "lang": "uk"
+      },
+      {
+        "name": "Нігерыя",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Նիգերիա",
+        "lang": "hy"
+      },
+      {
+        "name": "ნიგერია",
+        "lang": "ka"
+      },
+      {
+        "name": "नाइजेरिया",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "नाईजीरिया",
+        "lang": "hi"
+      },
+      {
+        "name": "नायजेरिया",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "નાઇજીરીયા",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "నైజీరియా",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ನೈಜೀರಿಯಾ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "நைஜீரியா",
+        "lang": "ta"
+      },
+      {
+        "name": "നൈജീരിയ",
+        "lang": "ml"
+      },
+      {
+        "name": "নাইজেরিয়া",
+        "lang": "bn"
+      },
+      {
+        "name": "နိုင်ဂျီးရီးယား",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "නයිජීරියාව",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "奈及利亞",
+        "lang": "zh"
+      },
+      {
+        "name": "尼日利亚",
+        "lang": "zh"
+      },
+      {
+        "name": "ナイジェリア連邦共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      }
+    ],
+    "countryName": "Nigeria",
+    "adminCode1": "00",
+    "lng": "8",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 1,
+      "gmtOffset": 1,
+      "timeZoneId": "Africa/Lagos"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 4.277144,
+      "east": 14.680073,
+      "north": 13.892007,
+      "west": 2.668432
+    },
+    "name": "Nigeria",
+    "fcode": "PCLI",
+    "geonameId": 2328926,
+    "asciiName": "Federal Republic of Nigeria",
+    "lat": "10",
+    "population": 154000000,
+    "adminName1": "",
+    "countryId": "2328926",
+    "fclName": "country, state, region,...",
+    "countryCode": "NG",
+    "srtm3": 779,
+    "wikipediaURL": "en.wikipedia.org/wiki/Nigeria",
+    "toponymName": "Federal Republic of Nigeria",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "São Tomé": 2410763,
+  "2410763": {
+    "alternateNames": [
+      {
+        "name": "ሳን ቶሜ",
+        "lang": "am"
+      },
+      {
+        "name": "상투메",
+        "lang": "ko"
+      },
+      {
+        "name": "サントメ",
+        "lang": "ja"
+      },
+      {
+        "name": "เซาตูเม",
+        "lang": "th"
+      },
+      {
+        "name": "སའོ་ཊོ་མེ།",
+        "lang": "bo"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/S%C3%A3o_Tom%C3%A9",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%A1%D0%B0%D0%BD-%D0%A2%D0%BE%D0%BC%D0%B5_%28%D0%B3%D0%BE%D1%80%D0%BE%D0%B4%29",
+        "lang": "link"
+      },
+      {
+        "name": "Salazar"
+      },
+      {
+        "name": "San Tomas",
+        "lang": "tl"
+      },
+      {
+        "name": "Santome",
+        "lang": "lv"
+      },
+      {
+        "name": "San-Tome",
+        "lang": "az"
+      },
+      {
+        "name": "San Tomé",
+        "lang": "gl"
+      },
+      {
+        "name": "San Tomė",
+        "lang": "lt"
+      },
+      {
+        "name": "Santo Tomé",
+        "lang": "es"
+      },
+      {
+        "name": "Santo Tomé",
+        "lang": "pap"
+      },
+      {
+        "name": "Sào Thomé"
+      },
+      {
+        "name": "Sao Tome",
+        "lang": "ht"
+      },
+      {
+        "name": "Sao Tome",
+        "lang": "io"
+      },
+      {
+        "name": "Sao Tome",
+        "lang": "ku"
+      },
+      {
+        "name": "Sao Tome",
+        "lang": "nov"
+      },
+      {
+        "name": "Sao Tome",
+        "lang": "so"
+      },
+      {
+        "name": "Sao Tome",
+        "lang": "sw"
+      },
+      {
+        "name": "Sao Tome",
+        "lang": "war"
+      },
+      {
+        "name": "Sao Tomé",
+        "lang": "nl"
+      },
+      {
+        "name": "São Tomé",
+        "lang": "da"
+      },
+      {
+        "name": "São Tomé",
+        "lang": "de"
+      },
+      {
+        "name": "São Tomé",
+        "lang": "en"
+      },
+      {
+        "name": "São Tomé",
+        "lang": "fi"
+      },
+      {
+        "name": "São Tomé",
+        "lang": "fr"
+      },
+      {
+        "name": "São Tomé",
+        "lang": "hr"
+      },
+      {
+        "name": "São Tomé",
+        "lang": "it"
+      },
+      {
+        "name": "São Tomé",
+        "lang": "no"
+      },
+      {
+        "name": "São Tomé",
+        "lang": "pl"
+      },
+      {
+        "name": "São Tomé",
+        "lang": "pt"
+      },
+      {
+        "name": "São Tomé",
+        "lang": "sv"
+      },
+      {
+        "name": "Sao Tomee",
+        "lang": "fy"
+      },
+      {
+        "name": "Sao-Tomeo",
+        "lang": "eo"
+      },
+      {
+        "name": "Söo Tomé",
+        "lang": "da"
+      },
+      {
+        "name": "Svätý Tomáš",
+        "lang": "sk"
+      },
+      {
+        "name": "Urbs Sancti Thomae",
+        "lang": "la"
+      },
+      {
+        "name": "ساو تۆمێ",
+        "lang": "ckb"
+      },
+      {
+        "name": "ساو تومي",
+        "lang": "ar"
+      },
+      {
+        "name": "ساؤ ٹومے",
+        "lang": "ur"
+      },
+      {
+        "name": "ساو ٹومے",
+        "lang": "pnb"
+      },
+      {
+        "name": "سائوتومه",
+        "lang": "fa"
+      },
+      {
+        "name": "סאו טומה",
+        "lang": "he"
+      },
+      {
+        "name": "Σάο Τομέ",
+        "lang": "el"
+      },
+      {
+        "name": "Горад Сан-Тамэ",
+        "lang": "be"
+      },
+      {
+        "name": "Сан-Томе",
+        "lang": "ky"
+      },
+      {
+        "name": "Сан-Томе",
+        "lang": "mrj"
+      },
+      {
+        "name": "Сан-Томе",
+        "lang": "ru"
+      },
+      {
+        "name": "Сан-Томе",
+        "lang": "tg"
+      },
+      {
+        "name": "Сан-Томе",
+        "lang": "udm"
+      },
+      {
+        "name": "Сан-Томе",
+        "lang": "uk"
+      },
+      {
+        "name": "Сао Томе",
+        "lang": "bg"
+      },
+      {
+        "name": "Сао Томе",
+        "lang": "mk"
+      },
+      {
+        "name": "Сао Томе",
+        "lang": "sr"
+      },
+      {
+        "name": "Սան Տոմե",
+        "lang": "hy"
+      },
+      {
+        "name": "სან-ტომე",
+        "lang": "ka"
+      },
+      {
+        "name": "साओ टोमे",
+        "lang": "mr"
+      },
+      {
+        "name": "ਸਾਓ ਤੋਮੇ",
+        "lang": "pa"
+      },
+      {
+        "name": "സാവോ ടോം",
+        "lang": "ml"
+      },
+      {
+        "name": "সাও টোমে",
+        "lang": "bpy"
+      },
+      {
+        "name": "圣多美",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "São Tomé and Príncipe",
+    "adminCode1": "02",
+    "lng": "6.72732",
+    "adminName2": "",
+    "fcodeName": "capital of a political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 0,
+      "gmtOffset": 0,
+      "timeZoneId": "Africa/Sao_Tome"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 0.30671163594662404,
+      "east": 6.7571527003289225,
+      "north": 0.36636875275608766,
+      "west": 6.697494363880062
+    },
+    "name": "São Tomé",
+    "fcode": "PPLC",
+    "geonameId": 2410763,
+    "asciiName": "Sao Tome",
+    "lat": "0.33654",
+    "population": 53300,
+    "adminName1": "São Tomé Island",
+    "adminId1": "2410764",
+    "countryId": "2410758",
+    "fclName": "city, village,...",
+    "countryCode": "ST",
+    "srtm3": 8,
+    "wikipediaURL": "en.wikipedia.org/wiki/S%C3%A3o_Tom%C3%A9",
+    "toponymName": "São Tomé",
+    "fcl": "P",
+    "continentCode": "AF"
+  },
+  "Senegal": 2245662,
+  "2245662": {
+    "alternateNames": [
+      {
+        "name": "세네갈",
+        "lang": "ko"
+      },
+      {
+        "name": "ሴኔጋል",
+        "lang": "am"
+      },
+      {
+        "name": "ሴኔጋል",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "セネガル",
+        "lang": "ja"
+      },
+      {
+        "name": "เซเนกัล",
+        "lang": "th"
+      },
+      {
+        "name": "ຊິນີກັນ",
+        "lang": "lo"
+      },
+      {
+        "name": "ସେନେଗାଲ୍",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "སེ་ནི་གྷལ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "សេនេហ្កាល់",
+        "lang": "km"
+      },
+      {
+        "name": "ประเทศเซเนกัล",
+        "lang": "th"
+      },
+      {
+        "name": "An tSeineagáil",
+        "lang": "ga"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Senegal",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%A1%D0%B5%D0%BD%D0%B5%D0%B3%D0%B0%D0%BB",
+        "lang": "link"
+      },
+      {
+        "name": "i-Senegal",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Orílẹ́ède Sẹnẹga",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Republic of Senegal",
+        "lang": "en"
+      },
+      {
+        "name": "République du Sénégal",
+        "lang": "fr"
+      },
+      {
+        "name": "Seanagal",
+        "lang": "gd"
+      },
+      {
+        "name": "Senegaal",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Senegaal",
+        "lang": "wo"
+      },
+      {
+        "name": "Senegaalo",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Senegal",
+        "lang": "af"
+      },
+      {
+        "name": "Senegal",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Senegal",
+        "lang": "an"
+      },
+      {
+        "name": "Senegal",
+        "lang": "ast"
+      },
+      {
+        "name": "Senegal",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Senegal",
+        "lang": "bs"
+      },
+      {
+        "name": "Senegal",
+        "lang": "ca"
+      },
+      {
+        "name": "Senegal",
+        "lang": "cs"
+      },
+      {
+        "name": "Senegal",
+        "lang": "cy"
+      },
+      {
+        "name": "Senegal",
+        "lang": "da"
+      },
+      {
+        "name": "Senegal",
+        "lang": "de"
+      },
+      {
+        "isShortName": true,
+        "name": "Senegal",
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Senegal",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Senegal",
+        "lang": "et"
+      },
+      {
+        "name": "Senegal",
+        "lang": "eu"
+      },
+      {
+        "name": "Senegal",
+        "lang": "ff"
+      },
+      {
+        "name": "Senegal",
+        "lang": "fi"
+      },
+      {
+        "name": "Senegal",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "name": "Senegal",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Senegal",
+        "lang": "hbs"
+      },
+      {
+        "name": "Senegal",
+        "lang": "hr"
+      },
+      {
+        "name": "Senegal",
+        "lang": "ht"
+      },
+      {
+        "name": "Senegal",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Senegal",
+        "lang": "id"
+      },
+      {
+        "name": "Senegal",
+        "lang": "ilo"
+      },
+      {
+        "name": "Senegal",
+        "lang": "io"
+      },
+      {
+        "name": "Senegal",
+        "lang": "is"
+      },
+      {
+        "name": "Senegal",
+        "lang": "it"
+      },
+      {
+        "name": "Senegal",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Senegal",
+        "lang": "kw"
+      },
+      {
+        "name": "Senegal",
+        "lang": "lmo"
+      },
+      {
+        "name": "Senegal",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Senegal",
+        "lang": "ms"
+      },
+      {
+        "name": "Senegal",
+        "lang": "mt"
+      },
+      {
+        "name": "Senegal",
+        "lang": "nb"
+      },
+      {
+        "name": "Senegal",
+        "lang": "nds"
+      },
+      {
+        "name": "Senegal",
+        "lang": "nl"
+      },
+      {
+        "name": "Senegal",
+        "lang": "nn"
+      },
+      {
+        "name": "Senegal",
+        "lang": "no"
+      },
+      {
+        "name": "Senegal",
+        "lang": "oc"
+      },
+      {
+        "name": "Senegal",
+        "lang": "pam"
+      },
+      {
+        "name": "Senegal",
+        "lang": "pl"
+      },
+      {
+        "name": "Senegal",
+        "lang": "pms"
+      },
+      {
+        "name": "Senegal",
+        "lang": "pt"
+      },
+      {
+        "name": "Senegal",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Senegal",
+        "lang": "ro"
+      },
+      {
+        "name": "Senegal",
+        "lang": "scn"
+      },
+      {
+        "name": "Senegal",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Senegal",
+        "lang": "sk"
+      },
+      {
+        "name": "Senegal",
+        "lang": "sl"
+      },
+      {
+        "name": "Senegal",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Senegal",
+        "lang": "sv"
+      },
+      {
+        "name": "Senegal",
+        "lang": "sw"
+      },
+      {
+        "name": "Senegal",
+        "lang": "tl"
+      },
+      {
+        "name": "Senegal",
+        "lang": "tr"
+      },
+      {
+        "name": "Senegal"
+      },
+      {
+        "name": "Sénégal",
+        "lang": "cy"
+      },
+      {
+        "isShortName": true,
+        "name": "Sénégal",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "name": "Sénégal",
+        "lang": "vi"
+      },
+      {
+        "name": "Sénégal"
+      },
+      {
+        "name": "Sènègal",
+        "lang": "frp"
+      },
+      {
+        "name": "Senegāla",
+        "lang": "lv"
+      },
+      {
+        "name": "Senegalän",
+        "lang": "vo"
+      },
+      {
+        "name": "Senegalas",
+        "lang": "lt"
+      },
+      {
+        "name": "Senegale",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Senegäle",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Senegalɛ",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Senegali",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Senegali",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Senegali",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Senegali",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Senegali",
+        "lang": "sq"
+      },
+      {
+        "name": "Senegali",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Senegalia",
+        "lang": "la"
+      },
+      {
+        "name": "Senegal nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Senegalo",
+        "lang": "eo"
+      },
+      {
+        "name": "Senegal - Sénégal",
+        "lang": "gl"
+      },
+      {
+        "name": "Seneqal",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Senikalo",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Sinigaal",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Sinigal",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Szenegál",
+        "lang": "hu"
+      },
+      {
+        "name": "Xê-nê-gan",
+        "lang": "vi"
+      },
+      {
+        "name": "Xê-nê-gan (Senegal)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "السنغال",
+        "lang": "ar"
+      },
+      {
+        "name": "سنغال",
+        "lang": "ar"
+      },
+      {
+        "name": "سینیگال",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "سېنېگال",
+        "lang": "ug"
+      },
+      {
+        "name": "سنگال",
+        "lang": "fa"
+      },
+      {
+        "name": "سینیگل",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "סנגאל",
+        "lang": "he"
+      },
+      {
+        "name": "סנגל",
+        "lang": "he"
+      },
+      {
+        "name": "Σενεγάλη",
+        "lang": "el"
+      },
+      {
+        "name": "Сенегал",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Сенегал",
+        "lang": "bg"
+      },
+      {
+        "name": "Сенегал",
+        "lang": "mk"
+      },
+      {
+        "name": "Сенегал",
+        "lang": "ru"
+      },
+      {
+        "name": "Сенегал",
+        "lang": "sr"
+      },
+      {
+        "name": "Сенегал",
+        "lang": "tg"
+      },
+      {
+        "name": "Сенегал",
+        "lang": "uk"
+      },
+      {
+        "name": "Сенеґал",
+        "lang": "uk"
+      },
+      {
+        "name": "Սենեգալ",
+        "lang": "hy"
+      },
+      {
+        "name": "სენეგალი",
+        "lang": "ka"
+      },
+      {
+        "name": "सेनेगल",
+        "lang": "hi"
+      },
+      {
+        "name": "सेनेगल",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "सेनेगाल",
+        "lang": "mr"
+      },
+      {
+        "name": "सेनेगाल",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "સેનેગલ",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "సెనెగల్",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಸೆನೆಗಲ್",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "செனிகல்",
+        "lang": "ta"
+      },
+      {
+        "name": "செனெகல்",
+        "isPreferredName": true,
+        "lang": "ta"
+      },
+      {
+        "name": "സെനഗല്‍",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "സെനെഗൽ",
+        "lang": "ml"
+      },
+      {
+        "name": "সেনেগাল",
+        "lang": "bn"
+      },
+      {
+        "name": "ဆီနီဂေါ",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "セネガル共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "塞内加尔",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Senegal",
+    "adminCode1": "00",
+    "lng": "-14.25",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 0,
+      "gmtOffset": 0,
+      "timeZoneId": "Africa/Dakar"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 12.307275,
+      "east": -11.355887,
+      "north": 16.691633,
+      "west": -17.535236
+    },
+    "name": "Senegal",
+    "fcode": "PCLI",
+    "geonameId": 2245662,
+    "asciiName": "Republic of Senegal",
+    "lat": "14.5",
+    "population": 12323252,
+    "adminName1": "",
+    "countryId": "2245662",
+    "fclName": "country, state, region,...",
+    "countryCode": "SN",
+    "srtm3": 53,
+    "wikipediaURL": "en.wikipedia.org/wiki/Senegal",
+    "toponymName": "Republic of Senegal",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "South Africa": 953987,
+  "953987": {
+    "alternateNames": [
+      {
+        "name": "남아공",
+        "lang": "ko"
+      },
+      {
+        "name": "ደቡብ አፍሪካ",
+        "lang": "am"
+      },
+      {
+        "name": "ደቡብ አፍሪካ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ལྷོ་ ཨཕྲི་ཀ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "남아프리카",
+        "lang": "ko"
+      },
+      {
+        "name": "남아프리카 공화국",
+        "isPreferredName": true,
+        "lang": "ko"
+      },
+      {
+        "name": "ଦକ୍ଷିଣ ଆଫ୍ରିକା",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "แอฟริกาใต้",
+        "lang": "th"
+      },
+      {
+        "name": "ອາຟະລິກາໃຕ້",
+        "lang": "lo"
+      },
+      {
+        "name": "སའུཐ་ཨཕ་རི་ཀ",
+        "lang": "dz"
+      },
+      {
+        "name": "ประเทศแอฟริกาใต้",
+        "lang": "th"
+      },
+      {
+        "name": "អាហ្វ្រិកខាងត្បូង",
+        "lang": "km"
+      },
+      {
+        "name": "Aferika Borwa",
+        "lang": "tn"
+      },
+      {
+        "name": "ʻAfilika tonga",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Afirka Ta Kudu",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Aforika Borwa",
+        "lang": "tn"
+      },
+      {
+        "name": "Afraga a Deas",
+        "lang": "gd"
+      },
+      {
+        "name": "Africa Australis",
+        "lang": "la"
+      },
+      {
+        "name": "Africa dal Sid",
+        "lang": "rm"
+      },
+      {
+        "name": "Africa del Sud",
+        "lang": "ia"
+      },
+      {
+        "name": "Africa de Sud",
+        "lang": "ro"
+      },
+      {
+        "name": "África do Sul",
+        "lang": "pt"
+      },
+      {
+        "name": "Africa du Sud",
+        "lang": "frp"
+      },
+      {
+        "name": "Àfrica dû Sud",
+        "lang": "scn"
+      },
+      {
+        "name": "Afrika Anaafo",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Afrika Atsimo",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Afrika Borwa",
+        "lang": "st"
+      },
+      {
+        "name": "Afrika-Borwa",
+        "lang": "nso"
+      },
+      {
+        "name": "Afrika Dhyhow",
+        "lang": "kw"
+      },
+      {
+        "name": "Afrika Dzonga",
+        "lang": "ts"
+      },
+      {
+        "name": "Afrika e Jugut",
+        "lang": "sq"
+      },
+      {
+        "name": "Afrika Kusini",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Afrika Kusini",
+        "lang": "sw"
+      },
+      {
+        "name": "Afrika Selatan",
+        "lang": "id"
+      },
+      {
+        "name": "Afrika Selatan",
+        "lang": "ms"
+      },
+      {
+        "name": "Afrika t’Isfel",
+        "lang": "mt"
+      },
+      {
+        "name": "Afrîkaya Başûr",
+        "lang": "ku"
+      },
+      {
+        "name": "Afrika ya Kusini",
+        "lang": "sw"
+      },
+      {
+        "name": "Afrika ya Súdi",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Afríka ya Súdi",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Afrik bŋ Worgo",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Afrik disid",
+        "lang": "ht"
+      },
+      {
+        "name": "Afrik Disid",
+        "lang": "ht"
+      },
+      {
+        "name": "Afrique du Sud",
+        "lang": "fr"
+      },
+      {
+        "name": "Afrique du Sud",
+        "lang": "nrm"
+      },
+      {
+        "name": "Afryka Południowa",
+        "lang": "pl"
+      },
+      {
+        "name": "Afurika Tshipembe"
+      },
+      {
+        "name": "Afurika y'Epfo",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "An Afraic Theas",
+        "lang": "ga"
+      },
+      {
+        "name": "Anyiehe Afrika nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Awherika ki te Tonga",
+        "lang": "mi"
+      },
+      {
+        "name": "Āwherika-ki-te-tonga",
+        "lang": "mi"
+      },
+      {
+        "name": "Cənub Afrika",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Cộng hòa Nam Phi",
+        "lang": "vi"
+      },
+      {
+        "name": "De Affrica",
+        "lang": "cy"
+      },
+      {
+        "name": "Dél-Afrika",
+        "lang": "hu"
+      },
+      {
+        "name": "Dél-afrikai Köztársaság",
+        "lang": "hu"
+      },
+      {
+        "name": "Dienvidāfrika",
+        "lang": "lv"
+      },
+      {
+        "name": "Dienvidāfrikas Republika",
+        "lang": "lv"
+      },
+      {
+        "name": "Etelä-Afrikka",
+        "lang": "fi"
+      },
+      {
+        "name": "Güney Afrika",
+        "lang": "tr"
+      },
+      {
+        "name": "Güney Afrika Cumhuriyeti",
+        "lang": "tr"
+      },
+      {
+        "name": "Hegoafrika",
+        "lang": "eu"
+      },
+      {
+        "name": "Hego Afrika",
+        "lang": "eu"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/South_Africa",
+        "lang": "link"
+      },
+      {
+        "name": "http://id.loc.gov/authorities/names/n79023005",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%AE%D0%B6%D0%BD%D0%BE-%D0%90%D1%84%D1%80%D0%B8%D0%BA%D0%B0%D0%BD%D1%81%D0%BA%D0%B0%D1%8F_%D0%A0%D0%B5%D1%81%D0%BF%D1%83%D0%B1%D0%BB%D0%B8%D0%BA%D0%B0",
+        "lang": "link"
+      },
+      {
+        "name": "iNingizimu Afrika",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "iRiphabhulikhi ye Ningizimu Afrika",
+        "lang": "ss"
+      },
+      {
+        "name": "iRiphabhuliki yase Ningizimu Afrika",
+        "lang": "zu"
+      },
+      {
+        "name": "IRiphabliki yaseNingizimu Afrika",
+        "lang": "zu"
+      },
+      {
+        "name": "iRiphabliki ye Sewula Afrika"
+      },
+      {
+        "name": "iRiphabliki yom Zantsi Afrika",
+        "lang": "xh"
+      },
+      {
+        "name": "iSewula Afrika"
+      },
+      {
+        "name": "Jihoafrická republika",
+        "lang": "cs"
+      },
+      {
+        "name": "Jižní Afrika",
+        "lang": "cs"
+      },
+      {
+        "name": "Južna Afrika",
+        "lang": "bs"
+      },
+      {
+        "name": "Južna Afrika",
+        "lang": "hbs"
+      },
+      {
+        "name": "Južna Afrika",
+        "lang": "hr"
+      },
+      {
+        "name": "Južná Afrika",
+        "lang": "sk"
+      },
+      {
+        "name": "Južnoafrička Republika",
+        "lang": "bs"
+      },
+      {
+        "name": "Južnoafrička Republika",
+        "lang": "hr"
+      },
+      {
+        "name": "Južnoafriška republika",
+        "isPreferredName": true,
+        "lang": "sl"
+      },
+      {
+        "name": "Koonfur Afrika",
+        "lang": "so"
+      },
+      {
+        "name": "Lõuna-Aafrika",
+        "isPreferredName": true,
+        "lang": "et"
+      },
+      {
+        "name": "Lõuna-Aafrika Vabariik",
+        "lang": "et"
+      },
+      {
+        "name": "Mátta-Afrihká",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Mauling Aprika",
+        "lang": "pam"
+      },
+      {
+        "name": "Mbongo-Afrîka",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Mzansi ye Afrika",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Nam Phi",
+        "lang": "vi"
+      },
+      {
+        "name": "Orílẹ́ède Ariwa Afirika",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Pietų Afrika",
+        "lang": "lt"
+      },
+      {
+        "name": "Pietų Afrikos Respublika",
+        "lang": "lt"
+      },
+      {
+        "name": "Repabliki ya Afrika-Borwa",
+        "lang": "nso"
+      },
+      {
+        "name": "Rephaboliki ya Aforika Borwa",
+        "lang": "tn"
+      },
+      {
+        "name": "Rephaboliki ya Afrika Borwa",
+        "lang": "st"
+      },
+      {
+        "name": "República Sudafricana",
+        "lang": "ast"
+      },
+      {
+        "name": "Republic of South Africa",
+        "lang": "en"
+      },
+      {
+        "name": "Republiek van Suid-Afrika",
+        "lang": "af"
+      },
+      {
+        "name": "Republika Južna Afrika",
+        "lang": "sl"
+      },
+      {
+        "name": "Republika Południowej Afryki",
+        "lang": "pl"
+      },
+      {
+        "name": "Republik Südafrika",
+        "isPreferredName": true,
+        "lang": "de"
+      },
+      {
+        "name": "Riphabliki ra Afrika Dzonga",
+        "lang": "ts"
+      },
+      {
+        "name": "Riphabuliki ya Afurika Tshipembe"
+      },
+      {
+        "name": "Saut Aprika",
+        "lang": "tpi"
+      },
+      {
+        "name": "Sawusafirika",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Sør-Afrika",
+        "lang": "nb"
+      },
+      {
+        "name": "Sør-Afrika",
+        "lang": "nn"
+      },
+      {
+        "name": "Sør-Afrika",
+        "lang": "no"
+      },
+      {
+        "isShortName": true,
+        "name": "South Africa",
+        "lang": "en"
+      },
+      {
+        "name": "South Africa",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Suafrika",
+        "lang": "br"
+      },
+      {
+        "name": "Sūðaffrica",
+        "lang": "ang"
+      },
+      {
+        "name": "Sudafrica",
+        "lang": "an"
+      },
+      {
+        "name": "Sudafrica",
+        "lang": "it"
+      },
+      {
+        "name": "Sud-Africa",
+        "lang": "oc"
+      },
+      {
+        "isShortName": true,
+        "name": "Sudáfrica",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Sudáfrica",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Sudàfrica",
+        "isPreferredName": true,
+        "lang": "ca"
+      },
+      {
+        "name": "Sudàfrica",
+        "lang": "pms"
+      },
+      {
+        "name": "Sud-àfrica",
+        "lang": "ca"
+      },
+      {
+        "name": "Sud Afrika",
+        "lang": "nov"
+      },
+      {
+        "name": "Sud-Afrika",
+        "lang": "io"
+      },
+      {
+        "name": "Südafrika",
+        "lang": "de"
+      },
+      {
+        "name": "Südafrika",
+        "lang": "lb"
+      },
+      {
+        "name": "Sud-Afriko",
+        "lang": "eo"
+      },
+      {
+        "name": "Suðurafrika",
+        "lang": "fo"
+      },
+      {
+        "name": "Suður-Afríka",
+        "lang": "is"
+      },
+      {
+        "name": "Suid-Afrika",
+        "lang": "af"
+      },
+      {
+        "name": "Suráfrica",
+        "lang": "gl"
+      },
+      {
+        "name": "Süüdafrika",
+        "lang": "nds"
+      },
+      {
+        "name": "Sydafrika",
+        "lang": "da"
+      },
+      {
+        "name": "Sydafrika",
+        "lang": "sv"
+      },
+      {
+        "name": "Timog Aprika",
+        "lang": "tl"
+      },
+      {
+        "name": "umZantsi Afrika",
+        "lang": "xh"
+      },
+      {
+        "name": "UMzantsi Afrika",
+        "lang": "xh"
+      },
+      {
+        "name": "Unie van Suid-Afrika",
+        "lang": "af"
+      },
+      {
+        "name": "Union of South Africa"
+      },
+      {
+        "name": "Worodugu Afriki",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Zuid-Afrika",
+        "lang": "li"
+      },
+      {
+        "name": "Zuid-Afrika",
+        "lang": "nl"
+      },
+      {
+        "name": "آفریقای جنوبی",
+        "lang": "fa"
+      },
+      {
+        "name": "افریقای جنوبی",
+        "lang": "fa"
+      },
+      {
+        "name": "جمهورية جنوب افريقيا",
+        "isPreferredName": true,
+        "lang": "ar"
+      },
+      {
+        "name": "جەنۇبىي ئافرىقا",
+        "lang": "ug"
+      },
+      {
+        "name": "جٔنوٗبی اَفریٖقہ",
+        "lang": "ks"
+      },
+      {
+        "name": "جنوبی افریقہ",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "جنوب أفريقيا",
+        "lang": "ar"
+      },
+      {
+        "name": "جنوب افريقيا",
+        "lang": "ar"
+      },
+      {
+        "name": "ئەفریقای باشوور",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "דרום אפריקה",
+        "lang": "he"
+      },
+      {
+        "name": "Νότια Αφρική",
+        "lang": "el"
+      },
+      {
+        "name": "Африқои Ҷанубӣ",
+        "lang": "tg"
+      },
+      {
+        "name": "Јужна Африка",
+        "lang": "mk"
+      },
+      {
+        "name": "Јужна Африка",
+        "lang": "sr"
+      },
+      {
+        "name": "Јужноафричка Република",
+        "lang": "sr"
+      },
+      {
+        "name": "Оңтүстік Африка республикасы",
+        "isPreferredName": true,
+        "lang": "kk"
+      },
+      {
+        "name": "ПАР",
+        "lang": "uk"
+      },
+      {
+        "name": "Паўднёва-Афрыканская Рэспубліка",
+        "lang": "be"
+      },
+      {
+        "name": "Південна Африка",
+        "isPreferredName": true,
+        "lang": "uk"
+      },
+      {
+        "name": "Південно-Африканська Республіка",
+        "lang": "uk"
+      },
+      {
+        "name": "Република Южна Африка",
+        "lang": "bg"
+      },
+      {
+        "name": "Юар",
+        "isPreferredName": true,
+        "lang": "ru"
+      },
+      {
+        "name": "ЮАР",
+        "isPreferredName": true,
+        "lang": "bg"
+      },
+      {
+        "name": "Южна Африка",
+        "lang": "bg"
+      },
+      {
+        "name": "Южноафриканска република",
+        "lang": "bg"
+      },
+      {
+        "name": "Южно-Африканская Республика",
+        "lang": "ru"
+      },
+      {
+        "name": "Հարավային Աֆրիկա",
+        "lang": "hy"
+      },
+      {
+        "name": "სამხრეთ აფრიკა",
+        "lang": "ka"
+      },
+      {
+        "name": "სამხრეთ აფრიკის რესპუბლიკა",
+        "lang": "ka"
+      },
+      {
+        "name": "दक्षिण अफ्रिका",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "दक्षिण अफ्रिका",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "दक्षिण अफ्रीका",
+        "lang": "hi"
+      },
+      {
+        "name": "दक्षिण अफ़्रीका",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "दक्षिण-आफ्रिका",
+        "lang": "sa"
+      },
+      {
+        "name": "દક્ષિણ આફ્રિકા",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "దక్షిణ ఆఫ్రికా రాజ్యం",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ದಕ್ಷಿಣ ಆಫ್ರಿಕಾ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "தென் ஆப்பிரிக்கா",
+        "isPreferredName": true,
+        "lang": "ta"
+      },
+      {
+        "name": "தென்னாப்பிரிக்கா",
+        "lang": "ta"
+      },
+      {
+        "name": "ദക്ഷിണാഫ്രിക്ക",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "দক্ষিণ আফ্রিকা",
+        "lang": "bn"
+      },
+      {
+        "name": "တောင်အာဖရိက",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "දකුණු අප්‍රිකාව",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "南アフリカ",
+        "lang": "ja"
+      },
+      {
+        "name": "南アフリカ共和国",
+        "lang": "ja"
+      },
+      {
+        "name": "南非",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "South Africa",
+    "adminCode1": "00",
+    "lng": "24",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 2,
+      "gmtOffset": 2,
+      "timeZoneId": "Africa/Johannesburg"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -46.978931,
+      "east": 38.000465,
+      "north": -22.126612,
+      "west": 16.458021
+    },
+    "name": "South Africa",
+    "fcode": "PCLI",
+    "geonameId": 953987,
+    "asciiName": "Republic of South Africa",
+    "lat": "-29",
+    "population": 49000000,
+    "adminName1": "",
+    "countryId": "953987",
+    "fclName": "country, state, region,...",
+    "countryCode": "ZA",
+    "srtm3": 1037,
+    "wikipediaURL": "en.wikipedia.org/wiki/South_Africa",
+    "toponymName": "Republic of South Africa",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Sudan": 366755,
+  "366755": {
+    "alternateNames": [
+      {
+        "name": "수단",
+        "lang": "ko"
+      },
+      {
+        "name": "ሱዳን",
+        "lang": "am"
+      },
+      {
+        "name": "ሱዳን",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "スーダン",
+        "lang": "ja"
+      },
+      {
+        "name": "ซูดาน",
+        "lang": "th"
+      },
+      {
+        "name": "ຊູດານ",
+        "lang": "lo"
+      },
+      {
+        "name": "ସୁଦାନ୍",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "ស៊ូដង់",
+        "lang": "km"
+      },
+      {
+        "name": "སུ་དཱན།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ประเทศซูดาน",
+        "lang": "th"
+      },
+      {
+        "name": "Anglo-Egyptian Sudan"
+      },
+      {
+        "name": "An tSúdáin",
+        "lang": "ga"
+      },
+      {
+        "name": "As Sūdān",
+        "lang": "ar"
+      },
+      {
+        "name": "El Sudan",
+        "isPreferredName": true,
+        "lang": "ca"
+      },
+      {
+        "name": "Es Sūdān el Inglīzi el Masri"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Sudan",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%A1%D1%83%D0%B4%D0%B0%D0%BD",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%A1%D1%83%D0%B4%D0%B0%D0%BD_%28%D0%B7%D0%BD%D0%B0%D1%87%D0%B5%D0%BD%D0%B8%D1%8F%29",
+        "lang": "link"
+      },
+      {
+        "name": "i-Sudan",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Jamhuryat el-Sudan"
+      },
+      {
+        "name": "Jumhūrīyat as Sūdān"
+      },
+      {
+        "name": "Jumhūrīyat as Sūdān ad Dīmuqrāţīyah"
+      },
+      {
+        "name": "Orílẹ́ède Sudani",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Republic of the Sudan"
+      },
+      {
+        "name": "Sodan",
+        "lang": "frp"
+      },
+      {
+        "name": "Sodan",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Sodan",
+        "lang": "oc"
+      },
+      {
+        "name": "Soedan",
+        "lang": "af"
+      },
+      {
+        "name": "Soedan",
+        "lang": "nl"
+      },
+      {
+        "name": "Soudan",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Soudan",
+        "lang": "fr"
+      },
+      {
+        "name": "Soudan",
+        "lang": "ht"
+      },
+      {
+        "name": "Soudan",
+        "lang": "kw"
+      },
+      {
+        "name": "Soudan"
+      },
+      {
+        "name": "Suda",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Sudá",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Sudaan",
+        "lang": "et"
+      },
+      {
+        "name": "Sudaan",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Sudäan",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Sudaani",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Sudan",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Sudan",
+        "lang": "ang"
+      },
+      {
+        "name": "Sudan",
+        "lang": "az"
+      },
+      {
+        "name": "Sudan",
+        "lang": "bs"
+      },
+      {
+        "name": "Sudan",
+        "lang": "ca"
+      },
+      {
+        "name": "Sudan",
+        "lang": "da"
+      },
+      {
+        "name": "Sudan",
+        "lang": "de"
+      },
+      {
+        "name": "Sudan",
+        "lang": "en"
+      },
+      {
+        "name": "Sudan",
+        "lang": "eu"
+      },
+      {
+        "name": "Sudan",
+        "lang": "fi"
+      },
+      {
+        "name": "Sudan",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "name": "Sudan",
+        "lang": "gd"
+      },
+      {
+        "name": "Sudan",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Sudan",
+        "lang": "hbs"
+      },
+      {
+        "name": "Sudan",
+        "lang": "hr"
+      },
+      {
+        "name": "Sudan",
+        "lang": "hsb"
+      },
+      {
+        "name": "Sudan",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Sudan",
+        "lang": "id"
+      },
+      {
+        "name": "Sudan",
+        "lang": "ilo"
+      },
+      {
+        "name": "Sudan",
+        "lang": "io"
+      },
+      {
+        "name": "Sudan",
+        "lang": "it"
+      },
+      {
+        "name": "Sudan",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Sudan",
+        "lang": "lij"
+      },
+      {
+        "name": "Sudan",
+        "lang": "ms"
+      },
+      {
+        "name": "Sudan",
+        "lang": "mt"
+      },
+      {
+        "name": "Sudan",
+        "lang": "nb"
+      },
+      {
+        "name": "Sudan",
+        "lang": "nds"
+      },
+      {
+        "name": "Sudan",
+        "lang": "nn"
+      },
+      {
+        "name": "Sudan",
+        "lang": "no"
+      },
+      {
+        "name": "Sudan",
+        "lang": "pam"
+      },
+      {
+        "name": "Sudan",
+        "lang": "pl"
+      },
+      {
+        "name": "Sudan",
+        "lang": "qu"
+      },
+      {
+        "name": "Sudan",
+        "lang": "rm"
+      },
+      {
+        "name": "Sudan",
+        "lang": "ro"
+      },
+      {
+        "name": "Sudan",
+        "lang": "se"
+      },
+      {
+        "name": "Sudan",
+        "lang": "sl"
+      },
+      {
+        "name": "Sudan",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Sudan",
+        "lang": "sv"
+      },
+      {
+        "name": "Sudan",
+        "lang": "sw"
+      },
+      {
+        "name": "Sudan",
+        "lang": "tl"
+      },
+      {
+        "name": "Sudan",
+        "lang": "tr"
+      },
+      {
+        "name": "Sudan",
+        "lang": "uz"
+      },
+      {
+        "name": "Sudan",
+        "lang": "vi"
+      },
+      {
+        "name": "Súdan",
+        "lang": "is"
+      },
+      {
+        "name": "Sûdan",
+        "lang": "ku"
+      },
+      {
+        "name": "Sudán",
+        "lang": "an"
+      },
+      {
+        "name": "Sudán",
+        "lang": "ast"
+      },
+      {
+        "isShortName": true,
+        "name": "Sudán",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Sudán",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Sudán",
+        "lang": "sk"
+      },
+      {
+        "name": "Súdán",
+        "lang": "cs"
+      },
+      {
+        "name": "Sudän",
+        "lang": "vo"
+      },
+      {
+        "name": "Sudāna",
+        "lang": "lv"
+      },
+      {
+        "name": "Sudanas",
+        "lang": "lt"
+      },
+      {
+        "name": "Sudaŋ",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Sudani",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Sudani",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Sudani",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Sudani",
+        "lang": "sq"
+      },
+      {
+        "name": "Sudani",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Sudania",
+        "lang": "la"
+      },
+      {
+        "name": "Sudan nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Sudano",
+        "lang": "eo"
+      },
+      {
+        "name": "Sudán - السودان",
+        "lang": "gl"
+      },
+      {
+        "name": "Sudão",
+        "lang": "pt"
+      },
+      {
+        "name": "Sūteni",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Suudaan",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Swdan",
+        "lang": "cy"
+      },
+      {
+        "name": "Szudán",
+        "lang": "hu"
+      },
+      {
+        "name": "Xu-đăng",
+        "lang": "vi"
+      },
+      {
+        "name": "Xuđăng (Sudan)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Y Swdan",
+        "lang": "cy"
+      },
+      {
+        "name": "السودان",
+        "lang": "ar"
+      },
+      {
+        "name": "سۇدان",
+        "lang": "ug"
+      },
+      {
+        "name": "سودان",
+        "lang": "fa"
+      },
+      {
+        "name": "سوڈان",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "سوودان",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "סודאן",
+        "lang": "he"
+      },
+      {
+        "name": "סודאן",
+        "lang": "yi"
+      },
+      {
+        "name": "סודן",
+        "isPreferredName": true,
+        "lang": "he"
+      },
+      {
+        "name": "Σουδάν",
+        "lang": "el"
+      },
+      {
+        "name": "Судан",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Судан",
+        "lang": "bg"
+      },
+      {
+        "name": "Судан",
+        "lang": "mk"
+      },
+      {
+        "name": "Судан",
+        "lang": "ru"
+      },
+      {
+        "name": "Судан",
+        "lang": "sr"
+      },
+      {
+        "name": "Судан",
+        "lang": "uk"
+      },
+      {
+        "name": "Սուդան",
+        "lang": "hy"
+      },
+      {
+        "name": "სუდანი",
+        "lang": "ka"
+      },
+      {
+        "name": "सुडान",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "सुदान",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "सूडान",
+        "lang": "hi"
+      },
+      {
+        "name": "સુદાન",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "సుడాన్",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಸೂಡಾನ್",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "சூடான்",
+        "lang": "ta"
+      },
+      {
+        "name": "സുഡാന്‍",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "সুদান",
+        "lang": "bn"
+      },
+      {
+        "name": "ဆူဒန်",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "සූඩානය",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "スーダン共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "苏丹",
+        "lang": "zh"
+      },
+      {
+        "name": "苏丹共和国",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Sudan",
+    "adminCode1": "00",
+    "lng": "30",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Khartoum"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 8.684720993041992,
+      "east": 38.60749816894531,
+      "north": 22.913195,
+      "west": 21.827774047851562
+    },
+    "name": "Sudan",
+    "fcode": "PCLI",
+    "geonameId": 366755,
+    "asciiName": "Republic of the Sudan",
+    "lat": "16",
+    "population": 35000000,
+    "adminName1": "",
+    "countryId": "366755",
+    "fclName": "country, state, region,...",
+    "countryCode": "SD",
+    "srtm3": 424,
+    "wikipediaURL": "en.wikipedia.org/wiki/Sudan",
+    "toponymName": "Republic of the Sudan",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Gambia": 2413451,
+  "2413451": {
+    "alternateNames": [
+      {
+        "name": "감비아",
+        "lang": "ko"
+      },
+      {
+        "name": "ጋምቢያ",
+        "lang": "am"
+      },
+      {
+        "name": "ጋምቢያ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ガンビア",
+        "lang": "ja"
+      },
+      {
+        "name": "ގެމްބިއާ",
+        "lang": "dv"
+      },
+      {
+        "name": "ແກມເບຍ",
+        "lang": "lo"
+      },
+      {
+        "name": "ଗାମ୍ବିଆ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "แกมเบีย",
+        "lang": "th"
+      },
+      {
+        "name": "ហ្គាំប៊ី",
+        "lang": "km"
+      },
+      {
+        "name": "གྷམ་བི་ཡ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "གྷེམ་བི་ཡ",
+        "lang": "dz"
+      },
+      {
+        "name": "གེམ་བྷི་ཡ།",
+        "lang": "bo"
+      },
+      {
+        "name": "ประเทศแกมเบีย",
+        "lang": "th"
+      },
+      {
+        "name": "A Ghaimbia",
+        "lang": "gd"
+      },
+      {
+        "name": "Ang Gambiya",
+        "lang": "tl"
+      },
+      {
+        "name": "An Ghaimbia",
+        "lang": "ga"
+      },
+      {
+        "name": "Gambėjė",
+        "lang": "sgs"
+      },
+      {
+        "name": "Gambi",
+        "lang": "kw"
+      },
+      {
+        "name": "Gambi",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Gambi",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Gambi",
+        "lang": "sq"
+      },
+      {
+        "name": "Gàmbi",
+        "lang": "wo"
+      },
+      {
+        "name": "Gambia",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Gambia",
+        "lang": "an"
+      },
+      {
+        "name": "Gambia",
+        "lang": "ast"
+      },
+      {
+        "name": "Gambia",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Gambia",
+        "lang": "cy"
+      },
+      {
+        "name": "Gambia",
+        "lang": "da"
+      },
+      {
+        "name": "Gambia",
+        "lang": "de"
+      },
+      {
+        "isShortName": true,
+        "name": "Gambia",
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Gambia",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Gambia",
+        "lang": "et"
+      },
+      {
+        "name": "Gambia",
+        "lang": "eu"
+      },
+      {
+        "name": "Gambia",
+        "lang": "fi"
+      },
+      {
+        "name": "Gambia",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "name": "Gambia",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Gambia",
+        "lang": "hu"
+      },
+      {
+        "name": "Gambia",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Gambia",
+        "lang": "id"
+      },
+      {
+        "name": "Gambia",
+        "lang": "ilo"
+      },
+      {
+        "name": "Gambia",
+        "lang": "io"
+      },
+      {
+        "name": "Gambia",
+        "lang": "it"
+      },
+      {
+        "name": "Gambia",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Gambia",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Gambia",
+        "lang": "la"
+      },
+      {
+        "name": "Gambia",
+        "lang": "li"
+      },
+      {
+        "name": "Gambia",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Gambia",
+        "lang": "ms"
+      },
+      {
+        "name": "Gambia",
+        "lang": "nb"
+      },
+      {
+        "name": "Gambia",
+        "lang": "nds"
+      },
+      {
+        "name": "Gambia",
+        "lang": "nl"
+      },
+      {
+        "name": "Gambia",
+        "lang": "nn"
+      },
+      {
+        "name": "Gambia",
+        "lang": "no"
+      },
+      {
+        "name": "Gambia",
+        "lang": "oc"
+      },
+      {
+        "name": "Gambia",
+        "lang": "pl"
+      },
+      {
+        "name": "Gambia",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Gambia",
+        "lang": "ro"
+      },
+      {
+        "name": "Gambia",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Gambia",
+        "lang": "sk"
+      },
+      {
+        "name": "Gambia",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Gambia",
+        "lang": "sq"
+      },
+      {
+        "name": "Gambia",
+        "lang": "sv"
+      },
+      {
+        "name": "Gambia",
+        "lang": "sw"
+      },
+      {
+        "name": "Gambia",
+        "lang": "tr"
+      },
+      {
+        "name": "Gambia",
+        "lang": "vi"
+      },
+      {
+        "name": "Gambia"
+      },
+      {
+        "name": "Gámbia",
+        "lang": "se"
+      },
+      {
+        "isShortName": true,
+        "name": "Gàmbia",
+        "isPreferredName": true,
+        "lang": "ca"
+      },
+      {
+        "name": "Gàmbia",
+        "lang": "oc"
+      },
+      {
+        "name": "Gàmbia",
+        "lang": "sc"
+      },
+      {
+        "name": "Găm-bi-a",
+        "lang": "vi"
+      },
+      {
+        "name": "Gâmbia",
+        "lang": "pt"
+      },
+      {
+        "name": "Gambía",
+        "lang": "is"
+      },
+      {
+        "name": "Gámbíà",
+        "lang": "yo"
+      },
+      {
+        "name": "Găm-bi-a (Gambia)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Gambia nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Gambia - The Gambia",
+        "lang": "gl"
+      },
+      {
+        "name": "Gambie",
+        "lang": "cs"
+      },
+      {
+        "name": "Gambie",
+        "lang": "fr"
+      },
+      {
+        "name": "Gambie",
+        "lang": "frp"
+      },
+      {
+        "name": "Gambië",
+        "lang": "af"
+      },
+      {
+        "name": "Gambïi",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Gambija",
+        "lang": "bs"
+      },
+      {
+        "name": "Gambija",
+        "lang": "hbs"
+      },
+      {
+        "name": "Gambija",
+        "lang": "hr"
+      },
+      {
+        "name": "Gambija",
+        "lang": "hsb"
+      },
+      {
+        "name": "Gambija",
+        "lang": "lt"
+      },
+      {
+        "name": "Gambija",
+        "lang": "lv"
+      },
+      {
+        "name": "Gambija",
+        "lang": "sl"
+      },
+      {
+        "name": "Gambijo",
+        "lang": "szl"
+      },
+      {
+        "name": "Gambio",
+        "lang": "eo"
+      },
+      {
+        "name": "Gambiya",
+        "lang": "crh"
+      },
+      {
+        "name": "Gambiya",
+        "lang": "diq"
+      },
+      {
+        "name": "Gambiya",
+        "lang": "gag"
+      },
+      {
+        "name": "Gambiya",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Gambiya",
+        "lang": "ku"
+      },
+      {
+        "name": "Gambiya",
+        "lang": "na"
+      },
+      {
+        "name": "Gambiya",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Gambiya",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Gambiya",
+        "lang": "rw"
+      },
+      {
+        "name": "Gambiya",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Gambiya",
+        "lang": "tr"
+      },
+      {
+        "name": "Gambiya",
+        "lang": "ts"
+      },
+      {
+        "name": "Gambiýa",
+        "lang": "tk"
+      },
+      {
+        "name": "Gambiyän",
+        "lang": "vo"
+      },
+      {
+        "name": "Gambja",
+        "lang": "mt"
+      },
+      {
+        "name": "Gambya",
+        "lang": "bcl"
+      },
+      {
+        "name": "Gambya",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Gambya",
+        "lang": "qu"
+      },
+      {
+        "name": "Gammbi",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Ganbi",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Ganbi",
+        "lang": "ht"
+      },
+      {
+        "name": "Ganbia",
+        "lang": "eu"
+      },
+      {
+        "name": "Géémbiya",
+        "lang": "nv"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/The_Gambia",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%93%D0%B0%D0%BC%D0%B1%D0%B8%D1%8F",
+        "lang": "link"
+      },
+      {
+        "name": "i-Gambia",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "IGambia",
+        "lang": "zu"
+      },
+      {
+        "name": "IGambiya",
+        "lang": "ss"
+      },
+      {
+        "name": "Kamipia",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Orílẹ́ède Gambia",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Qambiya",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Republic of The Gambia",
+        "lang": "en"
+      },
+      {
+        "name": "The Gambia",
+        "isPreferredName": true,
+        "lang": "en"
+      },
+      {
+        "name": "The Gambia",
+        "lang": "ie"
+      },
+      {
+        "name": "The Gambia",
+        "lang": "pam"
+      },
+      {
+        "name": "The Gambie",
+        "lang": "sco"
+      },
+      {
+        "name": "Y Gambia",
+        "lang": "cy"
+      },
+      {
+        "name": "Yn Ghambia",
+        "lang": "gv"
+      },
+      {
+        "name": "جامبيا",
+        "lang": "arz"
+      },
+      {
+        "name": "غامبيا",
+        "lang": "ar"
+      },
+      {
+        "name": "گامبیا",
+        "lang": "ckb"
+      },
+      {
+        "name": "گامبیا",
+        "lang": "fa"
+      },
+      {
+        "name": "گامبیا",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "گامبیا",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "گامبيا",
+        "lang": "ps"
+      },
+      {
+        "name": "گامبىيە",
+        "lang": "ug"
+      },
+      {
+        "name": "گیمبیا",
+        "lang": "pnb"
+      },
+      {
+        "name": "گیمبیا",
+        "lang": "ur"
+      },
+      {
+        "name": "گمبیا",
+        "isPreferredName": true,
+        "lang": "fa"
+      },
+      {
+        "name": "גאמביה",
+        "isPreferredName": true,
+        "lang": "he"
+      },
+      {
+        "name": "גמביה",
+        "lang": "he"
+      },
+      {
+        "name": "די גאמביע",
+        "lang": "yi"
+      },
+      {
+        "name": "Γκάμπια",
+        "lang": "el"
+      },
+      {
+        "name": "Гамби",
+        "lang": "bxr"
+      },
+      {
+        "name": "Гамби",
+        "lang": "ce"
+      },
+      {
+        "name": "Гамби",
+        "lang": "cv"
+      },
+      {
+        "name": "Гамби",
+        "lang": "mn"
+      },
+      {
+        "name": "Гамби",
+        "lang": "mrj"
+      },
+      {
+        "name": "Гамби",
+        "lang": "os"
+      },
+      {
+        "name": "Гамбија",
+        "lang": "mk"
+      },
+      {
+        "name": "Гамбија",
+        "lang": "sr"
+      },
+      {
+        "name": "Гамбия",
+        "lang": "ba"
+      },
+      {
+        "name": "Гамбия",
+        "lang": "bg"
+      },
+      {
+        "name": "Гамбия",
+        "lang": "kk"
+      },
+      {
+        "name": "Гамбия",
+        "lang": "ky"
+      },
+      {
+        "name": "Гамбия",
+        "lang": "ru"
+      },
+      {
+        "name": "Гамбия",
+        "lang": "sah"
+      },
+      {
+        "name": "Гамбия",
+        "lang": "tg"
+      },
+      {
+        "name": "Гамбия",
+        "lang": "tt"
+      },
+      {
+        "name": "Гамбія",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Гамбія",
+        "lang": "uk"
+      },
+      {
+        "name": "Ґамбія",
+        "lang": "uk"
+      },
+      {
+        "name": "Гамбудин Орн",
+        "lang": "xal"
+      },
+      {
+        "name": "Գամբիա",
+        "lang": "hy"
+      },
+      {
+        "name": "გამბია",
+        "lang": "ka"
+      },
+      {
+        "name": "გამბია",
+        "lang": "xmf"
+      },
+      {
+        "name": "गाम्बिया",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "गाम्बिया",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "गाम्बिया",
+        "lang": "ne"
+      },
+      {
+        "name": "गाम्बिया",
+        "lang": "new"
+      },
+      {
+        "name": "गाम्बिया",
+        "lang": "sa"
+      },
+      {
+        "name": "गाम्विया",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "गांबिया",
+        "lang": "mr"
+      },
+      {
+        "name": "ગેમ્બિયા",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "గాంబియా",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ਗਾਂਬੀਆ",
+        "lang": "pa"
+      },
+      {
+        "name": "ಗ್ಯಾಂಬಿಯ",
+        "lang": "kn"
+      },
+      {
+        "name": "ಗ್ಯಾಂಬಿಯಾ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "காம்பியா",
+        "lang": "ta"
+      },
+      {
+        "name": "ഗാംബിയ",
+        "lang": "ml"
+      },
+      {
+        "name": "গাম্বিয়া",
+        "lang": "bn"
+      },
+      {
+        "name": "গাম্বিয়া",
+        "lang": "bpy"
+      },
+      {
+        "name": "গ্যাম্বিয়া",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "ဂန်ဘီရာ",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "ဂမ်ဘီယာနိုင်ငံ",
+        "lang": "my"
+      },
+      {
+        "name": "ගැම්බියාව",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "ガンビア共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "冈比亚",
+        "lang": "wuu"
+      },
+      {
+        "name": "冈比亚",
+        "lang": "zh"
+      },
+      {
+        "name": "冈比亚共和国",
+        "lang": "zh"
+      },
+      {
+        "name": "甘比亞",
+        "lang": "yue"
+      }
+    ],
+    "countryName": "Gambia",
+    "adminCode1": "00",
+    "lng": "-15.5",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 0,
+      "gmtOffset": 0,
+      "timeZoneId": "Africa/Banjul"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 13.064252,
+      "east": -13.797793,
+      "north": 13.826571,
+      "west": -16.825079
+    },
+    "name": "Gambia",
+    "fcode": "PCLI",
+    "geonameId": 2413451,
+    "asciiName": "Gambia",
+    "lat": "13.5",
+    "population": 1593256,
+    "adminName1": "",
+    "countryId": "2413451",
+    "fclName": "country, state, region,...",
+    "countryCode": "GM",
+    "srtm3": 14,
+    "wikipediaURL": "en.wikipedia.org/wiki/The_Gambia",
+    "toponymName": "Gambia",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Togo": 2363686,
+  "2363686": {
+    "alternateNames": [
+      {
+        "name": "ቶጎ",
+        "lang": "am"
+      },
+      {
+        "name": "ቶጐ",
+        "lang": "am"
+      },
+      {
+        "name": "ቶጐ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "토고",
+        "lang": "ko"
+      },
+      {
+        "name": "トーゴ",
+        "lang": "ja"
+      },
+      {
+        "name": "ଟୋଗୋ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "โตโก",
+        "lang": "th"
+      },
+      {
+        "name": "โทโก",
+        "isPreferredName": true,
+        "lang": "th"
+      },
+      {
+        "name": "ໂຕໂກ",
+        "lang": "lo"
+      },
+      {
+        "name": "តូហ្គូ",
+        "lang": "km"
+      },
+      {
+        "name": "French Togoland"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Togo",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%A2%D0%BE%D0%B3%D0%BE",
+        "lang": "link"
+      },
+      {
+        "name": "i-Togo",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Orílẹ́ède Togo",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Republic of Togo"
+      },
+      {
+        "name": "République Togolaise",
+        "lang": "fr"
+      },
+      {
+        "name": "Thogo",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Tóga",
+        "lang": "ga"
+      },
+      {
+        "name": "Togas",
+        "lang": "lt"
+      },
+      {
+        "name": "Toge",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Togo",
+        "lang": "af"
+      },
+      {
+        "name": "Togo",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Togo",
+        "lang": "an"
+      },
+      {
+        "name": "Togo",
+        "lang": "bm"
+      },
+      {
+        "name": "Togo",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Togo",
+        "lang": "bs"
+      },
+      {
+        "name": "Togo",
+        "lang": "ca"
+      },
+      {
+        "name": "Togo",
+        "lang": "cs"
+      },
+      {
+        "name": "Togo",
+        "lang": "cy"
+      },
+      {
+        "name": "Togo",
+        "lang": "da"
+      },
+      {
+        "name": "Togo",
+        "lang": "de"
+      },
+      {
+        "isShortName": true,
+        "name": "Togo",
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Togo",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Togo",
+        "lang": "et"
+      },
+      {
+        "name": "Togo",
+        "lang": "eu"
+      },
+      {
+        "name": "Togo",
+        "lang": "fi"
+      },
+      {
+        "name": "Togo",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "name": "Togo",
+        "lang": "gl"
+      },
+      {
+        "name": "Togo",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Togo",
+        "lang": "hbs"
+      },
+      {
+        "name": "Togo",
+        "lang": "hr"
+      },
+      {
+        "name": "Togo",
+        "lang": "ht"
+      },
+      {
+        "name": "Togo",
+        "lang": "hu"
+      },
+      {
+        "name": "Togo",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Togo",
+        "lang": "id"
+      },
+      {
+        "name": "Togo",
+        "lang": "ilo"
+      },
+      {
+        "name": "Togo",
+        "lang": "io"
+      },
+      {
+        "name": "Togo",
+        "lang": "it"
+      },
+      {
+        "name": "Togo",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Togo",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Togo",
+        "lang": "ku"
+      },
+      {
+        "name": "Togo",
+        "lang": "kw"
+      },
+      {
+        "name": "Togo",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Togo",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Togo",
+        "lang": "lv"
+      },
+      {
+        "name": "Togo",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Togo",
+        "lang": "ms"
+      },
+      {
+        "name": "Togo",
+        "lang": "mt"
+      },
+      {
+        "name": "Togo",
+        "lang": "nb"
+      },
+      {
+        "name": "Togo",
+        "lang": "nds"
+      },
+      {
+        "name": "Togo",
+        "lang": "nl"
+      },
+      {
+        "name": "Togo",
+        "lang": "nn"
+      },
+      {
+        "name": "Togo",
+        "lang": "no"
+      },
+      {
+        "name": "Togo",
+        "lang": "pam"
+      },
+      {
+        "name": "Togo",
+        "lang": "pl"
+      },
+      {
+        "name": "Togo",
+        "lang": "pt"
+      },
+      {
+        "name": "Togo",
+        "lang": "rm"
+      },
+      {
+        "name": "Togo",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Togo",
+        "lang": "ro"
+      },
+      {
+        "name": "Togo",
+        "lang": "se"
+      },
+      {
+        "name": "Togo",
+        "lang": "sk"
+      },
+      {
+        "name": "Togo",
+        "lang": "sl"
+      },
+      {
+        "name": "Togo",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Togo",
+        "lang": "sq"
+      },
+      {
+        "name": "Togo",
+        "lang": "sv"
+      },
+      {
+        "name": "Togo",
+        "lang": "sw"
+      },
+      {
+        "name": "Togo",
+        "lang": "tl"
+      },
+      {
+        "name": "Togo",
+        "lang": "tr"
+      },
+      {
+        "name": "Togo",
+        "lang": "uz"
+      },
+      {
+        "name": "Togo",
+        "lang": "vi"
+      },
+      {
+        "name": "Tògo",
+        "lang": "gd"
+      },
+      {
+        "name": "Tògo",
+        "lang": "oc"
+      },
+      {
+        "name": "Tógó",
+        "lang": "is"
+      },
+      {
+        "name": "Togô",
+        "lang": "frp"
+      },
+      {
+        "name": "Tô-gô",
+        "lang": "vi"
+      },
+      {
+        "name": "Togö",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Togoän",
+        "lang": "vo"
+      },
+      {
+        "name": "Togolando",
+        "lang": "eo"
+      },
+      {
+        "name": "Togolese Republic",
+        "lang": "en"
+      },
+      {
+        "name": "Togolo",
+        "lang": "eo"
+      },
+      {
+        "name": "Togo nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Togoo",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Togu",
+        "lang": "ast"
+      },
+      {
+        "name": "Togu",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Togum",
+        "lang": "la"
+      },
+      {
+        "name": "Toko",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Toogo",
+        "lang": "so"
+      },
+      {
+        "name": "Toqo",
+        "lang": "az"
+      },
+      {
+        "name": "Tugu",
+        "lang": "qu"
+      },
+      {
+        "name": "تۆگۆ",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "توجو",
+        "isPreferredName": true,
+        "lang": "ar"
+      },
+      {
+        "name": "توغو",
+        "lang": "ar"
+      },
+      {
+        "name": "توگو",
+        "lang": "fa"
+      },
+      {
+        "name": "توگو",
+        "lang": "ug"
+      },
+      {
+        "name": "ٹوگو",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "טוגו",
+        "lang": "he"
+      },
+      {
+        "name": "Τόγκο",
+        "lang": "el"
+      },
+      {
+        "name": "Тога",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Того",
+        "lang": "bg"
+      },
+      {
+        "name": "Того",
+        "lang": "mk"
+      },
+      {
+        "name": "Того",
+        "lang": "ru"
+      },
+      {
+        "name": "Того",
+        "lang": "sr"
+      },
+      {
+        "name": "Того",
+        "lang": "tg"
+      },
+      {
+        "name": "Того",
+        "lang": "uk"
+      },
+      {
+        "name": "Тоґо",
+        "lang": "uk"
+      },
+      {
+        "name": "Տոգո",
+        "lang": "hy"
+      },
+      {
+        "name": "ტოგო",
+        "lang": "ka"
+      },
+      {
+        "name": "टोगो",
+        "lang": "hi"
+      },
+      {
+        "name": "टोगो",
+        "lang": "ks"
+      },
+      {
+        "name": "टोगो",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "टोगो",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "टोगो",
+        "lang": "sa"
+      },
+      {
+        "name": "ટોગો",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "టోగో",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಟೋಗೋ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "டோகோ",
+        "isPreferredName": true,
+        "lang": "ta"
+      },
+      {
+        "name": "ടോഗോ",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "টোগো",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "トーゴ共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "多哥",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Togo",
+    "adminCode1": "00",
+    "lng": "1.08333",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 0,
+      "gmtOffset": 0,
+      "timeZoneId": "Africa/Lome"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 6.104417,
+      "east": 1.806693,
+      "north": 11.138977,
+      "west": -0.147324
+    },
+    "name": "Togo",
+    "fcode": "PCLI",
+    "geonameId": 2363686,
+    "asciiName": "Togolese Republic",
+    "lat": "8.66667",
+    "population": 6587239,
+    "adminName1": "",
+    "countryId": "2363686",
+    "fclName": "country, state, region,...",
+    "countryCode": "TG",
+    "srtm3": 325,
+    "wikipediaURL": "en.wikipedia.org/wiki/Togo",
+    "toponymName": "Togolese Republic",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Uganda": 226074,
+  "226074": {
+    "alternateNames": [
+      {
+        "name": "우간다",
+        "lang": "ko"
+      },
+      {
+        "name": "ዩጋንዳ",
+        "lang": "am"
+      },
+      {
+        "name": "ዩጋንዳ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ウガンダ",
+        "lang": "ja"
+      },
+      {
+        "name": "ଉଗାଣ୍ଡା",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "ยูกันดา",
+        "isPreferredName": true,
+        "lang": "th"
+      },
+      {
+        "name": "ອູການດາ",
+        "lang": "lo"
+      },
+      {
+        "name": "ཡུ་གན་ཌ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ཨུ་གན་ད།",
+        "lang": "bo"
+      },
+      {
+        "name": "អ៊ូហ្កង់ដា",
+        "lang": "km"
+      },
+      {
+        "name": "ประเทศยูกันดา",
+        "lang": "th"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Uganda",
+        "lang": "link"
+      },
+      {
+        "name": "http://id.loc.gov/authorities/names/n80126332",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%A3%D0%B3%D0%B0%D0%BD%D0%B4%D0%B0",
+        "lang": "link"
+      },
+      {
+        "name": "i-Uganda",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "ʻIukanitā",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Lugandayän",
+        "lang": "vo"
+      },
+      {
+        "name": "Oeganda",
+        "lang": "nl"
+      },
+      {
+        "name": "Oganda",
+        "lang": "frp"
+      },
+      {
+        "name": "Oganda",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Oganda",
+        "lang": "oc"
+      },
+      {
+        "name": "Orílẹ́ède Uganda",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Ouganda",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Ouganda",
+        "lang": "fr"
+      },
+      {
+        "name": "Ouganda",
+        "lang": "kw"
+      },
+      {
+        "name": "Ouganda"
+      },
+      {
+        "name": "Republic of Uganda"
+      },
+      {
+        "name": "Ubugande",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Ugaanda",
+        "lang": "so"
+      },
+      {
+        "name": "Uganda",
+        "lang": "af"
+      },
+      {
+        "name": "Uganda",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Uganda",
+        "lang": "an"
+      },
+      {
+        "name": "Uganda",
+        "lang": "ast"
+      },
+      {
+        "name": "Uganda",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Uganda",
+        "lang": "bs"
+      },
+      {
+        "name": "Uganda",
+        "lang": "ca"
+      },
+      {
+        "name": "Uganda",
+        "lang": "cs"
+      },
+      {
+        "name": "Uganda",
+        "lang": "cy"
+      },
+      {
+        "name": "Uganda",
+        "lang": "da"
+      },
+      {
+        "name": "Uganda",
+        "lang": "de"
+      },
+      {
+        "name": "Uganda",
+        "isPreferredName": true,
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Uganda",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Uganda",
+        "lang": "et"
+      },
+      {
+        "name": "Uganda",
+        "lang": "eu"
+      },
+      {
+        "name": "Uganda",
+        "lang": "fi"
+      },
+      {
+        "name": "Uganda",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "name": "Uganda",
+        "lang": "gd"
+      },
+      {
+        "name": "Uganda",
+        "lang": "gl"
+      },
+      {
+        "name": "Uganda",
+        "lang": "hbs"
+      },
+      {
+        "name": "Uganda",
+        "lang": "hr"
+      },
+      {
+        "name": "Uganda",
+        "lang": "hu"
+      },
+      {
+        "name": "Uganda",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Uganda",
+        "lang": "id"
+      },
+      {
+        "name": "Uganda",
+        "lang": "ilo"
+      },
+      {
+        "name": "Uganda",
+        "lang": "io"
+      },
+      {
+        "name": "Uganda",
+        "lang": "it"
+      },
+      {
+        "name": "Uganda",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Uganda",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Uganda",
+        "lang": "la"
+      },
+      {
+        "name": "Uganda",
+        "lang": "lij"
+      },
+      {
+        "name": "Uganda",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Uganda",
+        "lang": "lt"
+      },
+      {
+        "name": "Uganda",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Uganda",
+        "lang": "lv"
+      },
+      {
+        "name": "Uganda",
+        "lang": "ms"
+      },
+      {
+        "name": "Uganda",
+        "lang": "mt"
+      },
+      {
+        "name": "Uganda",
+        "lang": "nb"
+      },
+      {
+        "name": "Uganda",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Uganda",
+        "lang": "nds"
+      },
+      {
+        "name": "Uganda",
+        "lang": "nn"
+      },
+      {
+        "name": "Uganda",
+        "lang": "no"
+      },
+      {
+        "name": "Uganda",
+        "lang": "pam"
+      },
+      {
+        "name": "Uganda",
+        "lang": "pl"
+      },
+      {
+        "name": "Uganda",
+        "lang": "pms"
+      },
+      {
+        "name": "Uganda",
+        "lang": "pt"
+      },
+      {
+        "name": "Uganda",
+        "lang": "qu"
+      },
+      {
+        "name": "Uganda",
+        "lang": "rm"
+      },
+      {
+        "name": "Uganda",
+        "lang": "ro"
+      },
+      {
+        "name": "Uganda",
+        "lang": "se"
+      },
+      {
+        "name": "Uganda",
+        "lang": "sk"
+      },
+      {
+        "name": "Uganda",
+        "lang": "sl"
+      },
+      {
+        "name": "Uganda",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Uganda",
+        "lang": "sq"
+      },
+      {
+        "name": "Uganda",
+        "lang": "sv"
+      },
+      {
+        "name": "Uganda",
+        "lang": "sw"
+      },
+      {
+        "name": "Uganda",
+        "lang": "tl"
+      },
+      {
+        "name": "Uganda",
+        "lang": "tr"
+      },
+      {
+        "name": "Uganda",
+        "lang": "uz"
+      },
+      {
+        "name": "Uganda",
+        "lang": "vi"
+      },
+      {
+        "name": "Uganda"
+      },
+      {
+        "name": "Úganda",
+        "isPreferredName": true,
+        "lang": "ga"
+      },
+      {
+        "name": "Úganda",
+        "lang": "is"
+      },
+      {
+        "name": "Ûganda",
+        "lang": "ku"
+      },
+      {
+        "name": "U-gan-đa",
+        "lang": "vi"
+      },
+      {
+        "name": "Ugandäa",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Uganda nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Uganda Protectorate"
+      },
+      {
+        "name": "Ugando",
+        "lang": "eo"
+      },
+      {
+        "name": "Unganndaa",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Uqanda",
+        "lang": "az"
+      },
+      {
+        "name": "Yuganda",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Yuganda",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "أوغندا",
+        "lang": "ar"
+      },
+      {
+        "name": "اوغندا",
+        "lang": "ar"
+      },
+      {
+        "name": "اوگاندا",
+        "lang": "fa"
+      },
+      {
+        "name": "یوگانڈا",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "ئۇگاندا",
+        "lang": "ug"
+      },
+      {
+        "name": "ئوگاندا",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "يوګانډا",
+        "lang": "ps"
+      },
+      {
+        "name": "אוגנדה",
+        "lang": "he"
+      },
+      {
+        "name": "Ουγκάντα",
+        "lang": "el"
+      },
+      {
+        "name": "Уганда",
+        "lang": "be"
+      },
+      {
+        "name": "Уганда",
+        "lang": "bg"
+      },
+      {
+        "name": "Уганда",
+        "lang": "mk"
+      },
+      {
+        "name": "Уганда",
+        "lang": "ru"
+      },
+      {
+        "name": "Уганда",
+        "lang": "sr"
+      },
+      {
+        "name": "Уганда",
+        "lang": "tg"
+      },
+      {
+        "name": "Уганда",
+        "lang": "uk"
+      },
+      {
+        "name": "Уґанда",
+        "lang": "uk"
+      },
+      {
+        "name": "Ուգանդա",
+        "lang": "hy"
+      },
+      {
+        "name": "უგანდა",
+        "lang": "ka"
+      },
+      {
+        "name": "युगाण्डा",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "युगांडा",
+        "lang": "hi"
+      },
+      {
+        "name": "युगांडा",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "यूगांडा",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "યુગાંડા",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "యుగాండా",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಉಗಾಂಡಾ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "உகாண்டா",
+        "lang": "ta"
+      },
+      {
+        "name": "ഉഗാണ്ട",
+        "lang": "ml"
+      },
+      {
+        "name": "উগান্ডা",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "ယူဂန္ဒာ",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "乌干达",
+        "lang": "zh"
+      },
+      {
+        "name": "ウガンダ共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      }
+    ],
+    "countryName": "Uganda",
+    "adminCode1": "00",
+    "lng": "32.5",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Kampala"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -1.48405,
+      "east": 35.036049,
+      "north": 4.214427,
+      "west": 29.573252
+    },
+    "name": "Uganda",
+    "fcode": "PCLI",
+    "geonameId": 226074,
+    "asciiName": "Republic of Uganda",
+    "lat": "1.25",
+    "population": 33398682,
+    "adminName1": "",
+    "countryId": "226074",
+    "fclName": "country, state, region,...",
+    "countryCode": "UG",
+    "srtm3": 1094,
+    "wikipediaURL": "en.wikipedia.org/wiki/Uganda",
+    "toponymName": "Republic of Uganda",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Zimbabwe": 878675,
+  "878675": {
+    "alternateNames": [
+      {
+        "name": "ዚምቧቤ",
+        "lang": "am"
+      },
+      {
+        "name": "ዚምቧቤ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "짐바브웨",
+        "lang": "ko"
+      },
+      {
+        "name": "ジンバブエ",
+        "lang": "ja"
+      },
+      {
+        "name": "ଜିମ୍ବାୱେ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "ซิมบับเว",
+        "isPreferredName": true,
+        "lang": "th"
+      },
+      {
+        "name": "ຊິມບັບເວ",
+        "lang": "lo"
+      },
+      {
+        "name": "ཛིམ་བབ་ཝེ",
+        "lang": "dz"
+      },
+      {
+        "name": "ཛིམ་བྷཱ་བེ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ហ្ស៊ីមបាបវ៉េ",
+        "lang": "km"
+      },
+      {
+        "name": "An tSiombáib",
+        "lang": "ga"
+      },
+      {
+        "name": "Cimbabue",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Colony of Rhodesia",
+        "isHistoric": true
+      },
+      {
+        "name": "Colony of Southern Rhodesia",
+        "isHistoric": true
+      },
+      {
+        "name": "Dim-ba-bu-ê",
+        "lang": "vi"
+      },
+      {
+        "name": "Dim-ba-bu-ê (Zimbabwe)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Zimbabwe",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%97%D0%B8%D0%BC%D0%B1%D0%B0%D0%B1%D0%B2%D0%B5",
+        "lang": "link"
+      },
+      {
+        "name": "i-Zimbabwe",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Orílẹ́ède ṣimibabe",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Republic of Rhodesia",
+        "isHistoric": true
+      },
+      {
+        "name": "Republic of Zimbabwe"
+      },
+      {
+        "name": "Rhodesia",
+        "isHistoric": true
+      },
+      {
+        "name": "Simbaabuwe",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Simbaabwe",
+        "lang": "so"
+      },
+      {
+        "name": "Simbabve",
+        "lang": "is"
+      },
+      {
+        "name": "Simbabvi",
+        "lang": "fo"
+      },
+      {
+        "name": "Simbabwe",
+        "lang": "cy"
+      },
+      {
+        "name": "Simbabwe",
+        "isPreferredName": true,
+        "lang": "de"
+      },
+      {
+        "name": "Simbabwe",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Simipapuei",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Southern Rhodesia",
+        "isHistoric": true,
+        "lang": "en"
+      },
+      {
+        "name": "Southern Rhodesia",
+        "isHistoric": true
+      },
+      {
+        "name": "State of Zimbabwe"
+      },
+      {
+        "name": "Südrhodesien",
+        "isHistoric": true,
+        "lang": "de"
+      },
+      {
+        "name": "Zembabwe",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Zimbaboe",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Zimbabue",
+        "lang": "es"
+      },
+      {
+        "name": "Zimbábue",
+        "isPreferredName": true,
+        "lang": "pt"
+      },
+      {
+        "name": "Zimbabuwe",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Zimbabuwe",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Zimbabve",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Zimbabve",
+        "isPreferredName": true,
+        "lang": "bs"
+      },
+      {
+        "name": "Zimbabve",
+        "lang": "hr"
+      },
+      {
+        "name": "Zimbabve",
+        "lang": "lv"
+      },
+      {
+        "name": "Zimbabve",
+        "lang": "sl"
+      },
+      {
+        "name": "Zimbabve",
+        "lang": "sq"
+      },
+      {
+        "name": "Zimbabve",
+        "isPreferredName": true,
+        "lang": "tr"
+      },
+      {
+        "name": "Zimbabvė",
+        "lang": "lt"
+      },
+      {
+        "name": "Zimbabvo",
+        "lang": "eo"
+      },
+      {
+        "name": "Zimbabwe",
+        "isPreferredName": true,
+        "lang": "af"
+      },
+      {
+        "name": "Zimbabwe",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "ca"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "cs"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "da"
+      },
+      {
+        "name": "Zimbabwe",
+        "isPreferredName": true,
+        "lang": "en"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "et"
+      },
+      {
+        "name": "Zimbabwe",
+        "isPreferredName": true,
+        "lang": "eu"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "fi"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "fr"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "hu"
+      },
+      {
+        "name": "Zimbabwe",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "id"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "it"
+      },
+      {
+        "name": "Zimbabwe",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Zimbabwe",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Zimbabwe",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Zimbabwe",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Zimbabwe",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "ms"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "nb"
+      },
+      {
+        "name": "Zimbabwe",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "nl"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "nn"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "pl"
+      },
+      {
+        "name": "Zimbabwe",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "ro"
+      },
+      {
+        "name": "Zimbabwe",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "sk"
+      },
+      {
+        "name": "Zimbabwe",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Zimbabwe",
+        "lang": "sv"
+      },
+      {
+        "name": "Zimbabwe",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Zimbabwe"
+      },
+      {
+        "name": "Żimbabwe",
+        "lang": "mt"
+      },
+      {
+        "name": "Zimbäbwe",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Zimbabwe nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Zimbabwe/Rhodesia"
+      },
+      {
+        "isShortName": true,
+        "name": "Zimbawe",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "رودزیای جنوبی",
+        "lang": "fa"
+      },
+      {
+        "name": "زیمبابوی",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "زیمبابوه",
+        "lang": "fa"
+      },
+      {
+        "name": "زمبابوے",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "زيمبابوي",
+        "lang": "ar"
+      },
+      {
+        "name": "זימבאבווה",
+        "lang": "he"
+      },
+      {
+        "name": "זימבבואה",
+        "isPreferredName": true,
+        "lang": "he"
+      },
+      {
+        "name": "Ζιμπάμπουε",
+        "lang": "el"
+      },
+      {
+        "name": "Зимбабве",
+        "lang": "bg"
+      },
+      {
+        "name": "Зимбабве",
+        "lang": "mk"
+      },
+      {
+        "name": "Зимбабве",
+        "lang": "ru"
+      },
+      {
+        "name": "Зимбабве",
+        "lang": "sr"
+      },
+      {
+        "name": "Зімбабве",
+        "lang": "uk"
+      },
+      {
+        "name": "Зімбабвэ",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Զիմբաբվե",
+        "lang": "hy"
+      },
+      {
+        "name": "ზიმბაბვე",
+        "lang": "ka"
+      },
+      {
+        "name": "जिम्बाबे",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "जिम्बाब्वे",
+        "lang": "hi"
+      },
+      {
+        "name": "ज़िम्बाब्वे",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "झिम्बाब्वे",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "ઝિમ્બાબ્વે",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "జింబాబ్వే",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಜಿಂಬಾಬ್ವೆ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "ஜிம்பாப்வே",
+        "lang": "ta"
+      },
+      {
+        "name": "സിംബാബ്വേ",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "জিম্বাবুয়ে",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "ဇင်ဘာဘွေ",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "සිම්බාබ්වේ",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "ジンバブエ共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "南ローデシア",
+        "lang": "ja"
+      },
+      {
+        "name": "津巴布韦",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Zimbabwe",
+    "adminCode1": "00",
+    "lng": "29.75",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 2,
+      "gmtOffset": 2,
+      "timeZoneId": "Africa/Harare"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -22.417738,
+      "east": 33.056305,
+      "north": -15.608835,
+      "west": 25.237028
+    },
+    "name": "Zimbabwe",
+    "fcode": "PCLI",
+    "geonameId": 878675,
+    "asciiName": "Republic of Zimbabwe",
+    "lat": "-19",
+    "population": 11651858,
+    "adminName1": "",
+    "countryId": "878675",
+    "fclName": "country, state, region,...",
+    "countryCode": "ZW",
+    "srtm3": 1285,
+    "wikipediaURL": "en.wikipedia.org/wiki/Zimbabwe",
+    "toponymName": "Republic of Zimbabwe",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Middle East": 6269133,
+  "6269133": {
+    "alternateNames": [
+      {
+        "name": "Mezoriento",
+        "lang": "eo"
+      },
+      {
+        "name": "Middle East",
+        "lang": "en"
+      },
+      {
+        "name": "Moyen-Orient",
+        "lang": "fr"
+      },
+      {
+        "name": "Oriente Medio",
+        "lang": "es"
+      },
+      {
+        "name": "Sudokcidenta Azio",
+        "lang": "eo"
+      }
+    ],
+    "countryName": "",
+    "fclName": "parks,area, ...",
+    "srtm3": 917,
+    "lng": "35.85869",
+    "adminName2": "",
+    "adminName3": "",
+    "fcodeName": "region",
+    "adminName4": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 2,
+      "timeZoneId": "Asia/Damascus"
+    },
+    "toponymName": "Middle East",
+    "adminName5": "",
+    "fcl": "L",
+    "name": "Middle East",
+    "fcode": "RGN",
+    "geonameId": 6269133,
+    "asciiName": "Middle East",
+    "lat": "33.13906",
+    "population": 0,
+    "adminName1": ""
+  },
+  "Europe": 7729884,
+  "7729884": {
+    "alternateNames": [
+      {
+        "name": "http://en.wikipedia.org/wiki/Eastern_Europe",
+        "lang": "link"
+      }
+    ],
+    "countryName": "",
+    "cc2": "RU,UA,PL,RO,CZ,HU,BY,BG,SK,MD",
+    "fclName": "parks,area, ...",
+    "srtm3": 141,
+    "lng": "28.38867",
+    "wikipediaURL": "en.wikipedia.org/wiki/Eastern_Europe",
+    "adminName2": "",
+    "adminName3": "",
+    "fcodeName": "region",
+    "adminName4": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Europe/Minsk"
+    },
+    "toponymName": "Eastern Europe",
+    "adminName5": "",
+    "fcl": "L",
+    "bbox": {
+      "south": 41.188862,
+      "east": -169.002365,
+      "north": 81.857361,
+      "west": 12.096194
+    },
+    "name": "Eastern Europe",
+    "fcode": "RGN",
+    "geonameId": 7729884,
+    "asciiName": "Eastern Europe",
+    "lat": "51.72703",
+    "population": 294600000,
+    "adminName1": ""
+  },
+  "Kisii": 191299,
+  "191299": {
+    "alternateNames": [
+      {
+        "name": "http://en.wikipedia.org/wiki/Kisii%2C_Kenya",
+        "lang": "link"
+      },
+      {
+        "name": "Kisii"
+      }
+    ],
+    "countryName": "Kenya",
+    "adminCode1": "25",
+    "lng": "34.76666",
+    "adminName2": "",
+    "fcodeName": "seat of a first-order administrative division",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Nairobi"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -0.7033030838686813,
+      "east": 34.788231948733696,
+      "north": -0.6601710596754136,
+      "west": 34.74509706127607
+    },
+    "name": "Kisii",
+    "fcode": "PPLA",
+    "geonameId": 191299,
+    "asciiName": "Kisii",
+    "lat": "-0.68174",
+    "population": 28547,
+    "adminName1": "Kisii",
+    "adminId1": "191298",
+    "countryId": "192950",
+    "fclName": "city, village,...",
+    "countryCode": "KE",
+    "srtm3": 1686,
+    "wikipediaURL": "en.wikipedia.org/wiki/Kisii%2C_Kenya",
+    "toponymName": "Kisii",
+    "fcl": "P",
+    "continentCode": "AF"
+  },
+  "Kisumu": 191245,
+  "191245": {
+    "alternateNames": [
+      {
+        "name": "キスム",
+        "lang": "ja"
+      },
+      {
+        "name": "키수무",
+        "lang": "ko"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Kisumu",
+        "lang": "link"
+      },
+      {
+        "name": "KIS",
+        "lang": "iata"
+      },
+      {
+        "name": "Kisumo"
+      },
+      {
+        "name": "Kisumu",
+        "lang": "de"
+      },
+      {
+        "name": "Kisumu",
+        "lang": "en"
+      },
+      {
+        "name": "Kisumu",
+        "lang": "fi"
+      },
+      {
+        "name": "Kisumu",
+        "lang": "fr"
+      },
+      {
+        "name": "Kisumu",
+        "lang": "nl"
+      },
+      {
+        "name": "Kisumu",
+        "lang": "pl"
+      },
+      {
+        "name": "Kisumu",
+        "lang": "sl"
+      },
+      {
+        "name": "Kisumu"
+      },
+      {
+        "name": "Lady Whitehouse"
+      },
+      {
+        "name": "Port Florence"
+      },
+      {
+        "name": "Winam"
+      },
+      {
+        "name": "كيزيمو",
+        "lang": "ar"
+      },
+      {
+        "name": "کیسومو، کنیا",
+        "lang": "fa"
+      },
+      {
+        "name": "Горад Кісуму",
+        "lang": "be"
+      },
+      {
+        "name": "Кисуму",
+        "lang": "ru"
+      },
+      {
+        "name": "Кисуму",
+        "lang": "sr"
+      },
+      {
+        "name": "Кісуму",
+        "lang": "uk"
+      },
+      {
+        "name": "კისუმუ",
+        "lang": "ka"
+      },
+      {
+        "name": "基蘇木",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Kenya",
+    "adminCode1": "26",
+    "lng": "34.76171",
+    "adminName2": "",
+    "fcodeName": "seat of a first-order administrative division",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Nairobi"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -0.16254122992403974,
+      "east": 34.8220452460373,
+      "north": -0.041878770075960234,
+      "west": 34.7013827539627
+    },
+    "name": "Kisumu",
+    "fcode": "PPLA",
+    "geonameId": 191245,
+    "asciiName": "Kisumu",
+    "lat": "-0.10221",
+    "population": 216479,
+    "adminName1": "Kisumu",
+    "adminId1": "191242",
+    "countryId": "192950",
+    "fclName": "city, village,...",
+    "countryCode": "KE",
+    "srtm3": 1174,
+    "wikipediaURL": "en.wikipedia.org/wiki/Kisumu",
+    "toponymName": "Kisumu",
+    "fcl": "P",
+    "continentCode": "AF"
+  },
+  "Bondo District": 7667620,
+  "7667620": {
+    "adminCode2": "7667620",
+    "alternateNames": [
+      {
+        "name": "Bondo"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Bondo_District",
+        "lang": "link"
+      }
+    ],
+    "countryName": "Kenya",
+    "adminCode1": "07",
+    "lng": "34.25",
+    "adminName2": "KE.07.7667620",
+    "fcodeName": "historical second-order administrative division",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Nairobi"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "name": "Bondo District",
+    "fcode": "ADM2H",
+    "geonameId": 7667620,
+    "asciiName": "Bondo District",
+    "lat": "-0.1",
+    "population": 0,
+    "adminName1": "KE.07",
+    "countryId": "192950",
+    "fclName": "country, state, region,...",
+    "countryCode": "KE",
+    "srtm3": 1245,
+    "wikipediaURL": "en.wikipedia.org/wiki/Bondo_District",
+    "toponymName": "Bondo District",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Nyando District": 7602531,
+  "7602531": {
+    "adminCode2": "7602531",
+    "alternateNames": [
+      {
+        "name": "http://en.wikipedia.org/wiki/Nyando_District",
+        "lang": "link"
+      },
+      {
+        "name": "Nyando"
+      }
+    ],
+    "countryName": "Kenya",
+    "adminCode1": "26",
+    "lng": "34.981",
+    "adminName2": "Nyando District",
+    "fcodeName": "second-order administrative division",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Nairobi"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "name": "Nyando District",
+    "fcode": "ADM2",
+    "geonameId": 7602531,
+    "asciiName": "Nyando District",
+    "lat": "-0.159",
+    "population": 0,
+    "adminName1": "Kisumu",
+    "adminId1": "191242",
+    "countryId": "192950",
+    "fclName": "country, state, region,...",
+    "countryCode": "KE",
+    "srtm3": 1174,
+    "adminId2": "7602531",
+    "wikipediaURL": "en.wikipedia.org/wiki/Nyando_District",
+    "toponymName": "Nyando District",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Nandi": 8051212,
+  "2202064": {
+    "alternateNames": [
+      {
+        "name": "http://en.wikipedia.org/wiki/Nadi%2C_Fiji",
+        "lang": "link"
+      },
+      {
+        "name": "Nadi",
+        "isPreferredName": true,
+        "lang": "de"
+      },
+      {
+        "name": "Nadi",
+        "isPreferredName": true,
+        "lang": "en"
+      },
+      {
+        "name": "Nadi",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "name": "NAN",
+        "lang": "iata"
+      },
+      {
+        "name": "Nandi"
+      },
+      {
+        "name": "Нанди",
+        "lang": "ru"
+      }
+    ],
+    "countryName": "Fiji",
+    "adminCode1": "05",
+    "cc2": "FJ",
+    "lng": "177.41667",
+    "adminName2": "",
+    "fcodeName": "populated place",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 12,
+      "gmtOffset": 12,
+      "timeZoneId": "Pacific/Fiji"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -17.82660357177731,
+      "east": 177.44460366925688,
+      "north": -17.773396428222693,
+      "west": 177.38872973074314
+    },
+    "name": "Nadi",
+    "fcode": "PPL",
+    "geonameId": 2202064,
+    "asciiName": "Nadi",
+    "lat": "-17.8",
+    "population": 42284,
+    "adminName1": "Western",
+    "adminId1": "2194371",
+    "countryId": "2205218",
+    "fclName": "city, village,...",
+    "countryCode": "FJ",
+    "srtm3": 10,
+    "wikipediaURL": "en.wikipedia.org/wiki/Nadi%2C_Fiji",
+    "toponymName": "Nadi",
+    "fcl": "P",
+    "continentCode": "OC"
+  },
+  "Kiberege": 157991,
+  "157991": {
+    "alternateNames": [
+      {
+        "name": "Kiberege",
+        "lang": "en"
+      }
+    ],
+    "countryName": "Tanzania",
+    "adminCode1": "10",
+    "lng": "36.85692",
+    "adminName2": "",
+    "fcodeName": "populated place",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Dar_es_Salaam"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -7.958151648751427,
+      "east": 36.866005706677186,
+      "north": -7.940164351248573,
+      "west": 36.84784429332281
+    },
+    "name": "Kiberege",
+    "fcode": "PPL",
+    "geonameId": 157991,
+    "asciiName": "Kiberege",
+    "lat": "-7.94916",
+    "population": 0,
+    "adminName1": "Morogoro",
+    "adminId1": "153214",
+    "countryId": "149590",
+    "fclName": "city, village,...",
+    "countryCode": "TZ",
+    "srtm3": 299,
+    "toponymName": "Kiberege",
+    "fcl": "P",
+    "continentCode": "AF"
+  },
+  "Guadalcanal Island": 2108832,
+  "2108832": {
+    "alternateNames": [
+      {
+        "name": "Guadalcanal Island"
+      },
+      {
+        "name": "Guadalcanar"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Guadalcanal",
+        "lang": "link"
+      }
+    ],
+    "countryName": "Solomon Islands",
+    "adminCode1": "06",
+    "lng": "160.13947",
+    "adminName2": "",
+    "fcodeName": "island",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 11,
+      "gmtOffset": 11,
+      "timeZoneId": "Pacific/Guadalcanal"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -9.949388,
+      "east": 160.833939,
+      "north": -9.24225,
+      "west": 159.58403
+    },
+    "name": "Guadalcanal Island",
+    "fcode": "ISL",
+    "geonameId": 2108832,
+    "asciiName": "Guadalcanal Island",
+    "lat": "-9.57062",
+    "population": 0,
+    "adminName1": "Guadalcanal",
+    "adminId1": "2108831",
+    "countryId": "2103350",
+    "fclName": "mountain,hill,rock,... ",
+    "countryCode": "SB",
+    "srtm3": -32768,
+    "wikipediaURL": "en.wikipedia.org/wiki/Guadalcanal",
+    "toponymName": "Guadalcanal Island",
+    "fcl": "T",
+    "continentCode": "OC"
+  },
+  "Zambia": 895949,
+  "895949": {
+    "alternateNames": [
+      {
+        "name": "잠비아",
+        "lang": "ko"
+      },
+      {
+        "name": "ዛምቢያ",
+        "lang": "am"
+      },
+      {
+        "name": "ዛምቢያ",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ザンビア",
+        "lang": "ja"
+      },
+      {
+        "name": "ແຊມເບຍ",
+        "lang": "lo"
+      },
+      {
+        "name": "ଜାମ୍ବିଆ",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "แซมเบีย",
+        "lang": "th"
+      },
+      {
+        "name": "ཛམ་བི་ཡ",
+        "lang": "dz"
+      },
+      {
+        "name": "ཛམ་བི་ཡ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ហ្សាំប៊ី",
+        "lang": "km"
+      },
+      {
+        "name": "An tSaimbia",
+        "lang": "ga"
+      },
+      {
+        "name": "Dăm-bi-a",
+        "lang": "vi"
+      },
+      {
+        "name": "Dăm-bi-a (Zambia)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Zambia",
+        "lang": "link"
+      },
+      {
+        "name": "http://id.loc.gov/authorities/names/n80089997",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%97%D0%B0%D0%BC%D0%B1%D0%B8%D1%8F",
+        "lang": "link"
+      },
+      {
+        "name": "i-Zambia",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Nordrhodesien",
+        "lang": "de"
+      },
+      {
+        "name": "Norður-Ródesía",
+        "lang": "is"
+      },
+      {
+        "name": "Northern Rhodesia",
+        "lang": "en"
+      },
+      {
+        "name": "Northern Rhodesia"
+      },
+      {
+        "name": "Orílẹ́ède ṣamibia",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Republic of Zambia"
+      },
+      {
+        "name": "Rodezja Północna",
+        "lang": "pl"
+      },
+      {
+        "name": "Saambiya",
+        "lang": "so"
+      },
+      {
+        "name": "Sambia",
+        "lang": "cy"
+      },
+      {
+        "isShortName": true,
+        "name": "Sambia",
+        "lang": "de"
+      },
+      {
+        "name": "Sambia",
+        "lang": "et"
+      },
+      {
+        "name": "Sambia",
+        "lang": "fi"
+      },
+      {
+        "name": "Sambia",
+        "lang": "fo"
+      },
+      {
+        "name": "Sambia",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Sambía",
+        "lang": "is"
+      },
+      {
+        "name": "Sammbi",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Semipia",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Zambi",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Zambi",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Zambi",
+        "lang": "sq"
+      },
+      {
+        "name": "Zambia",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Zambia",
+        "isPreferredName": true,
+        "lang": "br"
+      },
+      {
+        "name": "Zambia",
+        "lang": "da"
+      },
+      {
+        "name": "Zambia",
+        "isPreferredName": true,
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Zambia",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Zambia",
+        "isPreferredName": true,
+        "lang": "et"
+      },
+      {
+        "name": "Zambia",
+        "isPreferredName": true,
+        "lang": "eu"
+      },
+      {
+        "name": "Zambia",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Zambia",
+        "lang": "hu"
+      },
+      {
+        "name": "Zambia",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Zambia",
+        "lang": "id"
+      },
+      {
+        "name": "Zambia",
+        "lang": "it"
+      },
+      {
+        "name": "Zambia",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Zambia",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Zambia",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Zambia",
+        "lang": "ms"
+      },
+      {
+        "name": "Zambia",
+        "lang": "nb"
+      },
+      {
+        "name": "Zambia",
+        "lang": "nl"
+      },
+      {
+        "name": "Zambia",
+        "lang": "nn"
+      },
+      {
+        "name": "Zambia",
+        "lang": "pl"
+      },
+      {
+        "name": "Zambia",
+        "lang": "ro"
+      },
+      {
+        "name": "Zambia",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Zambia",
+        "lang": "sk"
+      },
+      {
+        "name": "Zambia",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Zambia",
+        "lang": "sv"
+      },
+      {
+        "name": "Zambia",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Zambia"
+      },
+      {
+        "name": "Zàmbia",
+        "lang": "ca"
+      },
+      {
+        "name": "Zâmbia",
+        "lang": "pt"
+      },
+      {
+        "name": "Zambia nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Zambie",
+        "lang": "cs"
+      },
+      {
+        "name": "Zambie",
+        "lang": "fr"
+      },
+      {
+        "name": "Zambië",
+        "lang": "af"
+      },
+      {
+        "name": "Zambïi",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Zambija",
+        "isPreferredName": true,
+        "lang": "bs"
+      },
+      {
+        "name": "Zambija",
+        "lang": "hr"
+      },
+      {
+        "name": "Zambija",
+        "lang": "lt"
+      },
+      {
+        "name": "Zambija",
+        "lang": "lv"
+      },
+      {
+        "name": "Zambija",
+        "lang": "sl"
+      },
+      {
+        "name": "Zambio",
+        "lang": "eo"
+      },
+      {
+        "name": "Zambiya",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Zambiya",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Zambiya",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Zambiya",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Zambiya",
+        "lang": "tr"
+      },
+      {
+        "name": "Żambja",
+        "lang": "mt"
+      },
+      {
+        "name": "Zambya",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Zanbi",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "زامبیا",
+        "lang": "fa"
+      },
+      {
+        "name": "زامبیا",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "زامبیا",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "زامبيا",
+        "lang": "ar"
+      },
+      {
+        "name": "זמביה",
+        "lang": "he"
+      },
+      {
+        "name": "Ζάμπια",
+        "lang": "el"
+      },
+      {
+        "name": "Замбија",
+        "lang": "mk"
+      },
+      {
+        "name": "Замбија",
+        "lang": "sr"
+      },
+      {
+        "name": "Замбия",
+        "lang": "bg"
+      },
+      {
+        "name": "Замбия",
+        "lang": "ru"
+      },
+      {
+        "name": "Замбія",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Замбія",
+        "lang": "uk"
+      },
+      {
+        "name": "Զամբիա",
+        "lang": "hy"
+      },
+      {
+        "name": "ზამბია",
+        "lang": "ka"
+      },
+      {
+        "name": "जाम्बिया",
+        "lang": "hi"
+      },
+      {
+        "name": "जाम्बिया",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "ज़ाम्बिया",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "झाम्बिया",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "ઝામ્બિયા",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "జాంబియా",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಝಾಂಬಿಯಾ",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "சாம்பியா",
+        "isPreferredName": true,
+        "lang": "ta"
+      },
+      {
+        "name": "സാംബിയ",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "জাম্বিয়া",
+        "isPreferredName": true,
+        "lang": "bn"
+      },
+      {
+        "name": "ဇမ်ဘီယာ",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "සැම්බියාව",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "ザンビア共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "北ローデシア",
+        "lang": "ja"
+      },
+      {
+        "name": "赞比亚",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Zambia",
+    "adminCode1": "00",
+    "lng": "28.5",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 2,
+      "gmtOffset": 2,
+      "timeZoneId": "Africa/Lusaka"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -18.079473,
+      "east": 33.705704,
+      "north": -8.22436,
+      "west": 21.999371
+    },
+    "name": "Zambia",
+    "fcode": "PCLI",
+    "geonameId": 895949,
+    "asciiName": "Republic of Zambia",
+    "lat": "-14.33333",
+    "population": 13460305,
+    "adminName1": "",
+    "countryId": "895949",
+    "fclName": "country, state, region,...",
+    "countryCode": "ZM",
+    "srtm3": 1156,
+    "wikipediaURL": "en.wikipedia.org/wiki/Zambia",
+    "toponymName": "Republic of Zambia",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Madagascar": 1062947,
+  "1062947": {
+    "alternateNames": [
+      {
+        "name": "ማዳጋስካር",
+        "lang": "am"
+      },
+      {
+        "name": "ማዳጋስካር",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "マダガスカル",
+        "lang": "ja"
+      },
+      {
+        "name": "마다가스카르",
+        "lang": "ko"
+      },
+      {
+        "name": "마다카스카르",
+        "isPreferredName": true,
+        "lang": "ko"
+      },
+      {
+        "name": "ມາຄາກັສກາ",
+        "lang": "lo"
+      },
+      {
+        "name": "ମାଡାଗାସ୍କର୍",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "มาดากัสการ์",
+        "lang": "th"
+      },
+      {
+        "name": "མ་དཱ་གྷསྐཱར།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ម៉ាដាហ្កាស្ការ",
+        "lang": "km"
+      },
+      {
+        "name": "ประเทศมาดากัสการ์",
+        "lang": "th"
+      },
+      {
+        "name": "Bukini",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Bukini",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Democratic Republic of Madagascar"
+      },
+      {
+        "name": "Grande-Île"
+      },
+      {
+        "name": "Grande-Terre"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Madagascar",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%9C%D0%B0%D0%B4%D0%B0%D0%B3%D0%B0%D1%81%D0%BA%D0%B0%D1%80",
+        "lang": "link"
+      },
+      {
+        "name": "Île Rouge"
+      },
+      {
+        "name": "i-Madagascar",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "La Grand Île de Madagascar"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "an"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "ast"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "ca"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "cy"
+      },
+      {
+        "name": "Madagascar",
+        "isPreferredName": true,
+        "lang": "da"
+      },
+      {
+        "isShortName": true,
+        "name": "Madagascar",
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Madagascar",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "isShortName": true,
+        "name": "Madagascar",
+        "lang": "fr"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "ga"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "gd"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "gl"
+      },
+      {
+        "name": "Madagascar",
+        "isPreferredName": true,
+        "lang": "ia"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "ilo"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "it"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "ms"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "oc"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "pam"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "pms"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "pt"
+      },
+      {
+        "name": "Madagascar",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "ro"
+      },
+      {
+        "name": "Madagascar",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "tl"
+      },
+      {
+        "name": "Madagascar",
+        "lang": "vi"
+      },
+      {
+        "name": "Madagáscar",
+        "lang": "pt"
+      },
+      {
+        "name": "Madagascar and Dependencies"
+      },
+      {
+        "name": "Madagascaria",
+        "lang": "la"
+      },
+      {
+        "name": "Madagasika",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Madagasikara",
+        "lang": "mg"
+      },
+      {
+        "name": "Madagasikari",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Madagasikari",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Madagasikari",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Madagasikari",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Madagaska",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Madagaska",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Madagaska",
+        "lang": "sw"
+      },
+      {
+        "name": "Madagaskaar",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Madagaska nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "af"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "br"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "bs"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "cs"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "da"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "de"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "et"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "eu"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "fi"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "fo"
+      },
+      {
+        "name": "Madagaskar",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "hbs"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "hr"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "id"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "io"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "is"
+      },
+      {
+        "name": "Madagaskar",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "ku"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "kw"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "ms"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "mt"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "nb"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "nds"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "nl"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "nn"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "no"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "pl"
+      },
+      {
+        "name": "Madagaskar",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "sk"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "sl"
+      },
+      {
+        "name": "Madagaskar",
+        "isPreferredName": true,
+        "lang": "so"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "sq"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "sv"
+      },
+      {
+        "name": "Madagaskar",
+        "lang": "tr"
+      },
+      {
+        "name": "Madagaskara",
+        "lang": "lv"
+      },
+      {
+        "name": "Madagaskära",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Madagaskaras",
+        "lang": "lt"
+      },
+      {
+        "name": "Madagaskaro",
+        "lang": "eo"
+      },
+      {
+        "name": "Madagaszkár",
+        "lang": "hu"
+      },
+      {
+        "name": "Ma-đa-gát-xca",
+        "lang": "vi"
+      },
+      {
+        "name": "Ma-đa-gát-xca (Madagascar)",
+        "isPreferredName": true,
+        "lang": "vi"
+      },
+      {
+        "name": "Madaqaskar",
+        "isPreferredName": true,
+        "lang": "az"
+      },
+      {
+        "name": "Maddajaßka",
+        "lang": "ksh"
+      },
+      {
+        "name": "Madegaskari",
+        "lang": "sq"
+      },
+      {
+        "name": "Malagash Republic"
+      },
+      {
+        "name": "Malagasy Republic"
+      },
+      {
+        "name": "Malgache"
+      },
+      {
+        "name": "Malgache Republic"
+      },
+      {
+        "name": "Matakasika",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Orílẹ́ède Madasika",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Repoblika Demokratika Malagasy"
+      },
+      {
+        "name": "Repoblika Malagasy"
+      },
+      {
+        "name": "Repoblikan’i Madagasikara",
+        "lang": "mg"
+      },
+      {
+        "name": "Republic of Madagascar",
+        "lang": "en"
+      },
+      {
+        "name": "République de Madagascar",
+        "lang": "fr"
+      },
+      {
+        "name": "République Démocratique de Madagascar"
+      },
+      {
+        "name": "République Malgache"
+      },
+      {
+        "name": "Territoire de Madagascar"
+      },
+      {
+        "name": "Territoire de Madagascar et Dépendances"
+      },
+      {
+        "name": "ماداگاسكار",
+        "lang": "ug"
+      },
+      {
+        "name": "ماداگاسکار",
+        "lang": "fa"
+      },
+      {
+        "name": "ماداگاسکار",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "مادغاسکر",
+        "lang": "ps"
+      },
+      {
+        "name": "مدغشقر",
+        "lang": "ar"
+      },
+      {
+        "name": "مڈغاسکر",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "מדגסקר",
+        "lang": "he"
+      },
+      {
+        "name": "Μαδαγασκάρη",
+        "lang": "el"
+      },
+      {
+        "name": "Мадагаскар",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Мадагаскар",
+        "lang": "bg"
+      },
+      {
+        "name": "Мадагаскар",
+        "lang": "mk"
+      },
+      {
+        "name": "Мадагаскар",
+        "lang": "ru"
+      },
+      {
+        "name": "Мадагаскар",
+        "lang": "sr"
+      },
+      {
+        "name": "Мадагаскар",
+        "lang": "tg"
+      },
+      {
+        "name": "Мадагаскар",
+        "lang": "uk"
+      },
+      {
+        "name": "Мадаґаскар",
+        "lang": "uk"
+      },
+      {
+        "name": "Республика Мадагаскар",
+        "lang": "ru"
+      },
+      {
+        "name": "Մադագասկար",
+        "lang": "hy"
+      },
+      {
+        "name": "მადაგასკარი",
+        "lang": "ka"
+      },
+      {
+        "name": "मडगास्कर",
+        "lang": "ks"
+      },
+      {
+        "name": "मडगास्कर",
+        "lang": "sa"
+      },
+      {
+        "name": "मडागास्कर",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "मदागास्कर",
+        "lang": "hi"
+      },
+      {
+        "name": "मादागास्कर",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "मेडागास्कर",
+        "isPreferredName": true,
+        "lang": "hi"
+      },
+      {
+        "name": "મેડાગાસ્કર",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "మాడ్గాస్కార్",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "ಮಡಗಾಸ್ಕರ್",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "மடகாஸ்கர்",
+        "lang": "ta"
+      },
+      {
+        "name": "മഡഗാസ്കര്‍",
+        "lang": "ml"
+      },
+      {
+        "name": "মাদাগাস্কার",
+        "lang": "bn"
+      },
+      {
+        "name": "မဒဂတ်စကာ",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "マダガスカル共和国",
+        "isPreferredName": true,
+        "lang": "ja"
+      },
+      {
+        "name": "马达加斯加",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Madagascar",
+    "adminCode1": "00",
+    "lng": "47",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Indian/Antananarivo"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -25.608952,
+      "east": 50.48378,
+      "north": -11.549225,
+      "west": 43.19138
+    },
+    "name": "Madagascar",
+    "fcode": "PCLI",
+    "geonameId": 1062947,
+    "asciiName": "Republic of Madagascar",
+    "lat": "-20",
+    "population": 21281844,
+    "adminName1": "",
+    "countryId": "1062947",
+    "fclName": "country, state, region,...",
+    "countryCode": "MG",
+    "srtm3": 1678,
+    "wikipediaURL": "en.wikipedia.org/wiki/Madagascar",
+    "toponymName": "Republic of Madagascar",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Ifakara": 159492,
+  "159492": {
+    "alternateNames": [
+      {
+        "name": "http://en.wikipedia.org/wiki/Ifakara",
+        "lang": "link"
+      },
+      {
+        "name": "Ifakara"
+      }
+    ],
+    "countryName": "Tanzania",
+    "adminCode1": "10",
+    "lng": "36.68333",
+    "adminName2": "",
+    "fcodeName": "populated place",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Dar_es_Salaam"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -8.16212672515161,
+      "east": 36.712417203953905,
+      "north": -8.10453927484839,
+      "west": 36.65424879604609
+    },
+    "name": "Ifakara",
+    "fcode": "PPL",
+    "geonameId": 159492,
+    "asciiName": "Ifakara",
+    "lat": "-8.13333",
+    "population": 49528,
+    "adminName1": "Morogoro",
+    "adminId1": "153214",
+    "countryId": "149590",
+    "fclName": "city, village,...",
+    "countryCode": "TZ",
+    "srtm3": 259,
+    "wikipediaURL": "en.wikipedia.org/wiki/Ifakara",
+    "toponymName": "Ifakara",
+    "fcl": "P",
+    "continentCode": "AF"
+  },
+  "8051212": {
+    "alternateNames": [
+      {
+        "name": "http://en.wikipedia.org/wiki/Nandi,_Kenya",
+        "lang": "link"
+      },
+      {
+        "name": "Nandi"
+      },
+      {
+        "name": "Nandi South"
+      }
+    ],
+    "countryName": "Kenya",
+    "adminCode1": "40",
+    "lng": "35.193",
+    "adminName2": "",
+    "fcodeName": "first-order administrative division",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 3,
+      "gmtOffset": 3,
+      "timeZoneId": "Africa/Nairobi"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -0.109754164679262,
+      "east": 35.43890906648317,
+      "north": 0.560472886320779,
+      "west": 34.740300668483194
+    },
+    "name": "Nandi",
+    "fcode": "ADM1",
+    "geonameId": 8051212,
+    "asciiName": "Nandi South District",
+    "lat": "0.055",
+    "population": 752965,
+    "adminName1": "Nandi",
+    "adminId1": "8051212",
+    "countryId": "192950",
+    "fclName": "country, state, region,...",
+    "countryCode": "KE",
+    "srtm3": 1701,
+    "wikipediaURL": "en.wikipedia.org/wiki/Nandi%2C_Kenya",
+    "toponymName": "Nandi",
+    "fcl": "A",
+    "continentCode": "AF"
+  },
+  "Vietnam": 1562822,
+  "1562822": {
+    "alternateNames": [
+      {
+        "name": "베트남",
+        "lang": "ko"
+      },
+      {
+        "name": "ቬትናም",
+        "lang": "am"
+      },
+      {
+        "name": "ቬትናም",
+        "isPreferredName": true,
+        "lang": "ti"
+      },
+      {
+        "name": "ベトナム",
+        "lang": "ja"
+      },
+      {
+        "name": "វៀតណាម",
+        "lang": "km"
+      },
+      {
+        "name": "ຫວຽດນາມ",
+        "lang": "lo"
+      },
+      {
+        "name": "བེཊ་ནཱམ",
+        "lang": "dz"
+      },
+      {
+        "name": "ଭିଏତନାମ୍",
+        "isPreferredName": true,
+        "lang": "or"
+      },
+      {
+        "name": "เวียดนาม",
+        "lang": "th"
+      },
+      {
+        "name": "வியட்நாம்",
+        "lang": "ta"
+      },
+      {
+        "name": "བི་དི་ནམ།",
+        "isPreferredName": true,
+        "lang": "bo"
+      },
+      {
+        "name": "ประเทศเวียดนาม",
+        "lang": "th"
+      },
+      {
+        "name": "Bhiet-Nam",
+        "lang": "gd"
+      },
+      {
+        "name": "Bietnam",
+        "lang": "an"
+      },
+      {
+        "name": "Bietnam",
+        "lang": "ilo"
+      },
+      {
+        "name": "Biyetinam",
+        "isPreferredName": true,
+        "lang": "ha"
+      },
+      {
+        "name": "Công Hòa Xã Hội Chủ Nghĩa Việt Nam",
+        "lang": "vi"
+      },
+      {
+        "name": "Fietnam",
+        "lang": "cy"
+      },
+      {
+        "name": "Fietnam",
+        "lang": "fy"
+      },
+      {
+        "name": "Fiyetnaam",
+        "lang": "so"
+      },
+      {
+        "name": "http://en.wikipedia.org/wiki/Vietnam",
+        "lang": "link"
+      },
+      {
+        "name": "http://ru.wikipedia.org/wiki/%D0%92%D1%8C%D0%B5%D1%82%D0%BD%D0%B0%D0%BC",
+        "lang": "link"
+      },
+      {
+        "name": "i-Vietnam",
+        "isPreferredName": true,
+        "lang": "zu"
+      },
+      {
+        "name": "Orílẹ́ède Fẹtinami",
+        "isPreferredName": true,
+        "lang": "yo"
+      },
+      {
+        "name": "Socialist Republic of Vietnam",
+        "lang": "en"
+      },
+      {
+        "name": "Vietinamu",
+        "isPreferredName": true,
+        "lang": "ki"
+      },
+      {
+        "name": "Vietinamu",
+        "isPreferredName": true,
+        "lang": "sw"
+      },
+      {
+        "name": "Vietinemi",
+        "isPreferredName": true,
+        "lang": "to"
+      },
+      {
+        "name": "Vietnã",
+        "lang": "pt"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "ast"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "ca"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "cs"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "da"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "de"
+      },
+      {
+        "isShortName": true,
+        "name": "Vietnam",
+        "lang": "en"
+      },
+      {
+        "isShortName": true,
+        "name": "Vietnam",
+        "isPreferredName": true,
+        "lang": "es"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "et"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "eu"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "fi"
+      },
+      {
+        "name": "Vietnam",
+        "isPreferredName": true,
+        "lang": "fo"
+      },
+      {
+        "name": "Vietnam",
+        "isPreferredName": true,
+        "lang": "fr"
+      },
+      {
+        "name": "Vietnam",
+        "isPreferredName": true,
+        "lang": "gl"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "hsb"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "hu"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "id"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "io"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "it"
+      },
+      {
+        "name": "Vietnam",
+        "isPreferredName": true,
+        "lang": "kl"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "kw"
+      },
+      {
+        "name": "Vietnam",
+        "isPreferredName": true,
+        "lang": "mg"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "ms"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "nb"
+      },
+      {
+        "name": "Vietnam",
+        "isPreferredName": true,
+        "lang": "nd"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "nds"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "nl"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "nn"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "no"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "oc"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "pam"
+      },
+      {
+        "name": "Vietnam",
+        "isPreferredName": true,
+        "lang": "rm"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "ro"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "scn"
+      },
+      {
+        "name": "Vietnam",
+        "isPreferredName": true,
+        "lang": "se"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "sk"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "sl"
+      },
+      {
+        "name": "Vietnam",
+        "isPreferredName": true,
+        "lang": "sn"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "sv"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "tl"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "tr"
+      },
+      {
+        "name": "Vietnam",
+        "lang": "wa"
+      },
+      {
+        "name": "Viet Nam",
+        "lang": "fr"
+      },
+      {
+        "name": "Víetnam",
+        "lang": "is"
+      },
+      {
+        "name": "Việt Nam",
+        "lang": "vi"
+      },
+      {
+        "name": "Viêt Nam",
+        "lang": "br"
+      },
+      {
+        "name": "Viêt Nam",
+        "lang": "fr"
+      },
+      {
+        "name": "Viêt Nam",
+        "lang": "frp"
+      },
+      {
+        "name": "Viëtnam",
+        "lang": "af"
+      },
+      {
+        "name": "Viëtnam",
+        "lang": "li"
+      },
+      {
+        "name": "Viɛtnam",
+        "isPreferredName": true,
+        "lang": "ak"
+      },
+      {
+        "name": "Vietnám",
+        "lang": "hu"
+      },
+      {
+        "name": "Vietnäm",
+        "isPreferredName": true,
+        "lang": "sg"
+      },
+      {
+        "name": "Vietnamän",
+        "lang": "vo"
+      },
+      {
+        "name": "Vietnamas",
+        "lang": "lt"
+      },
+      {
+        "name": "Vietname",
+        "lang": "pt"
+      },
+      {
+        "name": "Vietnami",
+        "lang": "sq"
+      },
+      {
+        "name": "Vietnamia",
+        "lang": "la"
+      },
+      {
+        "name": "Vietnam nutome",
+        "isPreferredName": true,
+        "lang": "ee"
+      },
+      {
+        "name": "Vietnam - Việt Nam",
+        "lang": "gl"
+      },
+      {
+        "name": "Vijetnam",
+        "lang": "bs"
+      },
+      {
+        "name": "Vijetnam",
+        "lang": "hbs"
+      },
+      {
+        "name": "Vijetnam",
+        "lang": "hr"
+      },
+      {
+        "name": "Vít Neam",
+        "isPreferredName": true,
+        "lang": "ga"
+      },
+      {
+        "name": "Viyetiname",
+        "isPreferredName": true,
+        "lang": "lu"
+      },
+      {
+        "name": "Viyetinamɛ",
+        "isPreferredName": true,
+        "lang": "ln"
+      },
+      {
+        "name": "Viyetinamu",
+        "isPreferredName": true,
+        "lang": "rn"
+      },
+      {
+        "name": "Viyetnam",
+        "lang": "ku"
+      },
+      {
+        "name": "Vjetnam",
+        "lang": "mt"
+      },
+      {
+        "name": "Vjetnama",
+        "lang": "lv"
+      },
+      {
+        "name": "Vjetnamio",
+        "lang": "eo"
+      },
+      {
+        "name": "Vjetnamo",
+        "lang": "eo"
+      },
+      {
+        "name": "Vyetinaamu",
+        "isPreferredName": true,
+        "lang": "lg"
+      },
+      {
+        "name": "Vyetnam",
+        "lang": "az"
+      },
+      {
+        "name": "Whitināmu",
+        "lang": "mi"
+      },
+      {
+        "name": "Wietnam",
+        "lang": "pl"
+      },
+      {
+        "name": "Witnam",
+        "lang": "qu"
+      },
+      {
+        "name": "Wiyɛtinamu",
+        "isPreferredName": true,
+        "lang": "bm"
+      },
+      {
+        "name": "Wiyetnaam",
+        "isPreferredName": true,
+        "lang": "ff"
+      },
+      {
+        "name": "Wýetnam",
+        "lang": "tk"
+      },
+      {
+        "name": "ڤیەتنام",
+        "isPreferredName": true,
+        "lang": "ku"
+      },
+      {
+        "name": "فيتنام",
+        "lang": "ar"
+      },
+      {
+        "name": "ویتنام",
+        "lang": "fa"
+      },
+      {
+        "name": "ویتنام",
+        "isPreferredName": true,
+        "lang": "ur"
+      },
+      {
+        "name": "ۋيېتنام",
+        "lang": "ug"
+      },
+      {
+        "name": "וייטנאם",
+        "lang": "he"
+      },
+      {
+        "name": "Βιετνάμ",
+        "lang": "el"
+      },
+      {
+        "name": "В'етнам",
+        "isPreferredName": true,
+        "lang": "be"
+      },
+      {
+        "name": "Ветнам",
+        "lang": "be"
+      },
+      {
+        "name": "Ветнам",
+        "lang": "tg"
+      },
+      {
+        "name": "Вʼєтнам",
+        "lang": "uk"
+      },
+      {
+        "name": "Вєтнам",
+        "lang": "uk"
+      },
+      {
+        "name": "Виетнам",
+        "lang": "bg"
+      },
+      {
+        "name": "Виетнам",
+        "lang": "mk"
+      },
+      {
+        "name": "Вијетнам",
+        "lang": "sr"
+      },
+      {
+        "name": "Вьетнам",
+        "lang": "os"
+      },
+      {
+        "name": "Вьетнам",
+        "lang": "ru"
+      },
+      {
+        "name": "Вьетнам",
+        "lang": "udm"
+      },
+      {
+        "name": "Վիետնամ",
+        "lang": "hy"
+      },
+      {
+        "name": "ვიეტნამი",
+        "lang": "ka"
+      },
+      {
+        "name": "चम्पादेश",
+        "lang": "sa"
+      },
+      {
+        "name": "भिएतनाम",
+        "isPreferredName": true,
+        "lang": "ne"
+      },
+      {
+        "name": "वियतनाम",
+        "lang": "hi"
+      },
+      {
+        "name": "व्हिएतनाम",
+        "isPreferredName": true,
+        "lang": "mr"
+      },
+      {
+        "name": "વિયેતનામ",
+        "isPreferredName": true,
+        "lang": "gu"
+      },
+      {
+        "name": "వియట్నాం",
+        "isPreferredName": true,
+        "lang": "te"
+      },
+      {
+        "name": "వియత్నాం",
+        "lang": "te"
+      },
+      {
+        "name": "ವಿಯೇಟ್ನಾಮ್",
+        "isPreferredName": true,
+        "lang": "kn"
+      },
+      {
+        "name": "വിയറ്റ്നാം",
+        "isPreferredName": true,
+        "lang": "ml"
+      },
+      {
+        "name": "ভিয়েতনাম",
+        "lang": "bn"
+      },
+      {
+        "name": "ভিয়েতনাম",
+        "lang": "bn"
+      },
+      {
+        "name": "ဗီယက်နမ်",
+        "isPreferredName": true,
+        "lang": "my"
+      },
+      {
+        "name": "වියට්නාමය",
+        "isPreferredName": true,
+        "lang": "si"
+      },
+      {
+        "name": "越南",
+        "lang": "zh"
+      }
+    ],
+    "countryName": "Vietnam",
+    "adminCode1": "00",
+    "lng": "107.83333",
+    "adminName2": "",
+    "fcodeName": "independent political entity",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 7,
+      "gmtOffset": 7,
+      "timeZoneId": "Asia/Ho_Chi_Minh"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": 8.40825,
+      "east": 109.464638,
+      "north": 23.388834,
+      "west": 102.148224
+    },
+    "name": "Vietnam",
+    "fcode": "PCLI",
+    "geonameId": 1562822,
+    "asciiName": "Socialist Republic of Vietnam",
+    "lat": "16.16667",
+    "population": 89571130,
+    "adminName1": "",
+    "countryId": "1562822",
+    "fclName": "country, state, region,...",
+    "countryCode": "VN",
+    "srtm3": 934,
+    "wikipediaURL": "en.wikipedia.org/wiki/Vietnam",
+    "toponymName": "Socialist Republic of Vietnam",
+    "fcl": "A",
+    "continentCode": "AS"
+  },
+  "896972": {
+    "alternateNames": [
+      {
+        "name": "http://en.wikipedia.org/wiki/Southern_Province%2C_Zambia",
+        "lang": "link"
+      },
+      {
+        "name": "http://id.loc.gov/authorities/names/n83022861",
+        "lang": "link"
+      },
+      {
+        "isShortName": true,
+        "name": "Southern",
+        "isPreferredName": true
+      },
+      {
+        "name": "Southern Province"
+      }
+    ],
+    "countryName": "Zambia",
+    "adminCode1": "07",
+    "lng": "27",
+    "adminName2": "",
+    "fcodeName": "first-order administrative division",
+    "adminName3": "",
+    "timezone": {
+      "dstOffset": 2,
+      "gmtOffset": 2,
+      "timeZoneId": "Africa/Lusaka"
+    },
+    "adminName4": "",
+    "adminName5": "",
+    "bbox": {
+      "south": -18.076126098632812,
+      "east": 28.943222045898438,
+      "north": -15.288888931274414,
+      "west": 24.96999740600586
+    },
+    "name": "Southern Province",
+    "fcode": "ADM1",
+    "geonameId": 896972,
+    "asciiName": "Southern Province",
+    "lat": "-16.5",
+    "population": 0,
+    "adminName1": "Southern",
+    "adminId1": "896972",
+    "countryId": "895949",
+    "fclName": "country, state, region,...",
+    "countryCode": "ZM",
+    "srtm3": 1166,
+    "wikipediaURL": "en.wikipedia.org/wiki/Southern_Province%2C_Zambia",
+    "toponymName": "Southern Province",
+    "fcl": "A",
+    "continentCode": "AF"
+  }
+}

--- a/lib/enrich_solr.rb
+++ b/lib/enrich_solr.rb
@@ -1,0 +1,106 @@
+require 'json'
+require_relative 'geonames'
+
+# this class is used to alter the solr records from the backend solr
+# to be in the format expected for the discovery solr. It does the following
+# broad tasks
+#
+#  * add geodata, coordinates, and bounding boxes for any place names
+#  * remap the solr field names to be in the form expected by geoblacklight
+#
+# This class does not talk to either solr. It just does the data enrichment and
+# transformation.
+class EnrichSolr
+  def initialize(cache_filename=nil)
+    @geonames = Geonames.new(cache_filename)
+  end
+
+  def process_one(record)
+    new_record = {
+      uuid:             record['id'],
+      dc_title_s:       first_or_nil(record['desc_metadata__title_t']),
+      dc_description_s: first_or_nil(record['desc_metadata__description_t']),
+      dc_creator_sm:    record['desc_metadata__creator_t'],
+      dc_type_s:        first_or_nil(record['desc_metadata__resource_type_t']),
+      dc_subject_sm:    record['desc_metadata__subject_t'],
+      dct_spatial_sm:   record['desc_metadata__based_near_t'],
+      # these are required ATM for geoblacklight...
+      layer_id_s:       first_or_nil(record['noid_s']),
+      layer_slug_s:     first_or_nil(record['noid_s']),
+      layer_geom_type_s: 'Point',
+      dct_provenance_s: 'Digital Library',
+      # should be dc_accessrights_s, dc_rights is for intellectual rights not access rights
+      dc_rights_s:      first_or_nil(record['read_access_group_t']) || 'Public'
+    }
+    new_record.merge!(enrich_bounding_box(record))
+    new_record.merge!(enrich_location_names(record))
+
+    new_record
+  end
+
+  def save
+    @geonames.save
+  end
+
+  private
+
+  # add all locations into a bounding box.
+  # todo: include spatial data in the bounding box
+  def enrich_bounding_box(record)
+    bbox = Geonames::Bbox.new
+    record.fetch('desc_metadata__based_near_t', []).each do |place|
+      place = place.split(",").first
+      info = @geonames.lookup_name(place)
+      if info.nil?
+        next
+      elsif info['bbox']
+        bbox.add_bbox(info['bbox'])
+      else
+        bbox.add_point(info)
+      end
+    end
+
+    if bbox.valid?
+      # nothing was added to this bounding box
+      new_record = {}
+    else
+      west = bbox.west
+      south = bbox.south
+      east = bbox.east
+      # solr does not like coordinates > 180 :(
+      east -= 360 if east > 180
+      north = bbox.north
+      new_record = {
+        "solr_bbox" => "#{west} #{south} #{east} #{north}",
+        "solr_geom" => "ENVELOPE(#{west}, #{east}, #{north}, #{south})",
+        "georss_box_s" => "#{south} #{west} #{north} #{east}",
+        #"georss_polygon_s" => "#{north} #{west} #{north} #{east} #{south} #{east} #{south} #{west} #{north} #{west}"
+      }
+    end
+    new_record
+  end
+
+  def enrich_location_names(record)
+    better_place_names = []
+    record.fetch('desc_metadata__based_near_t', []).each do |place|
+      short_place = place.split(",").first
+      info = @geonames.lookup_name(short_place)
+      if info.nil?
+        better_place_names << place
+      else
+        name = info['name']
+        country = info['countryName']
+        country = "(" + country + ")" if country != ""
+        geoid = info['geonameId']
+        fcode = info['fcode']
+        better_place_names << "#{name} #{country} [#{geoid}/#{fcode}]"
+      end
+    end
+    { 'dct_spatial_sm' => better_place_names }
+  end
+
+  def first_or_nil(lst)
+    return nil if lst.nil?
+    lst.first
+  end
+end

--- a/lib/geonames.rb
+++ b/lib/geonames.rb
@@ -1,0 +1,195 @@
+
+require 'json'
+require 'rest_client'
+
+#
+# Convert place names to geoname ids and coordinates.
+# While geonames does most of the work, we try to cache data
+# as much as possible to decrease the number of lookups.
+# Our cache stores both items of the form 'place name' => 'geoname id'
+# as well as 'geoname id' => 'hash of location information'.
+# This way we don't rely on the original place name as being a cannonical
+# lookup for the geoname id.
+#
+# usage:
+#
+
+class Geonames
+  class Cache
+    def initialize(cache_filename=nil)
+      @cache_filename = cache_filename
+      @cache = {}
+      if cache_filename
+        begin
+          data = File.read(cache_filename)
+          @cache = JSON.parse(data)
+          STDERR.puts "loaded file #{cache_filename}"
+        rescue Errno::ENOENT
+        end
+      end
+    end
+
+    def save
+      if @cache_filename
+        data = JSON.pretty_generate(@cache)
+        File.write(@cache_filename, data)
+      end
+    end
+
+    def lookup(key)
+      @cache[key]
+    end
+
+    def insert(key, value)
+      @cache[key] = value
+    end
+  end
+
+  class Bbox
+    # we store the west and east in a normalized form satisfying the
+    # invariant west <= east <= west + 360
+    # (unless we are uninitialized, in which case east < west).
+    # We will keep west in the range [-180, 180], and east
+    # in the range [-180, 540]. The values > 180 indicate this bbox
+    # crosses the anti-meridian.
+    #
+    # This comes about since we are really dealing with representatives from
+    # an equivalence class, and we don't know which one to pick.
+    attr_accessor :north, :east, :south, :west
+
+    def initialize
+      @north = -90
+      @east = -180
+      @south = 90
+      @west = 180
+    end
+
+    # bbox is a hash with the keys "north", "south", "east", "west"
+    # if east < west, then we assume the bbox crosses the anti-meridian.
+    def add_bbox(bbox)
+      @north = [@north, bbox["north"]].max
+      @south = [@south, bbox["south"]].min
+      # we don't know whether to add the other_bbox "to the left"
+      # or "to the right". So we do three and choose which ever has a
+      # smaller result (by side length). The three are: as is, moved
+      # right by 360 degrees and moved left by 360 degrees.
+      other_east = bbox["east"]
+      other_west = bbox["west"]
+      if other_east < other_west
+        other_east += 360
+      end
+      @east, @west = optimize_east_west_add(other_east, other_west)
+      normalize
+    end
+
+    # point is a hash with the keys "lng" and "lat"
+    def add_point(point)
+      # again, as with add_bbox(), we do not know whether to add the point
+      # "to the left" or "to the right". So we do it three times:
+      # as is, 360 to the left, 360 to the right, and choose the one
+      # which minimizes the new side length
+      @north = [@north, point["lat"].to_f].max
+      @south = [@south, point["lat"].to_f].min
+      lat = point["lng"].to_f
+      @east, @west = optimize_east_west_add(lat, lat)
+      normalize
+    end
+
+    def valid?
+      @north == -90 && @south == 90 && @east == -180 && @west == 180
+    end
+
+    def is_point?
+      @north == @south && @east == @west
+    end
+
+    private
+
+    def normalize
+      # make sure west is inside [-180,180]
+      if @west > 180
+        @west -= 360
+        @east -= 360
+      elsif @west < -180
+        @west += 360
+        @east += 360
+      end
+      # make sure east doesn't have any extra revolutions
+      while @east >= @west + 360
+        @east -= 360
+      end
+    end
+
+    def optimize_east_west_add(other_east, other_west)
+      new_east_asis = [@east, other_east].max
+      new_west_asis = [@west, other_west].min
+      side_length_asis = new_east_asis - new_west_asis
+
+      new_east_toright = [@east, other_east + 360].max
+      new_west_toright = [@west, other_west + 360].min
+      side_length_toright = new_east_toright - new_west_toright
+
+      new_east_toleft = [@east, other_east - 360].max
+      new_west_toleft = [@west, other_west - 360].min
+      side_length_toleft = new_east_toleft - new_west_toleft
+
+      best = [side_length_asis, side_length_toleft, side_length_toright].min
+
+      if best == side_length_asis
+        return new_east_asis, new_west_asis
+      elsif best == side_length_toright
+        return new_east_toright, new_west_toright
+      else
+        return new_east_toleft, new_west_toleft
+      end
+    end
+  end
+
+  def initialize(cache_filename=nil)
+    @cache = Cache.new(cache_filename)
+  end
+
+  def save
+    @cache.save
+  end
+
+  def lookup_name(place_name)
+    id = @cache.lookup(place_name)
+    if id.nil?
+      id = find_name_in_geonames(place_name)
+      @cache.insert(place_name, id)
+    end
+    return {} if id.nil?
+    result = @cache.lookup(id.to_s)
+    if result.nil?
+      result = load_feature_info(id)
+      @cache.insert(id.to_s, result)
+    end
+    result
+  end
+
+  private
+
+  def find_name_in_geonames(place_name)
+    data = RestClient.get 'http://api.geonames.org/searchJSON',
+      { params: { name: place_name, username: 'banu' }}
+    result = JSON.parse(data)
+    if result['totalResultsCount'] == 0
+      id = nil
+    elsif result['totalResultsCount'] == 1
+      id = result['geonames'].first['geonameId']
+    else
+      # We could try to find the result with the best feature class and type.
+      # Instead we take the first result geonames gives us. Lets see how well that does.
+      STDERR.puts "More than one result for: '#{place_name}'"
+      id = result['geonames'].first['geonameId']
+    end
+    id
+  end
+
+  def load_feature_info(geoname_id)
+    data = RestClient.get 'http://api.geonames.org/getJSON',
+      { params: { geonameId: geoname_id, username: 'banu' }}
+    JSON.parse(data)
+  end
+end

--- a/script/copy-dl-to-solr.rb
+++ b/script/copy-dl-to-solr.rb
@@ -1,0 +1,123 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'rsolr'
+require_relative '../lib/geonames'
+
+# usage:
+# $ copy-dl-to-solr.rb [source solr url] [target solr url]
+# $ copy-dl-to-solr.rb [source solr url] -o
+
+
+# This is getting to be kinda ugly.
+
+if ARGV.length != 2
+  puts "USAGE:"
+  puts "copy-dl-to-solr.rb [source solr url] [target solr url]"
+  puts "copy-dl-to-solr.rb [source solr url] -o"
+  puts "copy-dl-to-solr.rb [source solr url] -i"
+  exit 1
+end
+
+output_stdout = false
+
+if ARGV[1] == "-o"
+  output_stdout = true
+end
+
+STDERR.puts "Source is #{ARGV[0]}"
+source = RSolr.connect url: ARGV[0]
+
+if output_stdout
+  STDERR.puts "Output to stdout"
+  target = nil
+else
+  STDERR.puts "Target is #{ARGV[1]}"
+  target = RSolr.connect url: ARGV[1]
+end
+
+response = source.get 'select', params: {q: '*:vecnet', rows: 1000}
+
+def first_or_nil(lst)
+  return nil if lst.nil?
+  lst.first
+end
+
+geonames = Geonames.new('geoname-cache.json')
+processed_count = 0
+output = []
+
+response['response']['docs'].each do |record|
+  processed_count += 1
+  STDERR.puts "Processing record #{record['id']}"
+  new_record = {
+    uuid:             record['id'],
+    dc_title_s:       first_or_nil(record['desc_metadata__title_t']),
+    dc_description_s: first_or_nil(record['desc_metadata__description_t']),
+    dc_creator_sm:    record['desc_metadata__creator_t'],
+    dc_type_s:        first_or_nil(record['desc_metadata__resource_type_t']),
+    dc_subject_sm:    record['desc_metadata__subject_t'],
+    dct_spatial_sm:   record['desc_metadata__based_near_t'],
+    # these are required ATM for geoblacklight...
+    layer_id_s:       first_or_nil(record['noid_s']),
+    layer_slug_s:     first_or_nil(record['noid_s']),
+    layer_geom_type_s: 'Point',
+    dct_provenance_s: 'Digital Library',
+    # should be dc_accessrights_s, dc_rights is for intellectual rights not access rights
+    dc_rights_s:      first_or_nil(record['read_access_group_t']) || 'Public'
+  }
+  bbox = Geonames::Bbox.new
+  better_place_names = []
+  record.fetch('desc_metadata__based_near_t', []).each do |place|
+    STDERR.puts "Lookup #{place}"
+    place = place.split(",").first
+    STDERR.puts "/ #{place}"
+    info = geonames.lookup_name(place)
+    next unless info
+    if info['bbox']
+      bbox.add_bbox(info['bbox'])
+    else
+      bbox.add_point(info)
+    end
+    better_place_names << "#{info['name']} (#{info['countryName']}) [#{info['geonameId']}/#{info['fcode']}]"
+  end
+  STDERR.puts better_place_names.join("\n") if better_place_names.length > 0
+  new_record['dct_spatial_sm'] = better_place_names
+  if bbox.valid?
+    # nothing was added to this bounding box
+  else
+    west = bbox.west
+    south = bbox.south
+    east = bbox.east
+    # solr does not like coordinates > 180 :(
+    east -= 360 if east > 180
+    north = bbox.north
+    new_record.merge!({
+      "solr_bbox" => "#{west} #{south} #{east} #{north}",
+      "solr_geom" => "ENVELOPE(#{west}, #{east}, #{north}, #{south})",
+      #"solr_ne_pt" => "#{north},#{east}",
+      #"solr_sw_pt" => "#{south},#{west}",
+      "georss_box_s" => "#{south} #{west} #{north} #{east}",
+      #"georss_polygon_s" => "#{north} #{west} #{north} #{east} #{south} #{east} #{south} #{west} #{north} #{west}"
+    })
+  end
+
+  if output_stdout
+    output << new_record
+  end
+  if target
+    target.add new_record
+  end
+end
+
+geonames.save
+
+if output_stdout
+  puts JSON.pretty_generate(output)
+end
+
+if target
+  target.commit
+end
+
+STDERR.puts "Processed #{processed_count} records"

--- a/script/copy-dl-to-solr.rb
+++ b/script/copy-dl-to-solr.rb
@@ -3,6 +3,7 @@
 require 'json'
 require 'rsolr'
 require_relative '../lib/geonames'
+require_relative '../lib/enrich_solr'
 
 # usage:
 # $ copy-dl-to-solr.rb [source solr url] [target solr url]
@@ -43,74 +44,27 @@ def first_or_nil(lst)
   lst.first
 end
 
-geonames = Geonames.new('geoname-cache.json')
+enrich = EnrichSolr.new('geoname-cache.json')
 processed_count = 0
 output = []
 
 response['response']['docs'].each do |record|
   processed_count += 1
   STDERR.puts "Processing record #{record['id']}"
-  new_record = {
-    uuid:             record['id'],
-    dc_title_s:       first_or_nil(record['desc_metadata__title_t']),
-    dc_description_s: first_or_nil(record['desc_metadata__description_t']),
-    dc_creator_sm:    record['desc_metadata__creator_t'],
-    dc_type_s:        first_or_nil(record['desc_metadata__resource_type_t']),
-    dc_subject_sm:    record['desc_metadata__subject_t'],
-    dct_spatial_sm:   record['desc_metadata__based_near_t'],
-    # these are required ATM for geoblacklight...
-    layer_id_s:       first_or_nil(record['noid_s']),
-    layer_slug_s:     first_or_nil(record['noid_s']),
-    layer_geom_type_s: 'Point',
-    dct_provenance_s: 'Digital Library',
-    # should be dc_accessrights_s, dc_rights is for intellectual rights not access rights
-    dc_rights_s:      first_or_nil(record['read_access_group_t']) || 'Public'
-  }
-  bbox = Geonames::Bbox.new
-  better_place_names = []
-  record.fetch('desc_metadata__based_near_t', []).each do |place|
-    STDERR.puts "Lookup #{place}"
-    place = place.split(",").first
-    STDERR.puts "/ #{place}"
-    info = geonames.lookup_name(place)
-    next unless info
-    if info['bbox']
-      bbox.add_bbox(info['bbox'])
-    else
-      bbox.add_point(info)
-    end
-    better_place_names << "#{info['name']} (#{info['countryName']}) [#{info['geonameId']}/#{info['fcode']}]"
+  new_record = enrich.process_one(record)
+  if new_record['dct_spatial_sm'].length > 0
+    STDERR.puts "   " + new_record['dct_spatial_sm'].join("\n   ")
   end
-  STDERR.puts better_place_names.join("\n") if better_place_names.length > 0
-  new_record['dct_spatial_sm'] = better_place_names
-  if bbox.valid?
-    # nothing was added to this bounding box
-  else
-    west = bbox.west
-    south = bbox.south
-    east = bbox.east
-    # solr does not like coordinates > 180 :(
-    east -= 360 if east > 180
-    north = bbox.north
-    new_record.merge!({
-      "solr_bbox" => "#{west} #{south} #{east} #{north}",
-      "solr_geom" => "ENVELOPE(#{west}, #{east}, #{north}, #{south})",
-      #"solr_ne_pt" => "#{north},#{east}",
-      #"solr_sw_pt" => "#{south},#{west}",
-      "georss_box_s" => "#{south} #{west} #{north} #{east}",
-      #"georss_polygon_s" => "#{north} #{west} #{north} #{east} #{south} #{east} #{south} #{west} #{north} #{west}"
-    })
-  end
-
   if output_stdout
     output << new_record
   end
   if target
-    target.add new_record
+    target.add(new_record)
   end
 end
 
-geonames.save
+# save the geonames cache to disk
+enrich.save
 
 if output_stdout
   puts JSON.pretty_generate(output)

--- a/script/upload-to-solr.rb
+++ b/script/upload-to-solr.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'rsolr'
+
+# usage:
+# $ upload-to-solr.rb [filename] [target solr url]
+
+# This is getting to be kinda ugly.
+
+if ARGV.length != 2
+  puts "USAGE:"
+  puts "upload-to-solr.rb [filename] [target solr url]"
+  exit 1
+end
+
+STDERR.puts "Source is file #{ARGV[0]}"
+data = File.read(ARGV[0])
+source = JSON.parse(data)
+
+STDERR.puts "Target is #{ARGV[1]}"
+target = RSolr.connect url: ARGV[1]
+
+processed_count = 0
+source.each do |record|
+  processed_count += 1
+  STDERR.puts "Uploading record #{record['uuid']}"
+  target.add(record)
+end
+
+target.commit
+
+STDERR.puts "Uploaded #{processed_count} records"

--- a/vecnet-solr-sample.json
+++ b/vecnet-solr-sample.json
@@ -1,0 +1,1645 @@
+[
+  {
+    "uuid": "vecnet:sb397829v",
+    "dc_title_s": "Western Kenya VECNet Expert Opinion Table",
+    "dc_description_s": "Expert Opinion Lookup table covering Siaya District in Nyanza Province of Western Kenya provided by John E Gimnig at the request of VECNet.",
+    "dc_creator_sm": [
+      "Gimnig, John E"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]",
+      "Siaya (Kenya) [180320/ADM1]"
+    ],
+    "layer_id_s": "sb397829v",
+    "layer_slug_s": "sb397829v",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.311022202320769",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.311022202320769, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.311022202320769 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:x059c7397",
+    "dc_title_s": "VECNet Malaria Vector Species Parameters for look-up: AFRICA",
+    "dc_description_s": "Lookup table of parameter values for use in VECNet applications that require bionomic input.",
+    "dc_creator_sm": [
+      "VECNet"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "An. arabiensis",
+      "An. funestus",
+      "An. gambiae",
+      "An. melas",
+      "An. merus",
+      "An. moucheti",
+      "An. nili",
+      "Adult Survival Rate",
+      "Larval Survival Rate",
+      "Indoor Feeding Rate",
+      "Human Blood Index",
+      "Peak Biting Time",
+      "Length of Feeding Cycle",
+      "Pre-Feeding Resting Habits",
+      "Flight Range",
+      "Sugar Meal Frequency",
+      "Sugar Sources",
+      "Post-feeding Resting Habits"
+    ],
+    "dct_spatial_sm": [
+      "Africa () [6255146/CONT]"
+    ],
+    "layer_id_s": "x059c7397",
+    "layer_slug_s": "x059c7397",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "-18.1574885778138 -46.9697265625 51.412635803222656 37.53944396972656",
+    "solr_geom": "ENVELOPE(-18.1574885778138, 51.412635803222656, 37.53944396972656, -46.9697265625)",
+    "georss_box_s": "-46.9697265625 -18.1574885778138 37.53944396972656 51.412635803222656"
+  },
+  {
+    "uuid": "vecnet:1544c0741",
+    "dc_title_s": "Vector-Borne Disease Network Digital Library",
+    "dc_description_s": "Vector-Borne Disease Network (VecNet)’s digital library provides part of a common analytical framework to assemble data on malaria transmission and make it accessible for the purposes of computational modeling. This poster reports on VecNet digital library development, key decisions related to metadata standards, design, the central role of metadata and authority files in its architecture, and future directions of this Hydra/Fedora based repository solution.",
+    "dc_creator_sm": [
+      "Barker, Michelle",
+      "Brower, Donald",
+      "Meyers, Natalie",
+      "natalie.meyers@nd.edu"
+    ],
+    "dc_type_s": "Poster",
+    "dc_subject_sm": [
+      "Metadata",
+      "Hydra technology",
+      "Dublin Core",
+      "Darwin Core",
+      "Digital library"
+    ],
+    "dct_spatial_sm": [
+      "South Bend (United States) [4926563/PPLA2]"
+    ],
+    "layer_id_s": "1544c0741",
+    "layer_slug_s": "1544c0741",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "-86.30522725744922 41.64216722382274 -86.1947859425508 41.72459537617726",
+    "solr_geom": "ENVELOPE(-86.30522725744922, -86.1947859425508, 41.72459537617726, 41.64216722382274)",
+    "georss_box_s": "41.64216722382274 -86.30522725744922 41.72459537617726 -86.1947859425508"
+  },
+  {
+    "uuid": "vecnet:7m01bk70j",
+    "dc_title_s": "Solomon Islands Rainfall data from Henderson Archive",
+    "dc_description_s": "Zip Archive of Rainfall from weather station NZ52000 11 -0925 16003 9 ? -9999 19980101 20061029 40 Solomon Islands Henderson",
+    "dc_creator_sm": [
+      "PACRAIN",
+      "NZ52000"
+    ],
+    "dc_type_s": "Dataset: Climate/Weather",
+    "dc_subject_sm": [
+      "rainfall"
+    ],
+    "dct_spatial_sm": [
+      "Solomon Islands (Solomon Islands) [2103350/PCLI]"
+    ],
+    "layer_id_s": "7m01bk70j",
+    "layer_slug_s": "7m01bk70j",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "155.508606 -12.291889 168.843506 -5.0785",
+    "solr_geom": "ENVELOPE(155.508606, 168.843506, -5.0785, -12.291889)",
+    "georss_box_s": "-12.291889 155.508606 -5.0785 168.843506"
+  },
+  {
+    "uuid": "vecnet:sb3978279",
+    "dc_title_s": "Asembo Bay Tagged Bibliographic Citations",
+    "dc_description_s": "A bibliographic citation database in MS Access format where articles related to the study of malaria in the Asembo Bay area of Kenya are tagged by bionomic parameter.",
+    "dc_creator_sm": [
+      "Russell, Tanya"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]",
+      "Asembo Location (Kenya) [200827/ADMD]"
+    ],
+    "layer_id_s": "sb3978279",
+    "layer_slug_s": "sb3978279",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.308611124753952",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.308611124753952, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.308611124753952 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:4j03cz808",
+    "dc_title_s": "Solomon Islands 1999 Population and Housing Census Archive",
+    "dc_description_s": null,
+    "dc_creator_sm": [
+      "Solomon Islands National Statistics Office"
+    ],
+    "dc_type_s": "Dataset: Demography",
+    "dc_subject_sm": [
+      "Censuses",
+      "Statistics"
+    ],
+    "dct_spatial_sm": [
+      "Solomon Islands (Solomon Islands) [2103350/PCLI]"
+    ],
+    "layer_id_s": "4j03cz808",
+    "layer_slug_s": "4j03cz808",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "155.508606 -12.291889 168.843506 -5.0785",
+    "solr_geom": "ENVELOPE(155.508606, 168.843506, -5.0785, -12.291889)",
+    "georss_box_s": "-12.291889 155.508606 -5.0785 168.843506"
+  },
+  {
+    "uuid": "vecnet:1n79h441z",
+    "dc_title_s": "EMOD Data Input Files Bundle (v1.5)",
+    "dc_description_s": "EMOD Data Input Files Bundle (v1.5) Climate and Demography Data Set(s) for running EMOD DTK simulations.",
+    "dc_creator_sm": [
+      "Institute for Disease Modeling"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Muheza District (Tanzania) [152629/ADM2]",
+      "Garki (Nigeria) [8634242/ADM2]",
+      "Namawala River (Tanzania) [151982/STM]",
+      "Namawala River (Tanzania) [151982/STM]"
+    ],
+    "layer_id_s": "1n79h441z",
+    "layer_slug_s": "1n79h441z",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "8.721031074000052 -8.23333 38.923 12.587234598000066",
+    "solr_geom": "ENVELOPE(8.721031074000052, 38.923, 12.587234598000066, -8.23333)",
+    "georss_box_s": "-8.23333 8.721031074000052 12.587234598000066 38.923"
+  },
+  {
+    "uuid": "vecnet:ht24wj427",
+    "dc_title_s": "Tanzania_Region_EA_2002_region.zip",
+    "dc_description_s": "Administrative Unit Boundaries for Tanzania.",
+    "dc_creator_sm": [
+      "GAUL"
+    ],
+    "dc_type_s": "Dataset: GIS",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Tanzania (Tanzania) [149590/PCLI]"
+    ],
+    "layer_id_s": "ht24wj427",
+    "layer_slug_s": "ht24wj427",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "29.327168 -11.745696 40.443222 -0.990736",
+    "solr_geom": "ENVELOPE(29.327168, 40.443222, -0.990736, -11.745696)",
+    "georss_box_s": "-11.745696 29.327168 -0.990736 40.443222"
+  },
+  {
+    "uuid": "vecnet:ws859f64s",
+    "dc_title_s": "Tanzania_Region_EA_2002_region.prj",
+    "dc_description_s": "Administrative Unit Boundaries for Tanzania.",
+    "dc_creator_sm": [
+      "GAUL"
+    ],
+    "dc_type_s": "Dataset: GIS",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Tanzania (Tanzania) [149590/PCLI]"
+    ],
+    "layer_id_s": "ws859f64s",
+    "layer_slug_s": "ws859f64s",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "29.327168 -11.745696 40.443222 -0.990736",
+    "solr_geom": "ENVELOPE(29.327168, 40.443222, -0.990736, -11.745696)",
+    "georss_box_s": "-11.745696 29.327168 -0.990736 40.443222"
+  },
+  {
+    "uuid": "vecnet:ws859f68w",
+    "dc_title_s": "Tanzania_Region_EA_2002_region.dbf",
+    "dc_description_s": "Administrative Unit Boundaries for Tanzania.",
+    "dc_creator_sm": [
+      "GAUL"
+    ],
+    "dc_type_s": "Dataset: GIS",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Tanzania (Tanzania) [149590/PCLI]"
+    ],
+    "layer_id_s": "ws859f68w",
+    "layer_slug_s": "ws859f68w",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "29.327168 -11.745696 40.443222 -0.990736",
+    "solr_geom": "ENVELOPE(29.327168, 40.443222, -0.990736, -11.745696)",
+    "georss_box_s": "-11.745696 29.327168 -0.990736 40.443222"
+  },
+  {
+    "uuid": "vecnet:ws859f66b",
+    "dc_title_s": "Tanzania_Region_EA_2002_region.shp.xml",
+    "dc_description_s": "Administrative Unit Boundaries for Tanzania.",
+    "dc_creator_sm": [
+      "GAUL"
+    ],
+    "dc_type_s": "Dataset: GIS",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Tanzania (Tanzania) [149590/PCLI]"
+    ],
+    "layer_id_s": "ws859f66b",
+    "layer_slug_s": "ws859f66b",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "29.327168 -11.745696 40.443222 -0.990736",
+    "solr_geom": "ENVELOPE(29.327168, 40.443222, -0.990736, -11.745696)",
+    "georss_box_s": "-11.745696 29.327168 -0.990736 40.443222"
+  },
+  {
+    "uuid": "vecnet:7m01bk723",
+    "dc_title_s": "Kisumu_single_node_relative_humidity_daily.bin",
+    "dc_description_s": "Climate files for EMOD DTK 1.5 from GSOD data for Kisumu airport. Gridded world grump2.5arcmin",
+    "dc_creator_sm": [
+      "Philip Eckhoff"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Kisumu International Airport (Kenya) [6297309/AIRP]"
+    ],
+    "layer_id_s": "7m01bk723",
+    "layer_slug_s": "7m01bk723",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "34.72889 -0.08614 34.72889 -0.08614",
+    "solr_geom": "ENVELOPE(34.72889, 34.72889, -0.08614, -0.08614)",
+    "georss_box_s": "-0.08614 34.72889 -0.08614 34.72889"
+  },
+  {
+    "uuid": "vecnet:7m01bk73c",
+    "dc_title_s": "Kisumu_single_node_rainfall_daily.bin",
+    "dc_description_s": "Climate files for EMOD DTK 1.5 from GSOD data for Kisumu airport. Gridded world grump2.5arcmin",
+    "dc_creator_sm": [
+      "Philip Eckhoff"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Kisumu International Airport (Kenya) [6297309/AIRP]"
+    ],
+    "layer_id_s": "7m01bk73c",
+    "layer_slug_s": "7m01bk73c",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "34.72889 -0.08614 34.72889 -0.08614",
+    "solr_geom": "ENVELOPE(34.72889, 34.72889, -0.08614, -0.08614)",
+    "georss_box_s": "-0.08614 34.72889 -0.08614 34.72889"
+  },
+  {
+    "uuid": "vecnet:7m01bk77g",
+    "dc_title_s": "Kisumu_single_node_relative_humidity_daily.bin.json",
+    "dc_description_s": "Climate files for EMOD DTK 1.5 from GSOD data for Kisumu airport. Gridded world grump2.5arcmin",
+    "dc_creator_sm": [
+      "Philip Eckhoff"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Kisumu International Airport (Kenya) [6297309/AIRP]"
+    ],
+    "layer_id_s": "7m01bk77g",
+    "layer_slug_s": "7m01bk77g",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "34.72889 -0.08614 34.72889 -0.08614",
+    "solr_geom": "ENVELOPE(34.72889, 34.72889, -0.08614, -0.08614)",
+    "georss_box_s": "-0.08614 34.72889 -0.08614 34.72889"
+  },
+  {
+    "uuid": "vecnet:7m01bk74n",
+    "dc_title_s": "Kisumu_single_node_air_temperature_daily.bin.json",
+    "dc_description_s": "Climate files for EMOD DTK 1.5 from GSOD data for Kisumu airport. Gridded world grump2.5arcmin",
+    "dc_creator_sm": [
+      "Philip Eckhoff"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Kisumu International Airport (Kenya) [6297309/AIRP]"
+    ],
+    "layer_id_s": "7m01bk74n",
+    "layer_slug_s": "7m01bk74n",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "34.72889 -0.08614 34.72889 -0.08614",
+    "solr_geom": "ENVELOPE(34.72889, 34.72889, -0.08614, -0.08614)",
+    "georss_box_s": "-0.08614 34.72889 -0.08614 34.72889"
+  },
+  {
+    "uuid": "vecnet:7m01bk75x",
+    "dc_title_s": "Kisumu_single_node_land_temperature_daily.bin.json",
+    "dc_description_s": "Climate files for EMOD DTK 1.5 from GSOD data for Kisumu airport. Gridded world grump2.5arcmin",
+    "dc_creator_sm": [
+      "Philip Eckhoff"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Kisumu International Airport (Kenya) [6297309/AIRP]"
+    ],
+    "layer_id_s": "7m01bk75x",
+    "layer_slug_s": "7m01bk75x",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "34.72889 -0.08614 34.72889 -0.08614",
+    "solr_geom": "ENVELOPE(34.72889, 34.72889, -0.08614, -0.08614)",
+    "georss_box_s": "-0.08614 34.72889 -0.08614 34.72889"
+  },
+  {
+    "uuid": "vecnet:7m01bk766",
+    "dc_title_s": "Kisumu_single_node_rainfall_daily.bin.json",
+    "dc_description_s": "Climate files for EMOD DTK 1.5 from GSOD data for Kisumu airport. Gridded world grump2.5arcmin",
+    "dc_creator_sm": [
+      "Philip Eckhoff"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Kisumu International Airport (Kenya) [6297309/AIRP]"
+    ],
+    "layer_id_s": "7m01bk766",
+    "layer_slug_s": "7m01bk766",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "34.72889 -0.08614 34.72889 -0.08614",
+    "solr_geom": "ENVELOPE(34.72889, 34.72889, -0.08614, -0.08614)",
+    "georss_box_s": "-0.08614 34.72889 -0.08614 34.72889"
+  },
+  {
+    "uuid": "vecnet:z316q156s",
+    "dc_title_s": "NZ52000 Solomon Islands HendersonWeather station site description",
+    "dc_description_s": "Weather Station Site Description File for Rainfall from weather station NZ52000 11 -0925 16003 9 ? -9999 19980101 20061029 40 Solomon Islands Henderson .",
+    "dc_creator_sm": [
+      "PACRAIN",
+      "NZ52000"
+    ],
+    "dc_type_s": "Dataset: Climate/Weather",
+    "dc_subject_sm": [
+      "rainfall"
+    ],
+    "dct_spatial_sm": [
+      "Solomon Islands (Solomon Islands) [2103350/PCLI]"
+    ],
+    "layer_id_s": "z316q156s",
+    "layer_slug_s": "z316q156s",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "155.508606 -12.291889 168.843506 -5.0785",
+    "solr_geom": "ENVELOPE(155.508606, 168.843506, -5.0785, -12.291889)",
+    "georss_box_s": "-12.291889 155.508606 -5.0785 168.843506"
+  },
+  {
+    "uuid": "vecnet:ws859f67m",
+    "dc_title_s": "Tanzania_Region_EA_2002_region.shx",
+    "dc_description_s": "Administrative Unit Boundaries for Tanzania.",
+    "dc_creator_sm": [
+      "GAUL"
+    ],
+    "dc_type_s": "Dataset: GIS",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Tanzania (Tanzania) [149590/PCLI]"
+    ],
+    "layer_id_s": "ws859f67m",
+    "layer_slug_s": "ws859f67m",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "29.327168 -11.745696 40.443222 -0.990736",
+    "solr_geom": "ENVELOPE(29.327168, 40.443222, -0.990736, -11.745696)",
+    "georss_box_s": "-11.745696 29.327168 -0.990736 40.443222"
+  },
+  {
+    "uuid": "vecnet:z316q1572",
+    "dc_title_s": "Solomon Islands Rainfall Data from Henderson",
+    "dc_description_s": "Rainfall from weather station NZ52000 11 -0925 16003 9 ? -9999 19980101 20061029 40 Solomon Islands Henderson aka NZ52000.txt",
+    "dc_creator_sm": [
+      "PACRAIN",
+      "NZ52000"
+    ],
+    "dc_type_s": "Dataset: Climate/Weather",
+    "dc_subject_sm": [
+      "rainfall"
+    ],
+    "dct_spatial_sm": [
+      "Solomon Islands (Solomon Islands) [2103350/PCLI]"
+    ],
+    "layer_id_s": "z316q1572",
+    "layer_slug_s": "z316q1572",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "155.508606 -12.291889 168.843506 -5.0785",
+    "solr_geom": "ENVELOPE(155.508606, 168.843506, -5.0785, -12.291889)",
+    "georss_box_s": "-12.291889 155.508606 -5.0785 168.843506"
+  },
+  {
+    "uuid": "vecnet:ws859f652",
+    "dc_title_s": "Tanzania_Region_EA_2002_region.shp",
+    "dc_description_s": "Administrative Unit Boundaries for Tanzania.",
+    "dc_creator_sm": [
+      "GAUL"
+    ],
+    "dc_type_s": "Dataset: GIS",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Tanzania (Tanzania) [149590/PCLI]"
+    ],
+    "layer_id_s": "ws859f652",
+    "layer_slug_s": "ws859f652",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "29.327168 -11.745696 40.443222 -0.990736",
+    "solr_geom": "ENVELOPE(29.327168, 40.443222, -0.990736, -11.745696)",
+    "georss_box_s": "-11.745696 29.327168 -0.990736 40.443222"
+  },
+  {
+    "uuid": "vecnet:0p096721v",
+    "dc_title_s": "KilomberoMalariaProject/WELL.DBF",
+    "dc_description_s": "Wells in Namawala WELL.DBF 79 records last updated 06/06/93. This file contains measurements of the distance from the surface of water in wells in Namawala. Assuming the water table is horizontal, this can be used to obtain relative altitudes for different parts of the village. This file is part of: Individual parasitological, entomological and clinical data from observational studies and field trials from Kilombero Malaria project (Tanzania) (Smith et al. 1993; Smith et al. 1995; Charlwood et al. 1995) .",
+    "dc_creator_sm": [
+      "Smith, T.",
+      "Charlwood, J.D.",
+      "Killeen, G.F.",
+      "Swiss Tropical Public Health Institute",
+      "Ifakara Health Institute"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "malaria"
+    ],
+    "dct_spatial_sm": [
+      "Kilombero District (Tanzania) [157408/ADM2]",
+      "Namawala River (Tanzania) [151982/STM]",
+      "Idete (Tanzania) [159516/PPL]"
+    ],
+    "layer_id_s": "0p096721v",
+    "layer_slug_s": "0p096721v",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "36.41667 -8.25 36.53333 -8.091006351248573",
+    "solr_geom": "ENVELOPE(36.41667, 36.53333, -8.091006351248573, -8.25)",
+    "georss_box_s": "-8.25 36.41667 -8.091006351248573 36.53333"
+  },
+  {
+    "uuid": "vecnet:1n79h443h",
+    "dc_title_s": "Kenya Nyanza, EMOD DTK Input Files 30 arc Seconds Archive",
+    "dc_description_s": "What is in this release archive: DTK Input Files: Demographic and Weather files(tmean,rain, humidity) for 30 arc seconds for Nyanza Province, Kenya. The demographic file is an input data file in JSON format (e.g kenya.nyanza_DemographicsAt30arcsec.json) (or “compiled” JSON file format schema -e.g. kenya.nyanza_DemographicsAt30arcsec.compiled.json) containing information on the demographics of the geographical region to simulate. The types of climate input data are temperature, rainfall, and relative humidity. The DTK uses two types of files for the input of climate by data, one for metadata and one for binary data. A binary file (here for example, EMOD-Kenya_Nyanza_30arcsectmean_1365109863.json.bin) contains the climate data itself. The corresponding JSON file (for example, EMOD-Kenya_Nyanza_30arcsectmean_1365109863_climateheader.json) contains metadata that describes the binary data. One set comprised of these two input files is required for each of the basic climate by data types used in the simulation configuration file. Kenya Nyanza Input file release notes: This distribution contains the pre-release version of the DTK input files for use by Notre Dame in a joint collaboration VECNET program. These files have gone through a preliminary review by research and a smoke test for opperation. They have not been through an official review, test and signoff process.",
+    "dc_creator_sm": [
+      "EMOD Global Health"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "Weather"
+    ],
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]",
+      "Asembo Location (Kenya) [200827/ADMD]"
+    ],
+    "layer_id_s": "1n79h443h",
+    "layer_slug_s": "1n79h443h",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.308611124753952",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.308611124753952, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.308611124753952 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:7m01bk69s",
+    "dc_title_s": "Kisumu_single_node_air_temperature_daily.bin",
+    "dc_description_s": "Climate files for EMOD DTK 1.5 from GSOD data for Kisumu airport. Gridded world grump2.5arcmin",
+    "dc_creator_sm": [
+      "Philip Eckhoff"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Kisumu International Airport (Kenya) [6297309/AIRP]"
+    ],
+    "layer_id_s": "7m01bk69s",
+    "layer_slug_s": "7m01bk69s",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "34.72889 -0.08614 34.72889 -0.08614",
+    "solr_geom": "ENVELOPE(34.72889, 34.72889, -0.08614, -0.08614)",
+    "georss_box_s": "-0.08614 34.72889 -0.08614 34.72889"
+  },
+  {
+    "uuid": "vecnet:7m01bk71t",
+    "dc_title_s": "Kisumu_single_node_land_temperature_daily.bin",
+    "dc_description_s": "Climate files for EMOD DTK 1.5 from GSOD data for Kisumu airport. Gridded world grump2.5arcmin",
+    "dc_creator_sm": [
+      "Philip Eckhoff"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Kisumu International Airport (Kenya) [6297309/AIRP]"
+    ],
+    "layer_id_s": "7m01bk71t",
+    "layer_slug_s": "7m01bk71t",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "34.72889 -0.08614 34.72889 -0.08614",
+    "solr_geom": "ENVELOPE(34.72889, 34.72889, -0.08614, -0.08614)",
+    "georss_box_s": "-0.08614 34.72889 -0.08614 34.72889"
+  },
+  {
+    "uuid": "vecnet:st74cq441",
+    "dc_title_s": "Common Insecticides used in Vector control",
+    "dc_description_s": "A data set of Common Insecticides used in vector control including: products used for Indoor residual sprays, products used for mosquito larvae control, products used for LLIN, products used for space sprays. The data set includes the product's active ingredient, trade name, chemical class, manufacturing company, and country of origin/manufacture.",
+    "dc_creator_sm": [
+      "R. Farlow Consulting, LLC",
+      "VecNet"
+    ],
+    "dc_type_s": "Dataset: Intervention data",
+    "dc_subject_sm": [
+      "Insecticides",
+      "Insecticide-Treated Bednets",
+      "Mosquito Control",
+      "Mosquito Nets",
+      "Carbamates",
+      "Pyrethrins",
+      "Organophosphates",
+      "Benzoylureas",
+      "Permethrin",
+      "Malathion",
+      "Bacillus thuringiensis israelensis",
+      "Diflubenzuron",
+      "Fenthion"
+    ],
+    "dct_spatial_sm": [
+      "India (India) [1269750/PCLI]",
+      "India (India) [1269750/PCLI]",
+      "Denmark (Australia) [7839499/ADM2]",
+      "Japan (Japan) [1861060/PCLI]",
+      "Switzerland (Switzerland) [2658434/PCLI]",
+      "Germany (Germany) [2921044/PCLI]",
+      "China (China) [1814991/PCLI]",
+      "United States (United States) [6252001/PCLI]",
+      "Israel (Israel) [294640/PCLI]",
+      "Thailand (Thailand) [1605651/PCLI]",
+      "Fort-de-France (Martinique) [3570675/PPLC]"
+    ],
+    "layer_id_s": "st74cq441",
+    "layer_slug_s": "st74cq441",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "5.865639 -35.0678427475 -61.033358765662115 71.390656",
+    "solr_geom": "ENVELOPE(5.865639, -61.033358765662115, 71.390656, -35.0678427475)",
+    "georss_box_s": "-35.0678427475 5.865639 71.390656 -61.033358765662115"
+  },
+  {
+    "uuid": "vecnet:hd76s006h",
+    "dc_title_s": "Africa - ITN Susceptibility Map",
+    "dc_description_s": "From a series of maps created for VECNet to show continental scale zoning in Africa, Americas, and Asia related to intervention susceptibility. This map depicts zones where there is an exophagic malaria vector species present and where ITNs are likely to be a suitable or unsuitable intervention.",
+    "dc_creator_sm": [
+      "Malaria Atlas Project",
+      "MAP",
+      "Marianne Sinka"
+    ],
+    "dc_type_s": "Map or Cartographic Material",
+    "dc_subject_sm": [
+      "Insecticide-Treated Bednets",
+      "Intervention Suitability"
+    ],
+    "dct_spatial_sm": [
+      "Africa () [6255146/CONT]"
+    ],
+    "layer_id_s": "hd76s006h",
+    "layer_slug_s": "hd76s006h",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "-18.1574885778138 -46.9697265625 51.412635803222656 37.53944396972656",
+    "solr_geom": "ENVELOPE(-18.1574885778138, 51.412635803222656, 37.53944396972656, -46.9697265625)",
+    "georss_box_s": "-46.9697265625 -18.1574885778138 37.53944396972656 51.412635803222656"
+  },
+  {
+    "uuid": "vecnet:hd76s007s",
+    "dc_title_s": "Americas - IRS Susceptibility Map",
+    "dc_description_s": "From a series of maps created for VECNet to show continental scale zoning in Africa, Americas, and Asia related to intervention susceptibility. This map depicts zones where there is are endophilic malaria vector species present and where IRS is likely to be a suitable or unsuitable intervention.",
+    "dc_creator_sm": [
+      "Malaria Atlas Project",
+      "MAP",
+      "Marianne Sinka"
+    ],
+    "dc_type_s": "Map or Cartographic Material",
+    "dc_subject_sm": [
+      "Indoor Residual Spray",
+      "Intervention Suitability"
+    ],
+    "dct_spatial_sm": [
+      "Las Américas International Airport (Dominican Republic) [3500854/AIRP]"
+    ],
+    "layer_id_s": "hd76s007s",
+    "layer_slug_s": "hd76s007s",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "-69.66892 18.42966 -69.66892 18.42966",
+    "solr_geom": "ENVELOPE(-69.66892, -69.66892, 18.42966, 18.42966)",
+    "georss_box_s": "18.42966 -69.66892 18.42966 -69.66892"
+  },
+  {
+    "uuid": "vecnet:4j03cz85n",
+    "dc_title_s": "Kenya Population and Housing Census 2009: Constituency Population by Sex, Number of Households, Area and Density",
+    "dc_description_s": "Kenya Population and Housing Census 2009: Constituency Population by Sex, Number of Households, Area and Density",
+    "dc_creator_sm": [
+      "Kenya National Bureau of Statistics"
+    ],
+    "dc_type_s": "Dataset: Demography",
+    "dc_subject_sm": [
+      "Censuses"
+    ],
+    "dct_spatial_sm": [
+      "Kenya (Kenya) [192950/PCLI]"
+    ],
+    "layer_id_s": "4j03cz85n",
+    "layer_slug_s": "4j03cz85n",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.908859 -4.678047 41.899078 5.019938",
+    "solr_geom": "ENVELOPE(33.908859, 41.899078, 5.019938, -4.678047)",
+    "georss_box_s": "-4.678047 33.908859 5.019938 41.899078"
+  },
+  {
+    "uuid": "vecnet:hd76s0057",
+    "dc_title_s": "Africa - IRS Susceptibility Map",
+    "dc_description_s": "From a series of maps created for VECNet to show continental scale zoning in Africa, Americas, and Asia related to intervention susceptibility. This map depicts zones where there is are endophilic malaria vector species present and where IRS is likely to be a suitable or unsuitable intervention.",
+    "dc_creator_sm": [
+      "Malaria Atlas Project",
+      "MAP",
+      "Marianne Sinka"
+    ],
+    "dc_type_s": "Map or Cartographic Material",
+    "dc_subject_sm": [
+      "Indoor Residual Spray",
+      "Intervention Suitability"
+    ],
+    "dct_spatial_sm": [
+      "Africa () [6255146/CONT]"
+    ],
+    "layer_id_s": "hd76s0057",
+    "layer_slug_s": "hd76s0057",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "-18.1574885778138 -46.9697265625 51.412635803222656 37.53944396972656",
+    "solr_geom": "ENVELOPE(-18.1574885778138, 51.412635803222656, 37.53944396972656, -46.9697265625)",
+    "georss_box_s": "-46.9697265625 -18.1574885778138 37.53944396972656 51.412635803222656"
+  },
+  {
+    "uuid": "vecnet:tx31qh70j",
+    "dc_title_s": "Henderson Airport Rainfall Record",
+    "dc_description_s": "Monthly rainfall data from Henderson Airport on Guadalcanal, Solomon Islands",
+    "dc_creator_sm": [
+      "Hugo Bugoro",
+      "Jeffery Hii",
+      "Charles Butafa",
+      "Charlie Iro'ofa",
+      "Allen Apairamo",
+      "Robert Cooper",
+      "Cheng-Chen Chen",
+      "Tanya Russell"
+    ],
+    "dc_type_s": "Dataset: Climate/Weather",
+    "dc_subject_sm": [
+      "Weather"
+    ],
+    "dct_spatial_sm": [
+      "Honiara International Airport (Solomon Islands) [6295679/AIRP]"
+    ],
+    "layer_id_s": "tx31qh70j",
+    "layer_slug_s": "tx31qh70j",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "160.05479 -9.428 160.05479 -9.428",
+    "solr_geom": "ENVELOPE(160.05479, 160.05479, -9.428, -9.428)",
+    "georss_box_s": "-9.428 160.05479 -9.428 160.05479"
+  },
+  {
+    "uuid": "vecnet:7p88cg57g",
+    "dc_title_s": "Malaria Operational Plan: Kenya, 2013",
+    "dc_description_s": "President's Malaria Initiative Malaria Operational Plans (MOPs) present a detailed one-year country-wide implementation plan. Each plan briefly reviews the current status of a country's malaria control and prevention policies and interventions, identifies challenges and unmet needs if the goals of the PMI are to be achieved, and provides a description of planned activities under the PMI. These Malaria Operational Plans have been endorsed by the U.S. Global Malaria Coordinator and reflect collaborative discussions with the national malaria control programs and partners in country.",
+    "dc_creator_sm": [
+      "United States. Agency for International Development",
+      "President’s Malaria Initiative (U.S.)",
+      "USAID",
+      "Centers for Disease Control and Prevention"
+    ],
+    "dc_type_s": "Report",
+    "dc_subject_sm": [
+      "Malaria",
+      "Kenya",
+      "Annual Reports"
+    ],
+    "dct_spatial_sm": [
+      "Kenya (Kenya) [192950/PCLI]"
+    ],
+    "layer_id_s": "7p88cg57g",
+    "layer_slug_s": "7p88cg57g",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.908859 -4.678047 41.899078 5.019938",
+    "solr_geom": "ENVELOPE(33.908859, 41.899078, 5.019938, -4.678047)",
+    "georss_box_s": "-4.678047 33.908859 5.019938 41.899078"
+  },
+  {
+    "uuid": "vecnet:7p88cg612",
+    "dc_title_s": "Malaria Operational Plan: Revised Funding Table - Kenya FY 2012",
+    "dc_description_s": "Malaria Operational Plan: Revised Funding Table - Kenya FY 2012 updates a President's Malaria Initiative Malaria Operational Plan (MOP). MOPs present a detailed one-year country-wide implementation plan. Each plan briefly reviews the current status of a country's malaria control and prevention policies and interventions, identifies challenges and unmet needs if the goals of the PMI are to be achieved, and provides a description of planned activities under the PMI. These Malaria Operational Plans have been endorsed by the U.S. Global Malaria Coordinator and reflect collaborative discussions with the national malaria control programs and partners in country.",
+    "dc_creator_sm": [
+      "United States. Agency for International Development",
+      "USAID",
+      "Centers for Disease Control and Prevention"
+    ],
+    "dc_type_s": "Report",
+    "dc_subject_sm": [
+      "Malaria",
+      "Kenya",
+      "Annual Reports"
+    ],
+    "dct_spatial_sm": [
+      "Kenya (Kenya) [192950/PCLI]"
+    ],
+    "layer_id_s": "7p88cg612",
+    "layer_slug_s": "7p88cg612",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.908859 -4.678047 41.899078 5.019938",
+    "solr_geom": "ENVELOPE(33.908859, 41.899078, 5.019938, -4.678047)",
+    "georss_box_s": "-4.678047 33.908859 5.019938 41.899078"
+  },
+  {
+    "uuid": "vecnet:7p88cg566",
+    "dc_title_s": "Malaria Operational Plan: Kenya, 2012",
+    "dc_description_s": "President's Malaria Initiative Malaria Operational Plans (MOPs) present a detailed one-year country-wide implementation plan. Each plan briefly reviews the current status of a country's malaria control and prevention policies and interventions, identifies challenges and unmet needs if the goals of the PMI are to be achieved, and provides a description of planned activities under the PMI. These Malaria Operational Plans have been endorsed by the U.S. Global Malaria Coordinator and reflect collaborative discussions with the national malaria control programs and partners in country.",
+    "dc_creator_sm": [
+      "United States. Agency for International Development",
+      "President’s Malaria Initiative (U.S.)",
+      "USAID",
+      "Centers for Disease Control and Prevention"
+    ],
+    "dc_type_s": "Report",
+    "dc_subject_sm": [
+      "Malaria",
+      "Kenya",
+      "Annual Reports"
+    ],
+    "dct_spatial_sm": [
+      "Kenya (Kenya) [192950/PCLI]"
+    ],
+    "layer_id_s": "7p88cg566",
+    "layer_slug_s": "7p88cg566",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.908859 -4.678047 41.899078 5.019938",
+    "solr_geom": "ENVELOPE(33.908859, 41.899078, 5.019938, -4.678047)",
+    "georss_box_s": "-4.678047 33.908859 5.019938 41.899078"
+  },
+  {
+    "uuid": "vecnet:7p88cg62b",
+    "dc_title_s": "Malaria Operational Plan: Revised Funding Table - Kenya FY 2011",
+    "dc_description_s": "Malaria Operational Plan: Revised Funding Table - Kenya FY 2011. Updates a President's Malaria Initiative Malaria Operational Plan (MOP). MOPs present a detailed one-year country-wide implementation plan. Each plan briefly reviews the current status of a country's malaria control and prevention policies and interventions, identifies challenges and unmet needs if the goals of the PMI are to be achieved, and provides a description of planned activities under the PMI. These Malaria Operational Plans have been endorsed by the U.S. Global Malaria Coordinator and reflect collaborative discussions with the national malaria control programs and partners in country.",
+    "dc_creator_sm": [
+      "United States. Agency for International Development",
+      "USAID",
+      "Centers for Disease Control and Prevention"
+    ],
+    "dc_type_s": "Report",
+    "dc_subject_sm": [
+      "Malaria",
+      "Kenya",
+      "Annual Reports"
+    ],
+    "dct_spatial_sm": [
+      "Kenya (Kenya) [192950/PCLI]"
+    ],
+    "layer_id_s": "7p88cg62b",
+    "layer_slug_s": "7p88cg62b",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.908859 -4.678047 41.899078 5.019938",
+    "solr_geom": "ENVELOPE(33.908859, 41.899078, 5.019938, -4.678047)",
+    "georss_box_s": "-4.678047 33.908859 5.019938 41.899078"
+  },
+  {
+    "uuid": "vecnet:7p88cg55x",
+    "dc_title_s": "Malaria Operational Plan: Kenya, 2011",
+    "dc_description_s": "A President's Malaria Initiative Malaria Operational Plan (MOP). MOPs present a detailed one-year country-wide implementation plan. Each plan briefly reviews the current status of a country's malaria control and prevention policies and interventions, identifies challenges and unmet needs if the goals of the PMI are to be achieved, and provides a description of planned activities under the PMI. These Malaria Operational Plans have been endorsed by the U.S. Global Malaria Coordinator and reflect collaborative discussions with the national malaria control programs and partners in country.",
+    "dc_creator_sm": [
+      "United States. Agency for International Development",
+      "President’s Malaria Initiative (U.S.)",
+      "USAID",
+      "Centers for Disease Control and Prevention"
+    ],
+    "dc_type_s": "Report",
+    "dc_subject_sm": [
+      "Malaria",
+      "Kenya",
+      "Annual Reports"
+    ],
+    "dct_spatial_sm": [
+      "Kenya (Kenya) [192950/PCLI]"
+    ],
+    "layer_id_s": "7p88cg55x",
+    "layer_slug_s": "7p88cg55x",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.908859 -4.678047 41.899078 5.019938",
+    "solr_geom": "ENVELOPE(33.908859, 41.899078, 5.019938, -4.678047)",
+    "georss_box_s": "-4.678047 33.908859 5.019938 41.899078"
+  },
+  {
+    "uuid": "vecnet:7p88cg60s",
+    "dc_title_s": "Malaria Operational Plan: Revised Funding Table - Kenya FY 2010",
+    "dc_description_s": "Malaria Operational Plan: Revised Funding Table - Kenya FY 2010 updates a President's Malaria Initiative Malaria Operational Plan (MOP). MOPs present a detailed one-year country-wide implementation plan. Each plan briefly reviews the current status of a country's malaria control and prevention policies and interventions, identifies challenges and unmet needs if the goals of the PMI are to be achieved, and provides a description of planned activities under the PMI. These Malaria Operational Plans have been endorsed by the U.S. Global Malaria Coordinator and reflect collaborative discussions with the national malaria control programs and partners in country.",
+    "dc_creator_sm": [
+      "United States. Agency for International Development",
+      "USAID",
+      "Centers for Disease Control and Prevention"
+    ],
+    "dc_type_s": "Report",
+    "dc_subject_sm": [
+      "Malaria",
+      "Kenya",
+      "Annual Reports"
+    ],
+    "dct_spatial_sm": [
+      "Kenya (Kenya) [192950/PCLI]"
+    ],
+    "layer_id_s": "7p88cg60s",
+    "layer_slug_s": "7p88cg60s",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.908859 -4.678047 41.899078 5.019938",
+    "solr_geom": "ENVELOPE(33.908859, 41.899078, 5.019938, -4.678047)",
+    "georss_box_s": "-4.678047 33.908859 5.019938 41.899078"
+  },
+  {
+    "uuid": "vecnet:7p88cg591",
+    "dc_title_s": "Malaria Operational Plan: Revised Funding Table - Kenya FY 2009",
+    "dc_description_s": "Malaria Operational Plan: Revised Funding Table - Kenya FY 2009 updates a President's Malaria Initiative Malaria Operational Plan (MOP). MOPs present a detailed one-year country-wide implementation plan. Each plan briefly reviews the current status of a country's malaria control and prevention policies and interventions, identifies challenges and unmet needs if the goals of the PMI are to be achieved, and provides a description of planned activities under the PMI. These Malaria Operational Plans have been endorsed by the U.S. Global Malaria Coordinator and reflect collaborative discussions with the national malaria control programs and partners in country.",
+    "dc_creator_sm": [
+      "United States. Agency for International Development",
+      "USAID",
+      "Centers for Disease Control and Prevention"
+    ],
+    "dc_type_s": "Report",
+    "dc_subject_sm": [
+      "Malaria",
+      "Kenya",
+      "Annual Reports"
+    ],
+    "dct_spatial_sm": [
+      "Kenya (Kenya) [192950/PCLI]"
+    ],
+    "layer_id_s": "7p88cg591",
+    "layer_slug_s": "7p88cg591",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.908859 -4.678047 41.899078 5.019938",
+    "solr_geom": "ENVELOPE(33.908859, 41.899078, 5.019938, -4.678047)",
+    "georss_box_s": "-4.678047 33.908859 5.019938 41.899078"
+  },
+  {
+    "uuid": "vecnet:7p88cg54n",
+    "dc_title_s": "Malaria Operational Plan: Kenya, 2010",
+    "dc_description_s": "A President's Malaria Initiative Malaria Operational Plan (MOP). MOPs present a detailed one-year country-wide implementation plan. Each plan briefly reviews the current status of a country's malaria control and prevention policies and interventions, identifies challenges and unmet needs if the goals of the PMI are to be achieved, and provides a description of planned activities under the PMI. These Malaria Operational Plans have been endorsed by the U.S. Global Malaria Coordinator and reflect collaborative discussions with the national malaria control programs and partners in country.",
+    "dc_creator_sm": [
+      "United States. Agency for International Development",
+      "President’s Malaria Initiative (U.S.)",
+      "USAID",
+      "Centers for Disease Control and Prevention"
+    ],
+    "dc_type_s": "Report",
+    "dc_subject_sm": [
+      "Malaria",
+      "Kenya",
+      "Annual Reports"
+    ],
+    "dct_spatial_sm": [
+      "Kenya (Kenya) [192950/PCLI]"
+    ],
+    "layer_id_s": "7p88cg54n",
+    "layer_slug_s": "7p88cg54n",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.908859 -4.678047 41.899078 5.019938",
+    "solr_geom": "ENVELOPE(33.908859, 41.899078, 5.019938, -4.678047)",
+    "georss_box_s": "-4.678047 33.908859 5.019938 41.899078"
+  },
+  {
+    "uuid": "vecnet:7p88cg53c",
+    "dc_title_s": "Malaria Operational Plan: Kenya, 2009",
+    "dc_description_s": "A President's Malaria Initiative Malaria Operational Plan (MOP). MOPs present a detailed one-year country-wide implementation plan. Each plan briefly reviews the current status of a country's malaria control and prevention policies and interventions, identifies challenges and unmet needs if the goals of the PMI are to be achieved, and provides a description of planned activities under the PMI. These Malaria Operational Plans have been endorsed by the U.S. Global Malaria Coordinator and reflect collaborative discussions with the national malaria control programs and partners in country.",
+    "dc_creator_sm": [
+      "United States. Agency for International Development",
+      "President’s Malaria Initiative (U.S.)",
+      "USAID",
+      "Centers for Disease Control and Prevention"
+    ],
+    "dc_type_s": "Report",
+    "dc_subject_sm": [
+      "Malaria",
+      "Kenya",
+      "Annual Reports"
+    ],
+    "dct_spatial_sm": [
+      "Kenya (Kenya) [192950/PCLI]"
+    ],
+    "layer_id_s": "7p88cg53c",
+    "layer_slug_s": "7p88cg53c",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.908859 -4.678047 41.899078 5.019938",
+    "solr_geom": "ENVELOPE(33.908859, 41.899078, 5.019938, -4.678047)",
+    "georss_box_s": "-4.678047 33.908859 5.019938 41.899078"
+  },
+  {
+    "uuid": "vecnet:7p88cg58r",
+    "dc_title_s": "Malaria Operational Plan: Revised Funding Table - Kenya FY 2008",
+    "dc_description_s": "Malaria Operational Plan: Revised Funding Table - Kenya FY 2008 updates a President's Malaria Initiative Malaria Operational Plan (MOP). MOPs present a detailed one-year country-wide implementation plan. Each plan briefly reviews the current status of a country's malaria control and prevention policies and interventions, identifies challenges and unmet needs if the goals of the PMI are to be achieved, and provides a description of planned activities under the PMI. These Malaria Operational Plans have been endorsed by the U.S. Global Malaria Coordinator and reflect collaborative discussions with the national malaria control programs and partners in country.",
+    "dc_creator_sm": [
+      "United States. Agency for International Development",
+      "USAID",
+      "Centers for Disease Control and Prevention"
+    ],
+    "dc_type_s": "Report",
+    "dc_subject_sm": [
+      "Malaria",
+      "Kenya",
+      "Annual Reports"
+    ],
+    "dct_spatial_sm": [
+      "Kenya (Kenya) [192950/PCLI]"
+    ],
+    "layer_id_s": "7p88cg58r",
+    "layer_slug_s": "7p88cg58r",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.908859 -4.678047 41.899078 5.019938",
+    "solr_geom": "ENVELOPE(33.908859, 41.899078, 5.019938, -4.678047)",
+    "georss_box_s": "-4.678047 33.908859 5.019938 41.899078"
+  },
+  {
+    "uuid": "vecnet:7p88cg523",
+    "dc_title_s": "Malaria Operational Plan: Kenya, 2008",
+    "dc_description_s": "A President's Malaria Initiative Malaria Operational Plans (MOP). MOPs present a detailed one-year country-wide implementation plan. Each plan briefly reviews the current status of a country's malaria control and prevention policies and interventions, identifies challenges and unmet needs if the goals of the PMI are to be achieved, and provides a description of planned activities under the PMI. These Malaria Operational Plans have been endorsed by the U.S. Global Malaria Coordinator and reflect collaborative discussions with the national malaria control programs and partners in country.",
+    "dc_creator_sm": [
+      "United States. Agency for International Development",
+      "President’s Malaria Initiative (U.S.)",
+      "USAID",
+      "Centers for Disease Control and Prevention"
+    ],
+    "dc_type_s": "Report",
+    "dc_subject_sm": [
+      "Malaria",
+      "Kenya",
+      "Annual Reports"
+    ],
+    "dct_spatial_sm": [
+      "Kenya (Kenya) [192950/PCLI]"
+    ],
+    "layer_id_s": "7p88cg523",
+    "layer_slug_s": "7p88cg523",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.908859 -4.678047 41.899078 5.019938",
+    "solr_geom": "ENVELOPE(33.908859, 41.899078, 5.019938, -4.678047)",
+    "georss_box_s": "-4.678047 33.908859 5.019938 41.899078"
+  },
+  {
+    "uuid": "vecnet:1n79h4427",
+    "dc_title_s": "Kenya Nyanza EMOD DTK 2_5arcmin Data Set Archive",
+    "dc_description_s": "DTK Input Files: Demographic and Weather files(tmean,rain, humidity) for 2.5 arc min for Nyanza Province, Kenya. The demographic file is an input data file in JSON format (e.g kenya.nyanza_DemographicsAt2_5arcMinutes.json) (or “compiled” JSON file format schema -e.g. kenya.nyanza_DemographicsAt2_5arcMinutes.compiled.json) containing information on the demographics of the geographical region to simulate. The types of climate input data are temperature, rainfall, and relative humidity. The DTK uses two types of files for the input of climate by data, one for metadata and one for binary data. A binary file (here for example, EMOD-Kenya_Nyanza_2.5arcmintmean_1365118775.json.bin) contains the climate data itself. The corresponding JSON file (for example, EMOD-Kenya_Nyanza_2.5arcmintmean_1365118775_climateheader.json) contains metadata that describes the binary data. One set comprised of these two input files is required for each of the basic climate by data types used in the simulation configuration file. Kenya Nyanza Input file release notes: This distribution contains the pre-release version of the DTK input files for use by Notre Dame in a joint collaboration VECNET program. These files have gone through a preliminary review by research and a smoke test for opperation. They have not been through an official review, test and signoff process. Abt this data: Tool: \"MergeNodes.exe\", IdReference: \"Gridded world grump2.5arcmin\", NodeCount: 856, DatavalueCount: 3650, UpdateResolution: CLIMATE_UPDATE_DAY, OriginalDataYears\": \"2002-2011\", \"StartDayOfYear\": \"January 1\", DataProvenance: \"Generated by internally-developed [EMOD] algorithm applied to GSOD weather-station data\"",
+    "dc_creator_sm": [
+      "EMOD Global Health"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "Climate",
+      "Demography"
+    ],
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]",
+      "Asembo Location (Kenya) [200827/ADMD]"
+    ],
+    "layer_id_s": "1n79h4427",
+    "layer_slug_s": "1n79h4427",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.308611124753952",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.308611124753952, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.308611124753952 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:70795769f",
+    "dc_title_s": "humid/EMOD-Kenya_Nyanza_2.5arcminhumid_1365118879.json.bin",
+    "dc_description_s": "Data Set(s) for Epidemiological Modeling (EMOD) : Abt this data: Tool: \"MergeNodes.exe\", IdReference: \"Gridded world grump2.5arcmin\", NodeCount: 856, DatavalueCount: 3650, UpdateResolution: CLIMATE_UPDATE_DAY, OriginalDataYears\": \"2002-2011\", \"StartDayOfYear\": \"January 1\", DataProvenance: \"Generated by internally-developed [EMOD] algorithm applied to GSOD weather-station data\"",
+    "dc_creator_sm": [
+      "EMOD Global Health"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "Climate",
+      "Demography"
+    ],
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]"
+    ],
+    "layer_id_s": "70795769f",
+    "layer_slug_s": "70795769f",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.308611124753952",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.308611124753952, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.308611124753952 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:70795772r",
+    "dc_title_s": "rain/EMOD-Kenya_Nyanza_2.5arcminrain_1365118975.json.bin",
+    "dc_description_s": "Data Set(s) for Epidemiological Modeling (EMOD) : Abt this data: Tool: \"MergeNodes.exe\", IdReference: \"Gridded world grump2.5arcmin\", NodeCount: 856, DatavalueCount: 3650, UpdateResolution: CLIMATE_UPDATE_DAY, OriginalDataYears\": \"2002-2011\", \"StartDayOfYear\": \"January 1\", DataProvenance: \"Generated by internally-developed [EMOD] algorithm applied to GSOD weather-station data\"",
+    "dc_creator_sm": [
+      "EMOD Global Health"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "Climate",
+      "Demography"
+    ],
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]"
+    ],
+    "layer_id_s": "70795772r",
+    "layer_slug_s": "70795772r",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.308611124753952",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.308611124753952, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.308611124753952 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:70795775k",
+    "dc_title_s": "tmean/EMOD-Kenya_Nyanza_2.5arcmintmean_1365118775.json.bin",
+    "dc_description_s": "Data Set(s) for Epidemiological Modeling (EMOD) : Abt this data: Tool: \"MergeNodes.exe\", IdReference: \"Gridded world grump2.5arcmin\", NodeCount: 856, DatavalueCount: 3650, UpdateResolution: CLIMATE_UPDATE_DAY, OriginalDataYears\": \"2002-2011\", \"StartDayOfYear\": \"January 1\", DataProvenance: \"Generated by internally-developed [EMOD] algorithm applied to GSOD weather-station data\"",
+    "dc_creator_sm": [
+      "EMOD Global Health"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "Climate",
+      "Demography"
+    ],
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]"
+    ],
+    "layer_id_s": "70795775k",
+    "layer_slug_s": "70795775k",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.308611124753952",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.308611124753952, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.308611124753952 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:707957749",
+    "dc_title_s": "rain/rain_JSON.md5",
+    "dc_description_s": "Data Set(s) for Epidemiological Modeling (EMOD) : Abt this data: Tool: \"MergeNodes.exe\", IdReference: \"Gridded world grump2.5arcmin\", NodeCount: 856, DatavalueCount: 3650, UpdateResolution: CLIMATE_UPDATE_DAY, OriginalDataYears\": \"2002-2011\", \"StartDayOfYear\": \"January 1\", DataProvenance: \"Generated by internally-developed [EMOD] algorithm applied to GSOD weather-station data\"",
+    "dc_creator_sm": [
+      "EMOD Global Health"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "Climate",
+      "Demography"
+    ],
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]"
+    ],
+    "layer_id_s": "707957749",
+    "layer_slug_s": "707957749",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.308611124753952",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.308611124753952, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.308611124753952 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:707957774",
+    "dc_title_s": "tmean/tmean_JSON.md5",
+    "dc_description_s": "Data Set(s) for Epidemiological Modeling (EMOD) : Abt this data: Tool: \"MergeNodes.exe\", IdReference: \"Gridded world grump2.5arcmin\", NodeCount: 856, DatavalueCount: 3650, UpdateResolution: CLIMATE_UPDATE_DAY, OriginalDataYears\": \"2002-2011\", \"StartDayOfYear\": \"January 1\", DataProvenance: \"Generated by internally-developed [EMOD] algorithm applied to GSOD weather-station data\"",
+    "dc_creator_sm": [
+      "EMOD Global Health"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "Climate",
+      "Demography"
+    ],
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]"
+    ],
+    "layer_id_s": "707957774",
+    "layer_slug_s": "707957774",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.308611124753952",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.308611124753952, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.308611124753952 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:70795771g",
+    "dc_title_s": "humid/humid_JSON.md5",
+    "dc_description_s": "Data Set(s) for Epidemiological Modeling (EMOD) : Abt this data: Tool: \"MergeNodes.exe\", IdReference: \"Gridded world grump2.5arcmin\", NodeCount: 856, DatavalueCount: 3650, UpdateResolution: CLIMATE_UPDATE_DAY, OriginalDataYears\": \"2002-2011\", \"StartDayOfYear\": \"January 1\", DataProvenance: \"Generated by internally-developed [EMOD] algorithm applied to GSOD weather-station data\"",
+    "dc_creator_sm": [
+      "EMOD Global Health"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "Climate",
+      "Demography"
+    ],
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]"
+    ],
+    "layer_id_s": "70795771g",
+    "layer_slug_s": "70795771g",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.308611124753952",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.308611124753952, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.308611124753952 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:707957731",
+    "dc_title_s": "rain/EMOD-Kenya_Nyanza_2.5arcminrain_1365118975_climateheader.json",
+    "dc_description_s": "Data Set(s) for Epidemiological Modeling (EMOD) : Abt this data: Tool: \"MergeNodes.exe\", IdReference: \"Gridded world grump2.5arcmin\", NodeCount: 856, DatavalueCount: 3650, UpdateResolution: CLIMATE_UPDATE_DAY, OriginalDataYears\": \"2002-2011\", \"StartDayOfYear\": \"January 1\", DataProvenance: \"Generated by internally-developed [EMOD] algorithm applied to GSOD weather-station data\"",
+    "dc_creator_sm": [
+      "EMOD Global Health"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "Climate",
+      "Demography"
+    ],
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]"
+    ],
+    "layer_id_s": "707957731",
+    "layer_slug_s": "707957731",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.308611124753952",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.308611124753952, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.308611124753952 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:70795780f",
+    "dc_title_s": "Kenya_Nyanza_2_5_JSON.md5",
+    "dc_description_s": "Data Set(s) for Epidemiological Modeling (EMOD) : Abt this data: Tool: \"MergeNodes.exe\", IdReference: \"Gridded world grump2.5arcmin\", NodeCount: 856, DatavalueCount: 3650, UpdateResolution: CLIMATE_UPDATE_DAY, OriginalDataYears\": \"2002-2011\", \"StartDayOfYear\": \"January 1\", DataProvenance: \"Generated by internally-developed [EMOD] algorithm applied to GSOD weather-station data\"",
+    "dc_creator_sm": [
+      "EMOD Global Health"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "Climate",
+      "Demography"
+    ],
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]"
+    ],
+    "layer_id_s": "70795780f",
+    "layer_slug_s": "70795780f",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.308611124753952",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.308611124753952, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.308611124753952 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:70795778d",
+    "dc_title_s": "kenya.nyanza_DemographicsAt2_5arcMinutes.compiled.json",
+    "dc_description_s": "Data Set(s) for Epidemiological Modeling (EMOD) : Abt this data: Tool: \"MergeNodes.exe\", IdReference: \"Gridded world grump2.5arcmin\", NodeCount: 856, DatavalueCount: 3650, UpdateResolution: CLIMATE_UPDATE_DAY, OriginalDataYears\": \"2002-2011\", \"StartDayOfYear\": \"January 1\", DataProvenance: \"Generated by internally-developed [EMOD] algorithm applied to GSOD weather-station data\"",
+    "dc_creator_sm": [
+      "EMOD Global Health"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "Climate",
+      "Demography"
+    ],
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]"
+    ],
+    "layer_id_s": "70795778d",
+    "layer_slug_s": "70795778d",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.308611124753952",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.308611124753952, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.308611124753952 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:70795779p",
+    "dc_title_s": "kenya.nyanza_DemographicsAt2_5arcMinutes.json",
+    "dc_description_s": "Data Set(s) for Epidemiological Modeling (EMOD) : Abt this data: Tool: \"MergeNodes.exe\", IdReference: \"Gridded world grump2.5arcmin\", NodeCount: 856, DatavalueCount: 3650, UpdateResolution: CLIMATE_UPDATE_DAY, OriginalDataYears\": \"2002-2011\", \"StartDayOfYear\": \"January 1\", DataProvenance: \"Generated by internally-developed [EMOD] algorithm applied to GSOD weather-station data\"",
+    "dc_creator_sm": [
+      "EMOD Global Health"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "Climate",
+      "Demography"
+    ],
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]"
+    ],
+    "layer_id_s": "70795779p",
+    "layer_slug_s": "70795779p",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.308611124753952",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.308611124753952, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.308611124753952 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:707957706",
+    "dc_title_s": "humid/EMOD-Kenya_Nyanza_2.5arcminhumid_1365118879_climateheader.json",
+    "dc_description_s": "Data Set(s) for Epidemiological Modeling (EMOD) : Abt this data: Tool: \"MergeNodes.exe\", IdReference: \"Gridded world grump2.5arcmin\", NodeCount: 856, DatavalueCount: 3650, UpdateResolution: CLIMATE_UPDATE_DAY, OriginalDataYears\": \"2002-2011\", \"StartDayOfYear\": \"January 1\", DataProvenance: \"Generated by internally-developed [EMOD] algorithm applied to GSOD weather-station data\"",
+    "dc_creator_sm": [
+      "EMOD Global Health"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "Climate",
+      "Demography"
+    ],
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]"
+    ],
+    "layer_id_s": "707957706",
+    "layer_slug_s": "707957706",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.308611124753952",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.308611124753952, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.308611124753952 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:70795776v",
+    "dc_title_s": "tmean/EMOD-Kenya_Nyanza_2.5arcmintmean_1365118775_climateheader.json",
+    "dc_description_s": "Data Set(s) for Epidemiological Modeling (EMOD) : Abt this data: Tool: \"MergeNodes.exe\", IdReference: \"Gridded world grump2.5arcmin\", NodeCount: 856, DatavalueCount: 3650, UpdateResolution: CLIMATE_UPDATE_DAY, OriginalDataYears\": \"2002-2011\", \"StartDayOfYear\": \"January 1\", DataProvenance: \"Generated by internally-developed [EMOD] algorithm applied to GSOD weather-station data\"",
+    "dc_creator_sm": [
+      "EMOD Global Health"
+    ],
+    "dc_type_s": "Dataset",
+    "dc_subject_sm": [
+      "Climate",
+      "Demography"
+    ],
+    "dct_spatial_sm": [
+      "Nyanza Province (Kenya) [182763/ADM1H]"
+    ],
+    "layer_id_s": "70795776v",
+    "layer_slug_s": "70795776v",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.918609619140625 -1.3988890647888184 35.326385498046875 0.308611124753952",
+    "solr_geom": "ENVELOPE(33.918609619140625, 35.326385498046875, 0.308611124753952, -1.3988890647888184)",
+    "georss_box_s": "-1.3988890647888184 33.918609619140625 0.308611124753952 35.326385498046875"
+  },
+  {
+    "uuid": "vecnet:9z902z875",
+    "dc_title_s": "Kisumu Weather Archive",
+    "dc_description_s": "Archive of 1980-2011 Global Surface Summary of the Day (GSOD) weather data for Kisumu, Kenya (station 637080). Archive includes: GSOD weather data file(CDO5111355911589Kisumu1980-2011.csv), GSOD format description (GSOD_DESC_of_Format.pdf), Availability and Gaps data file for this weather station (GSODAvailabilityANDGaps.xlsx).",
+    "dc_creator_sm": [
+      "National Climatic Data Center",
+      "NOAA",
+      "NCDC",
+      "National Oceanic and Atmospheric Administration"
+    ],
+    "dc_type_s": "Dataset: Climate/Weather",
+    "dc_subject_sm": [
+      "Weather"
+    ],
+    "dct_spatial_sm": [
+      "Kisumu International Airport (Kenya) [6297309/AIRP]"
+    ],
+    "layer_id_s": "9z902z875",
+    "layer_slug_s": "9z902z875",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "34.72889 -0.08614 34.72889 -0.08614",
+    "solr_geom": "ENVELOPE(34.72889, 34.72889, -0.08614, -0.08614)",
+    "georss_box_s": "-0.08614 34.72889 -0.08614 34.72889"
+  },
+  {
+    "uuid": "vecnet:hd76s009b",
+    "dc_title_s": "Asia - IRS Susceptibility Map",
+    "dc_description_s": "From a series of maps created for VECNet to show continental scale zoning in Africa, Americas, and Asia related to intervention susceptibility. This map depicts zones where there are endophilic malaria vector species present and where IRS is likely to be a suitable or unsuitable intervention.",
+    "dc_creator_sm": [
+      "Malaria Atlas Project",
+      "MAP",
+      "Marianne Sinka"
+    ],
+    "dc_type_s": "Map or Cartographic Material",
+    "dc_subject_sm": [
+      "Insecticide-Treated Bednets",
+      "Indoor Residual Spray",
+      "Intervention Suitability"
+    ],
+    "dct_spatial_sm": [
+      "Asia () [6255147/CONT]"
+    ],
+    "layer_id_s": "hd76s009b",
+    "layer_slug_s": "hd76s009b",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "25.668510437000123 -10.930000305175781 -168.98974609375 81.8519287109375",
+    "solr_geom": "ENVELOPE(25.668510437000123, -168.98974609375, 81.8519287109375, -10.930000305175781)",
+    "georss_box_s": "-10.930000305175781 25.668510437000123 81.8519287109375 -168.98974609375"
+  },
+  {
+    "uuid": "vecnet:hd76s004z",
+    "dc_title_s": "Asia - ITN Susceptibility Map",
+    "dc_description_s": "From a series of maps created for VECNet to show continental scale zoning in Africa, Americas, and Asia related to intervention susceptibility. This map depicts zones where there is an exophagic malaria vector species present and where ITNs are likely to be a suitable or unsuitable intervention.",
+    "dc_creator_sm": [
+      "Malaria Atlas Project",
+      "MAP",
+      "Marianne Sinka"
+    ],
+    "dc_type_s": "Map or Cartographic Material",
+    "dc_subject_sm": [
+      "Insecticide-Treated Bednets",
+      "Indoor Residual Spray",
+      "Intervention Suitability"
+    ],
+    "dct_spatial_sm": [
+      "Asia () [6255147/CONT]"
+    ],
+    "layer_id_s": "hd76s004z",
+    "layer_slug_s": "hd76s004z",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "25.668510437000123 -10.930000305175781 -168.98974609375 81.8519287109375",
+    "solr_geom": "ENVELOPE(25.668510437000123, -168.98974609375, 81.8519287109375, -10.930000305175781)",
+    "georss_box_s": "-10.930000305175781 25.668510437000123 81.8519287109375 -168.98974609375"
+  },
+  {
+    "uuid": "vecnet:jq085k01r",
+    "dc_title_s": "Intervention Susceptibility Maps 2012 Archive",
+    "dc_description_s": "Archive of maps created for VECNet to show continental scale zoning in Africa, Americas, and Asia related to intervention susceptibility. The maps depict zones where there is are endophilic malaria vector species present and where IRS is likely to be a suitable or unsuitable intervention. The maps depict zones where there is an exophagic malaria vector species present and where ITNs are likely to be a suitable or unsuitable intervention.",
+    "dc_creator_sm": [
+      "Malaria Atlas Project",
+      "MAP",
+      "Marianne Sinka"
+    ],
+    "dc_type_s": "Map or Cartographic Material",
+    "dc_subject_sm": [
+      "Insecticide-Treated Bednets",
+      "Indoor Residual Spray",
+      "Intervention Suitability"
+    ],
+    "dct_spatial_sm": [
+      "Africa () [6255146/CONT]",
+      "Asia () [6255147/CONT]",
+      "Las Américas International Airport (Dominican Republic) [3500854/AIRP]"
+    ],
+    "layer_id_s": "jq085k01r",
+    "layer_slug_s": "jq085k01r",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "-69.66892 -46.9697265625 -168.98974609375 81.8519287109375",
+    "solr_geom": "ENVELOPE(-69.66892, -168.98974609375, 81.8519287109375, -46.9697265625)",
+    "georss_box_s": "-46.9697265625 -69.66892 81.8519287109375 -168.98974609375"
+  },
+  {
+    "uuid": "vecnet:hd76s0082",
+    "dc_title_s": "Americas - ITN Susceptibility Map",
+    "dc_description_s": "From a series of maps created for VECNet to show continental scale zoning in Africa, Americas, and Asia related to intervention susceptibility. This map depicts zones where there is an exophagic malaria vector species present and where ITNs are likely to be a suitable or unsuitable intervention.",
+    "dc_creator_sm": [
+      "Malaria Atlas Project",
+      "MAP",
+      "Marianne Sinka"
+    ],
+    "dc_type_s": "Map or Cartographic Material",
+    "dc_subject_sm": [
+      "Insecticide-Treated Bednets",
+      "Indoor Residual Spray",
+      "Intervention Suitability"
+    ],
+    "dct_spatial_sm": [
+      "Africa () [6255146/CONT]",
+      "Asia () [6255147/CONT]",
+      "Las Américas International Airport (Dominican Republic) [3500854/AIRP]"
+    ],
+    "layer_id_s": "hd76s0082",
+    "layer_slug_s": "hd76s0082",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "-69.66892 -46.9697265625 -168.98974609375 81.8519287109375",
+    "solr_geom": "ENVELOPE(-69.66892, -168.98974609375, 81.8519287109375, -46.9697265625)",
+    "georss_box_s": "-46.9697265625 -69.66892 81.8519287109375 -168.98974609375"
+  },
+  {
+    "uuid": "vecnet:tx31qh69s",
+    "dc_title_s": "Bugoro Parity Data",
+    "dc_description_s": "The ovaries of mosquitoes caught in the night landing catches were dissected in physiological saline, allowed to dry and examined under 100-200X for the presence or absence of skeins at the end of the trachea. The number of Nulliparous and Parous females for each collection are detailed in this data table. There are two tabs in this excel spreedsheet: 1) the dataset and 2) the dictionary detailing each attribute in the data table. For more detail see: Bugoro H, Hii J, Butafa C, Iroofa C, Apairamo A, Cooper R, Chen C-C, Russell T: The bionomics of the malaria vector Anopheles farauti in Northern Guadalcanal, Solomon Islands: issues for successful vector control. Malaria Journal 2014, 13:56.",
+    "dc_creator_sm": [
+      "Hugo Bugoro",
+      "Jeffery Hii",
+      "Charles Butafa",
+      "Charlie Iro'ofa",
+      "Allen Apairamo",
+      "Robert Cooper",
+      "Cheng-Chen Chen",
+      "Tanya Russell"
+    ],
+    "dc_type_s": "Dataset: Entomological",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Guadalcanal Island (Solomon Islands) [2108832/ISL]"
+    ],
+    "layer_id_s": "tx31qh69s",
+    "layer_slug_s": "tx31qh69s",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "159.58403 -9.949388 160.833939 -9.24225",
+    "solr_geom": "ENVELOPE(159.58403, 160.833939, -9.24225, -9.949388)",
+    "georss_box_s": "-9.949388 159.58403 -9.24225 160.833939"
+  },
+  {
+    "uuid": "vecnet:ht24wj452",
+    "dc_title_s": "Malaria Operational Plan: Kenya Archive 2008 - 2013",
+    "dc_description_s": "An archive of 2008 - 2013 PMI Malaria Operational Plans for Kenya. President's Malaria Initiative Malaria Operational Plans (MOPs) present a detailed one-year country-wide implementation plan. Each plan briefly reviews the current status of a country's malaria control and prevention policies and interventions, identifies challenges and unmet needs if the goals of the PMI are to be achieved, and provides a description of planned activities under the PMI. These Malaria Operational Plans have been endorsed by the U.S. Global Malaria Coordinator and reflect collaborative discussions with the national malaria control programs and partners in country.",
+    "dc_creator_sm": [
+      "United States. Agency for International Development",
+      "USAID",
+      "Centers for Disease Control and Prevention"
+    ],
+    "dc_type_s": "Report",
+    "dc_subject_sm": [
+      "Malaria",
+      "Kenya",
+      "Annual Reports"
+    ],
+    "dct_spatial_sm": [
+      "Kenya (Kenya) [192950/PCLI]"
+    ],
+    "layer_id_s": "ht24wj452",
+    "layer_slug_s": "ht24wj452",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.908859 -4.678047 41.899078 5.019938",
+    "solr_geom": "ENVELOPE(33.908859, 41.899078, 5.019938, -4.678047)",
+    "georss_box_s": "-4.678047 33.908859 5.019938 41.899078"
+  },
+  {
+    "uuid": "vecnet:qn59q4075",
+    "dc_title_s": "Kenya Child Mortality by Cause",
+    "dc_description_s": "This spreadsheet contains metadata about the following dimensions, including codes, display strings, and reference URLs: - Indicator - Age Group - Country - Sex - Year - GBDCHILDCAUSES - WHO region",
+    "dc_creator_sm": [
+      "Global Health Observatory of the World Health Organization",
+      "WHO"
+    ],
+    "dc_type_s": "Dataset: Epidemiology / Public Health",
+    "dc_subject_sm": [
+      "Child Mortality"
+    ],
+    "dct_spatial_sm": [
+      "Kenya (Kenya) [192950/PCLI]"
+    ],
+    "layer_id_s": "qn59q4075",
+    "layer_slug_s": "qn59q4075",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.908859 -4.678047 41.899078 5.019938",
+    "solr_geom": "ENVELOPE(33.908859, 41.899078, 5.019938, -4.678047)",
+    "georss_box_s": "-4.678047 33.908859 5.019938 41.899078"
+  },
+  {
+    "uuid": "vecnet:9880vr00j",
+    "dc_title_s": "WHO Life Expectancy Life Tables :Kenya - expectation of life at age x",
+    "dc_description_s": "Life expectancy: Life table Kenya holds data on Expectation of life at the beginning of the age group x in five year increments for ages: <1, 1-4, 5-9, 10-14, 15-19, 20-24, 25-29, 30-34, 35-39, 40-44, 45-49, 50-54, 55-59, 60-64, 65-69, 70-74, 75-79, 80-84, 85-89, 90-94, 95-99, and 100+ . Data is avail for male, female, and Both Sexes combined. From WHO Global Health Observatory",
+    "dc_creator_sm": [
+      "World Health Organization",
+      "WHO"
+    ],
+    "dc_type_s": "Dataset: Demography",
+    "dc_subject_sm": [
+      "Life Expectancy"
+    ],
+    "dct_spatial_sm": [
+      "Kenya (Kenya) [192950/PCLI]"
+    ],
+    "layer_id_s": "9880vr00j",
+    "layer_slug_s": "9880vr00j",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "33.908859 -4.678047 41.899078 5.019938",
+    "solr_geom": "ENVELOPE(33.908859, 41.899078, 5.019938, -4.678047)",
+    "georss_box_s": "-4.678047 33.908859 5.019938 41.899078"
+  },
+  {
+    "uuid": "vecnet:tx31qh68h",
+    "dc_title_s": "Bugoro HLC Data",
+    "dc_description_s": "Seasonality, biting densities and biting behaviour were ascertained by human landing catches (HLC) conducted from 18.00-06.00 at least twice monthly from July 2007 to June 2008 in the three study villages. Sampling was not conducted in February 2008 due to flooding. Catches were made by four collectors, two working indoors and two working outdoors, for 40 min each hour, in two experimental huts. The number of female Anopheles farauti caught during each collection effort is detailed in this data table. Note that for each collection, the data has been pooled across the two experimental huts. There are two tabs in this excel spreedsheet: 1) the dataset and 2) the dictionary detailing each attribute in the data table. For more detail see: Bugoro H, Hii J, Butafa C, Iroofa C, Apairamo A, Cooper R, Chen C-C, Russell T: The bionomics of the malaria vector Anopheles farauti in Northern Guadalcanal, Solomon Islands: issues for successful vector control. Malaria Journal 2014, 13:56.",
+    "dc_creator_sm": [
+      "Hugo Bugoro",
+      "Jeffery Hii",
+      "Charles Butafa",
+      "Charlie Iro'ofa",
+      "Allen Apairamo",
+      "Robert Cooper",
+      "Cheng-Chen Chen",
+      "Tanya Russell"
+    ],
+    "dc_type_s": "Dataset: Entomological",
+    "dc_subject_sm": null,
+    "dct_spatial_sm": [
+      "Guadalcanal Island (Solomon Islands) [2108832/ISL]"
+    ],
+    "layer_id_s": "tx31qh68h",
+    "layer_slug_s": "tx31qh68h",
+    "layer_geom_type_s": "Point",
+    "dct_provenance_s": "Digital Library",
+    "dc_rights_s": "public",
+    "solr_bbox": "159.58403 -9.949388 160.833939 -9.24225",
+    "solr_geom": "ENVELOPE(159.58403, 160.833939, -9.24225, -9.949388)",
+    "georss_box_s": "-9.949388 159.58403 -9.24225 160.833939"
+  }
+]


### PR DESCRIPTION
This adds some basic enrichment to the metadata records copied from the base vecnet system.
It is not perfect, in particular the following still need to be addressed:
- how do we handle items with more than one location. This code builds up a bounding box around everything, but sometimes the bounding box is _really small_. It is better to use pins in this case.
- It looks like geoblacklight deprecated the `solr_bbox` field. (see geoblacklight/geoblacklight-schema) Yet we are still relying on it. I tried generating the data without `solr_bbox` and the bounding boxes did not display.
- The enriched data does not contain links back to the base locations because I don't know which solr field to put the links in.
