### PR TITLE
Add actual result thumbnails and default placeholder image

### DIFF
--- a/app/assets/javascripts/modules/search_layout.js.erb
+++ b/app/assets/javascripts/modules/search_layout.js.erb
@@ -168,3 +168,9 @@ function makeHiddenInputElement($link) {
     $('#ajax-modal').modal('hide');
 }
 // ----------------------------------------------------------------------------
+
+function imgError(image) {
+    image.onerror = "";
+    image.src = "<%= asset_path('placeholder-image.png') %>";
+    return true;
+}

--- a/app/views/catalog/_index_split_default.html.erb
+++ b/app/views/catalog/_index_split_default.html.erb
@@ -20,20 +20,20 @@
 
   <div class="col-xs-4 col-md-2">
 
-    <!--TODO: Change this to be correct thumbnail url and logic if no url then default image-->
+    <% hash = JSON.parse(document[:dct_references_s]) %>
+    <% downloadUrl = hash["http://schema.org/downloadUrl"]%>
+    <% thumbnailUrl = hash["http://schema.org/thumbnailUrl"]%>
 
-    <% unless document[:dct_references_s].nil? or document[:dct_references_s]["https://schema.org/thumbnailUrl"].nil? %>
 
-        <!--use the fake thumbnail-->
-        <a href="#" title="Placeholder document thumbnail" class="thumbnail"><img src="<%= asset_path('example-thumbnail.png')%>" alt="Example document thumbnail"/></a>
+    <% if downloadUrl.nil? %>
+        <% downloadUrl = thumbnailUrl %>
+        <% end %>
 
-        <!--use the correct link-->
-        <!--<a href="<%# document[:dct_references_s]["https://schema.org/thumbnailUrl"]%>" class="thumbnail"><img src="<%# document[:dct_references_s]["https://schema.org/thumbnailUrl"]%>" alt="Document thumbnail"/></a>-->
+      <%= link_to downloadUrl, class: 'thumbnail', title: 'document thumbnail', alt: 'document thumbnail' do %>
 
-  <% else %>
+          <img src="<%= thumbnailUrl%>" onError="imgError(this);" />
 
-    <a href="#" title="Placeholder document thumbnail" class="thumbnail"><img src="<%= asset_path('example-thumbnail.png')%>" alt="Example document thumbnail"/></a>
-    <% end %>
+      <% end %>
   </div>
 
   <div class="col-xs-8 col-md-2">
@@ -44,7 +44,7 @@
       <% unless document[:layer_geom_type_s].blank? %> <li><i class="glyphicon glyphicon-map-marker"></i> <span><%= document[:layer_geom_type_s] %></span></li><% end %>
     </ul>
   </div>
-  <div class="col-xs-12 col-md-8 excerpet">
+  <div class="col-xs-12 col-md-8 excerpt">
     <h3 class="result-title"><%= link_to_document document, document_show_link_field(document), title: document['dc_title_s'] %></h3>
 
     <h5 class="result-author"><%= Array(document[:dc_creator_sm]).join(", ") %> </h5>

--- a/app/views/catalog/_upper_metadata.html.erb
+++ b/app/views/catalog/_upper_metadata.html.erb
@@ -27,19 +27,25 @@
     <dt>Access</dt>
     <dd><%= @document["dc_rights_s"]%></dd>
 
+    <dt>Download</dt>
+    <% hash = JSON.parse(@document["dct_references_s"]) %>
+    <dd><%= link_to hash["http://schema.org/downloadUrl"]%></dd>
 
-    <dt>URL</dt>
-    <%# hash = JSON.parse(@document["dct_references_s"]) %>
-    <dd><%# link_to hash["https://schema.org/url"]%></dd>
+    <% links = Array(@document["dc_relation_sm"]) %>
+    <% links.map{|link| link_to link}.join(', ').html_safe %>
+
+    <dt>Related Links</dt>
+    <dd> <%= links.map{|link| link_to link}.join(', ').html_safe %></dd>
 
 
-    <dt>Links</dt>
-    <dd><%= Array(@document["dc_relation_sm"]).join(", ")%></dd>
+    <% comment do %>
+        <dd><%= Array(@document["dc_relation_sm"]).join(", ")%></dd>
+
+    <% end %>
 
 
-    <!--TODO: Fish out the correct links from JSON object here || Check with Don -->
-    <% if !@document.references.nil? && !@document.references.url.nil? %>
-      <dt>More details at</dt>
+        <% if !@document.references.nil? && !@document.references.url.nil? %>
+      <dt>Details page</dt>
       <dd itemprop="url"><%= link_to @document.references.url.endpoint, @document.references.url.endpoint %></dd>
     <% end %>
   </dl>


### PR DESCRIPTION
Add correct thumbnail URLs and handle img load errors by js replace s…rc with placeholder image. (+12 squashed commits)

Squashed commits:
[9e22b07] And again...
[65e0cfc] Using asset_path instead of relative
[19d6f8f] JS method to catch img error
[0c07f2a] Still giving img errors a default placeholder
[8d97dbc] Add the download link to the thumbnail
[cbf183d] Specify path of placeholder image
[95c2813] Background doesn't work, lets try onError event.
[1d77d68] Try using background images with a fallback example thumbnail to deal with thumbnail image being empty.
[f076cf7] Reference the key differently in views.
[6ab3f0b] Add JSON parsing for download and related links and thumbnail.

[ee70c02] Map arrays not strings...

[4a2243f] Display related links URLs
